### PR TITLE
Update nuget packages + Use RippleColor instead of SetRippleColor

### DIFF
--- a/Library/FloatingActionButton.Droid/FAB.Droid.csproj
+++ b/Library/FloatingActionButton.Droid/FAB.Droid.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -42,44 +43,68 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
+    <Reference Include="Xamarin.Android.Support.Annotations">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Transition">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Transition.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Transition.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v4.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.CardView">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.Palette">
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.Palette.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Vector.Drawable">
-      <HintPath>..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <HintPath>..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Design">
-      <HintPath>..\..\packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.Design.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -95,7 +120,6 @@
   </ItemGroup>
   <Import Project="..\FloatingActionButton.Shared\FloatingActionButton.Shared.projitems" Label="Shared" Condition="Exists('..\FloatingActionButton.Shared\FloatingActionButton.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
   <ItemGroup>
     <Folder Include="Resources\" />
     <Folder Include="Library\" />
@@ -127,5 +151,22 @@
       <Name>FAB.Forms.Profile78</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Library/FloatingActionButton.Droid/FloatingActionButtonRenderer.cs
+++ b/Library/FloatingActionButton.Droid/FloatingActionButtonRenderer.cs
@@ -115,7 +115,7 @@ namespace FAB.Droid
             this.Control.BackgroundTintList = ColorStateList.ValueOf(this.Element.NormalColor.ToAndroid());
             try
             {
-                this.Control.SetRippleColor(this.Element.RippleColor.ToAndroid());
+                this.Control.RippleColor = this.Element.RippleColor.ToAndroid();
             }
             catch (MissingMethodException)
             {

--- a/Library/FloatingActionButton.Droid/Resources/Resource.designer.cs
+++ b/Library/FloatingActionButton.Droid/Resources/Resource.designer.cs
@@ -85,974 +85,1056 @@ namespace FAB.Droid
 			}
 		}
 		
+		public partial class Animator
+		{
+			
+			// aapt resource value: 0x7f050000
+			public static int design_appbar_state_list_animator = 2131034112;
+			
+			static Animator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animator()
+			{
+			}
+		}
+		
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010000
-			public static int MediaRouteControllerWindowBackground = 2130771968;
-			
-			// aapt resource value: 0x7f010097
-			public static int actionBarDivider = 2130772119;
-			
-			// aapt resource value: 0x7f010098
-			public static int actionBarItemBackground = 2130772120;
-			
-			// aapt resource value: 0x7f010091
-			public static int actionBarPopupTheme = 2130772113;
-			
-			// aapt resource value: 0x7f010096
-			public static int actionBarSize = 2130772118;
-			
-			// aapt resource value: 0x7f010093
-			public static int actionBarSplitStyle = 2130772115;
-			
-			// aapt resource value: 0x7f010092
-			public static int actionBarStyle = 2130772114;
-			
-			// aapt resource value: 0x7f01008d
-			public static int actionBarTabBarStyle = 2130772109;
-			
-			// aapt resource value: 0x7f01008c
-			public static int actionBarTabStyle = 2130772108;
-			
-			// aapt resource value: 0x7f01008e
-			public static int actionBarTabTextStyle = 2130772110;
-			
-			// aapt resource value: 0x7f010094
-			public static int actionBarTheme = 2130772116;
-			
-			// aapt resource value: 0x7f010095
-			public static int actionBarWidgetTheme = 2130772117;
-			
-			// aapt resource value: 0x7f0100b1
-			public static int actionButtonStyle = 2130772145;
-			
-			// aapt resource value: 0x7f0100ad
-			public static int actionDropDownStyle = 2130772141;
-			
-			// aapt resource value: 0x7f0100ff
-			public static int actionLayout = 2130772223;
-			
-			// aapt resource value: 0x7f010099
-			public static int actionMenuTextAppearance = 2130772121;
-			
-			// aapt resource value: 0x7f01009a
-			public static int actionMenuTextColor = 2130772122;
-			
-			// aapt resource value: 0x7f01009d
-			public static int actionModeBackground = 2130772125;
-			
-			// aapt resource value: 0x7f01009c
-			public static int actionModeCloseButtonStyle = 2130772124;
-			
-			// aapt resource value: 0x7f01009f
-			public static int actionModeCloseDrawable = 2130772127;
-			
-			// aapt resource value: 0x7f0100a1
-			public static int actionModeCopyDrawable = 2130772129;
-			
-			// aapt resource value: 0x7f0100a0
-			public static int actionModeCutDrawable = 2130772128;
-			
-			// aapt resource value: 0x7f0100a5
-			public static int actionModeFindDrawable = 2130772133;
-			
-			// aapt resource value: 0x7f0100a2
-			public static int actionModePasteDrawable = 2130772130;
-			
-			// aapt resource value: 0x7f0100a7
-			public static int actionModePopupWindowStyle = 2130772135;
-			
-			// aapt resource value: 0x7f0100a3
-			public static int actionModeSelectAllDrawable = 2130772131;
-			
-			// aapt resource value: 0x7f0100a4
-			public static int actionModeShareDrawable = 2130772132;
-			
-			// aapt resource value: 0x7f01009e
-			public static int actionModeSplitBackground = 2130772126;
-			
-			// aapt resource value: 0x7f01009b
-			public static int actionModeStyle = 2130772123;
-			
-			// aapt resource value: 0x7f0100a6
-			public static int actionModeWebSearchDrawable = 2130772134;
-			
-			// aapt resource value: 0x7f01008f
-			public static int actionOverflowButtonStyle = 2130772111;
-			
-			// aapt resource value: 0x7f010090
-			public static int actionOverflowMenuStyle = 2130772112;
-			
-			// aapt resource value: 0x7f010101
-			public static int actionProviderClass = 2130772225;
-			
-			// aapt resource value: 0x7f010100
-			public static int actionViewClass = 2130772224;
-			
-			// aapt resource value: 0x7f0100b9
-			public static int activityChooserViewStyle = 2130772153;
-			
-			// aapt resource value: 0x7f0100dc
-			public static int alertDialogButtonGroupStyle = 2130772188;
-			
-			// aapt resource value: 0x7f0100dd
-			public static int alertDialogCenterButtons = 2130772189;
-			
-			// aapt resource value: 0x7f0100db
-			public static int alertDialogStyle = 2130772187;
-			
-			// aapt resource value: 0x7f0100de
-			public static int alertDialogTheme = 2130772190;
-			
-			// aapt resource value: 0x7f0100f0
-			public static int allowStacking = 2130772208;
-			
-			// aapt resource value: 0x7f0100f7
-			public static int arrowHeadLength = 2130772215;
-			
-			// aapt resource value: 0x7f0100f8
-			public static int arrowShaftLength = 2130772216;
-			
-			// aapt resource value: 0x7f0100e3
-			public static int autoCompleteTextViewStyle = 2130772195;
-			
-			// aapt resource value: 0x7f010068
-			public static int background = 2130772072;
-			
-			// aapt resource value: 0x7f01006a
-			public static int backgroundSplit = 2130772074;
-			
-			// aapt resource value: 0x7f010069
-			public static int backgroundStacked = 2130772073;
-			
-			// aapt resource value: 0x7f01012b
-			public static int backgroundTint = 2130772267;
-			
-			// aapt resource value: 0x7f01012c
-			public static int backgroundTintMode = 2130772268;
-			
-			// aapt resource value: 0x7f0100f9
-			public static int barLength = 2130772217;
-			
-			// aapt resource value: 0x7f01001b
-			public static int behavior_hideable = 2130771995;
-			
-			// aapt resource value: 0x7f010041
-			public static int behavior_overlapTop = 2130772033;
-			
-			// aapt resource value: 0x7f01001a
-			public static int behavior_peekHeight = 2130771994;
-			
-			// aapt resource value: 0x7f010037
-			public static int borderWidth = 2130772023;
-			
-			// aapt resource value: 0x7f0100b6
-			public static int borderlessButtonStyle = 2130772150;
-			
-			// aapt resource value: 0x7f010031
-			public static int bottomSheetDialogTheme = 2130772017;
-			
-			// aapt resource value: 0x7f010032
-			public static int bottomSheetStyle = 2130772018;
-			
-			// aapt resource value: 0x7f0100b3
-			public static int buttonBarButtonStyle = 2130772147;
-			
-			// aapt resource value: 0x7f0100e1
-			public static int buttonBarNegativeButtonStyle = 2130772193;
-			
-			// aapt resource value: 0x7f0100e2
-			public static int buttonBarNeutralButtonStyle = 2130772194;
-			
-			// aapt resource value: 0x7f0100e0
-			public static int buttonBarPositiveButtonStyle = 2130772192;
-			
-			// aapt resource value: 0x7f0100b2
-			public static int buttonBarStyle = 2130772146;
-			
-			// aapt resource value: 0x7f01007b
-			public static int buttonPanelSideLayout = 2130772091;
-			
-			// aapt resource value: 0x7f0100e4
-			public static int buttonStyle = 2130772196;
-			
-			// aapt resource value: 0x7f0100e5
-			public static int buttonStyleSmall = 2130772197;
-			
-			// aapt resource value: 0x7f0100f1
-			public static int buttonTint = 2130772209;
-			
-			// aapt resource value: 0x7f0100f2
-			public static int buttonTintMode = 2130772210;
-			
-			// aapt resource value: 0x7f010131
-			public static int cardBackgroundColor = 2130772273;
-			
-			// aapt resource value: 0x7f010132
-			public static int cardCornerRadius = 2130772274;
-			
-			// aapt resource value: 0x7f010133
-			public static int cardElevation = 2130772275;
-			
-			// aapt resource value: 0x7f010134
-			public static int cardMaxElevation = 2130772276;
-			
-			// aapt resource value: 0x7f010136
-			public static int cardPreventCornerOverlap = 2130772278;
-			
-			// aapt resource value: 0x7f010135
-			public static int cardUseCompatPadding = 2130772277;
-			
-			// aapt resource value: 0x7f0100e6
-			public static int checkboxStyle = 2130772198;
-			
-			// aapt resource value: 0x7f0100e7
-			public static int checkedTextViewStyle = 2130772199;
-			
-			// aapt resource value: 0x7f010109
-			public static int closeIcon = 2130772233;
-			
-			// aapt resource value: 0x7f010078
-			public static int closeItemLayout = 2130772088;
-			
-			// aapt resource value: 0x7f010122
-			public static int collapseContentDescription = 2130772258;
-			
-			// aapt resource value: 0x7f010121
-			public static int collapseIcon = 2130772257;
-			
-			// aapt resource value: 0x7f010028
-			public static int collapsedTitleGravity = 2130772008;
-			
-			// aapt resource value: 0x7f010024
-			public static int collapsedTitleTextAppearance = 2130772004;
-			
-			// aapt resource value: 0x7f0100f3
-			public static int color = 2130772211;
-			
-			// aapt resource value: 0x7f0100d4
-			public static int colorAccent = 2130772180;
-			
-			// aapt resource value: 0x7f0100d8
-			public static int colorButtonNormal = 2130772184;
-			
-			// aapt resource value: 0x7f0100d6
-			public static int colorControlActivated = 2130772182;
-			
-			// aapt resource value: 0x7f0100d7
-			public static int colorControlHighlight = 2130772183;
-			
-			// aapt resource value: 0x7f0100d5
-			public static int colorControlNormal = 2130772181;
-			
-			// aapt resource value: 0x7f0100d2
-			public static int colorPrimary = 2130772178;
-			
-			// aapt resource value: 0x7f0100d3
-			public static int colorPrimaryDark = 2130772179;
-			
-			// aapt resource value: 0x7f0100d9
-			public static int colorSwitchThumbNormal = 2130772185;
-			
-			// aapt resource value: 0x7f01010e
-			public static int commitIcon = 2130772238;
-			
-			// aapt resource value: 0x7f010073
-			public static int contentInsetEnd = 2130772083;
-			
-			// aapt resource value: 0x7f010074
-			public static int contentInsetLeft = 2130772084;
-			
-			// aapt resource value: 0x7f010075
-			public static int contentInsetRight = 2130772085;
-			
-			// aapt resource value: 0x7f010072
-			public static int contentInsetStart = 2130772082;
-			
-			// aapt resource value: 0x7f010137
-			public static int contentPadding = 2130772279;
-			
-			// aapt resource value: 0x7f01013b
-			public static int contentPaddingBottom = 2130772283;
-			
-			// aapt resource value: 0x7f010138
-			public static int contentPaddingLeft = 2130772280;
-			
-			// aapt resource value: 0x7f010139
-			public static int contentPaddingRight = 2130772281;
-			
-			// aapt resource value: 0x7f01013a
-			public static int contentPaddingTop = 2130772282;
-			
-			// aapt resource value: 0x7f010025
-			public static int contentScrim = 2130772005;
-			
-			// aapt resource value: 0x7f0100da
-			public static int controlBackground = 2130772186;
-			
-			// aapt resource value: 0x7f010057
-			public static int counterEnabled = 2130772055;
-			
-			// aapt resource value: 0x7f010058
-			public static int counterMaxLength = 2130772056;
-			
-			// aapt resource value: 0x7f01005a
-			public static int counterOverflowTextAppearance = 2130772058;
-			
-			// aapt resource value: 0x7f010059
-			public static int counterTextAppearance = 2130772057;
-			
-			// aapt resource value: 0x7f01006b
-			public static int customNavigationLayout = 2130772075;
-			
-			// aapt resource value: 0x7f010108
-			public static int defaultQueryHint = 2130772232;
-			
-			// aapt resource value: 0x7f0100ab
-			public static int dialogPreferredPadding = 2130772139;
-			
-			// aapt resource value: 0x7f0100aa
-			public static int dialogTheme = 2130772138;
-			
-			// aapt resource value: 0x7f010061
-			public static int displayOptions = 2130772065;
-			
-			// aapt resource value: 0x7f010067
-			public static int divider = 2130772071;
-			
-			// aapt resource value: 0x7f0100b8
-			public static int dividerHorizontal = 2130772152;
-			
-			// aapt resource value: 0x7f0100fd
-			public static int dividerPadding = 2130772221;
-			
-			// aapt resource value: 0x7f0100b7
-			public static int dividerVertical = 2130772151;
-			
-			// aapt resource value: 0x7f0100f5
-			public static int drawableSize = 2130772213;
-			
-			// aapt resource value: 0x7f01005c
-			public static int drawerArrowStyle = 2130772060;
-			
-			// aapt resource value: 0x7f0100ca
-			public static int dropDownListViewStyle = 2130772170;
-			
-			// aapt resource value: 0x7f0100ae
-			public static int dropdownListPreferredItemHeight = 2130772142;
-			
-			// aapt resource value: 0x7f0100bf
-			public static int editTextBackground = 2130772159;
-			
-			// aapt resource value: 0x7f0100be
-			public static int editTextColor = 2130772158;
-			
-			// aapt resource value: 0x7f0100e8
-			public static int editTextStyle = 2130772200;
-			
-			// aapt resource value: 0x7f010076
-			public static int elevation = 2130772086;
-			
-			// aapt resource value: 0x7f010055
-			public static int errorEnabled = 2130772053;
-			
-			// aapt resource value: 0x7f010056
-			public static int errorTextAppearance = 2130772054;
-			
-			// aapt resource value: 0x7f01007a
-			public static int expandActivityOverflowButtonDrawable = 2130772090;
-			
-			// aapt resource value: 0x7f010017
-			public static int expanded = 2130771991;
-			
-			// aapt resource value: 0x7f010029
-			public static int expandedTitleGravity = 2130772009;
-			
-			// aapt resource value: 0x7f01001e
-			public static int expandedTitleMargin = 2130771998;
-			
-			// aapt resource value: 0x7f010022
-			public static int expandedTitleMarginBottom = 2130772002;
-			
-			// aapt resource value: 0x7f010021
-			public static int expandedTitleMarginEnd = 2130772001;
-			
-			// aapt resource value: 0x7f01001f
-			public static int expandedTitleMarginStart = 2130771999;
-			
-			// aapt resource value: 0x7f010020
-			public static int expandedTitleMarginTop = 2130772000;
-			
-			// aapt resource value: 0x7f010023
-			public static int expandedTitleTextAppearance = 2130772003;
-			
-			// aapt resource value: 0x7f010016
-			public static int externalRouteEnabledDrawable = 2130771990;
-			
-			// aapt resource value: 0x7f010035
-			public static int fabSize = 2130772021;
-			
-			// aapt resource value: 0x7f01013e
-			public static int fab_colorDisabled = 2130772286;
-			
-			// aapt resource value: 0x7f01013d
-			public static int fab_colorNormal = 2130772285;
-			
-			// aapt resource value: 0x7f01013c
-			public static int fab_colorPressed = 2130772284;
-			
-			// aapt resource value: 0x7f01013f
-			public static int fab_colorRipple = 2130772287;
-			
-			// aapt resource value: 0x7f010140
-			public static int fab_shadow = 2130772288;
-			
-			// aapt resource value: 0x7f010141
-			public static int fab_size = 2130772289;
-			
-			// aapt resource value: 0x7f010039
-			public static int foregroundInsidePadding = 2130772025;
-			
-			// aapt resource value: 0x7f0100f6
-			public static int gapBetweenBars = 2130772214;
-			
-			// aapt resource value: 0x7f01010a
-			public static int goIcon = 2130772234;
-			
-			// aapt resource value: 0x7f01003f
-			public static int headerLayout = 2130772031;
-			
 			// aapt resource value: 0x7f01005d
-			public static int height = 2130772061;
-			
-			// aapt resource value: 0x7f010071
-			public static int hideOnContentScroll = 2130772081;
-			
-			// aapt resource value: 0x7f01005b
-			public static int hintAnimationEnabled = 2130772059;
-			
-			// aapt resource value: 0x7f010054
-			public static int hintEnabled = 2130772052;
-			
-			// aapt resource value: 0x7f010053
-			public static int hintTextAppearance = 2130772051;
-			
-			// aapt resource value: 0x7f0100b0
-			public static int homeAsUpIndicator = 2130772144;
-			
-			// aapt resource value: 0x7f01006c
-			public static int homeLayout = 2130772076;
-			
-			// aapt resource value: 0x7f010065
-			public static int icon = 2130772069;
-			
-			// aapt resource value: 0x7f010106
-			public static int iconifiedByDefault = 2130772230;
-			
-			// aapt resource value: 0x7f0100c0
-			public static int imageButtonStyle = 2130772160;
-			
-			// aapt resource value: 0x7f01006e
-			public static int indeterminateProgressStyle = 2130772078;
-			
-			// aapt resource value: 0x7f010079
-			public static int initialActivityCount = 2130772089;
-			
-			// aapt resource value: 0x7f010040
-			public static int insetForeground = 2130772032;
+			public static int actionBarDivider = 2130772061;
 			
 			// aapt resource value: 0x7f01005e
-			public static int isLightTheme = 2130772062;
+			public static int actionBarItemBackground = 2130772062;
 			
-			// aapt resource value: 0x7f01003d
-			public static int itemBackground = 2130772029;
+			// aapt resource value: 0x7f010057
+			public static int actionBarPopupTheme = 2130772055;
 			
-			// aapt resource value: 0x7f01003b
-			public static int itemIconTint = 2130772027;
+			// aapt resource value: 0x7f01005c
+			public static int actionBarSize = 2130772060;
 			
-			// aapt resource value: 0x7f010070
-			public static int itemPadding = 2130772080;
+			// aapt resource value: 0x7f010059
+			public static int actionBarSplitStyle = 2130772057;
 			
-			// aapt resource value: 0x7f01003e
-			public static int itemTextAppearance = 2130772030;
+			// aapt resource value: 0x7f010058
+			public static int actionBarStyle = 2130772056;
 			
-			// aapt resource value: 0x7f01003c
-			public static int itemTextColor = 2130772028;
-			
-			// aapt resource value: 0x7f01002b
-			public static int keylines = 2130772011;
-			
-			// aapt resource value: 0x7f010105
-			public static int layout = 2130772229;
-			
-			// aapt resource value: 0x7f01012d
-			public static int layoutManager = 2130772269;
-			
-			// aapt resource value: 0x7f01002e
-			public static int layout_anchor = 2130772014;
-			
-			// aapt resource value: 0x7f010030
-			public static int layout_anchorGravity = 2130772016;
-			
-			// aapt resource value: 0x7f01002d
-			public static int layout_behavior = 2130772013;
-			
-			// aapt resource value: 0x7f01001c
-			public static int layout_collapseMode = 2130771996;
-			
-			// aapt resource value: 0x7f01001d
-			public static int layout_collapseParallaxMultiplier = 2130771997;
-			
-			// aapt resource value: 0x7f01002f
-			public static int layout_keyline = 2130772015;
-			
-			// aapt resource value: 0x7f010018
-			public static int layout_scrollFlags = 2130771992;
-			
-			// aapt resource value: 0x7f010019
-			public static int layout_scrollInterpolator = 2130771993;
-			
-			// aapt resource value: 0x7f0100d1
-			public static int listChoiceBackgroundIndicator = 2130772177;
-			
-			// aapt resource value: 0x7f0100ac
-			public static int listDividerAlertDialog = 2130772140;
-			
-			// aapt resource value: 0x7f01007f
-			public static int listItemLayout = 2130772095;
-			
-			// aapt resource value: 0x7f01007c
-			public static int listLayout = 2130772092;
-			
-			// aapt resource value: 0x7f0100cb
-			public static int listPopupWindowStyle = 2130772171;
-			
-			// aapt resource value: 0x7f0100c5
-			public static int listPreferredItemHeight = 2130772165;
-			
-			// aapt resource value: 0x7f0100c7
-			public static int listPreferredItemHeightLarge = 2130772167;
-			
-			// aapt resource value: 0x7f0100c6
-			public static int listPreferredItemHeightSmall = 2130772166;
-			
-			// aapt resource value: 0x7f0100c8
-			public static int listPreferredItemPaddingLeft = 2130772168;
-			
-			// aapt resource value: 0x7f0100c9
-			public static int listPreferredItemPaddingRight = 2130772169;
-			
-			// aapt resource value: 0x7f010066
-			public static int logo = 2130772070;
-			
-			// aapt resource value: 0x7f010125
-			public static int logoDescription = 2130772261;
-			
-			// aapt resource value: 0x7f010042
-			public static int maxActionInlineWidth = 2130772034;
-			
-			// aapt resource value: 0x7f010120
-			public static int maxButtonHeight = 2130772256;
-			
-			// aapt resource value: 0x7f0100fb
-			public static int measureWithLargestChild = 2130772219;
-			
-			// aapt resource value: 0x7f010001
-			public static int mediaRouteAudioTrackDrawable = 2130771969;
-			
-			// aapt resource value: 0x7f010002
-			public static int mediaRouteBluetoothIconDrawable = 2130771970;
-			
-			// aapt resource value: 0x7f010003
-			public static int mediaRouteButtonStyle = 2130771971;
-			
-			// aapt resource value: 0x7f010004
-			public static int mediaRouteCastDrawable = 2130771972;
-			
-			// aapt resource value: 0x7f010005
-			public static int mediaRouteChooserPrimaryTextStyle = 2130771973;
-			
-			// aapt resource value: 0x7f010006
-			public static int mediaRouteChooserSecondaryTextStyle = 2130771974;
-			
-			// aapt resource value: 0x7f010007
-			public static int mediaRouteCloseDrawable = 2130771975;
-			
-			// aapt resource value: 0x7f010008
-			public static int mediaRouteCollapseGroupDrawable = 2130771976;
-			
-			// aapt resource value: 0x7f010009
-			public static int mediaRouteConnectingDrawable = 2130771977;
-			
-			// aapt resource value: 0x7f01000a
-			public static int mediaRouteControllerPrimaryTextStyle = 2130771978;
-			
-			// aapt resource value: 0x7f01000b
-			public static int mediaRouteControllerSecondaryTextStyle = 2130771979;
-			
-			// aapt resource value: 0x7f01000c
-			public static int mediaRouteControllerTitleTextStyle = 2130771980;
-			
-			// aapt resource value: 0x7f01000d
-			public static int mediaRouteDefaultIconDrawable = 2130771981;
-			
-			// aapt resource value: 0x7f01000e
-			public static int mediaRouteExpandGroupDrawable = 2130771982;
-			
-			// aapt resource value: 0x7f01000f
-			public static int mediaRouteOffDrawable = 2130771983;
-			
-			// aapt resource value: 0x7f010010
-			public static int mediaRouteOnDrawable = 2130771984;
-			
-			// aapt resource value: 0x7f010011
-			public static int mediaRoutePauseDrawable = 2130771985;
-			
-			// aapt resource value: 0x7f010012
-			public static int mediaRoutePlayDrawable = 2130771986;
-			
-			// aapt resource value: 0x7f010013
-			public static int mediaRouteSpeakerGroupIconDrawable = 2130771987;
-			
-			// aapt resource value: 0x7f010014
-			public static int mediaRouteSpeakerIconDrawable = 2130771988;
-			
-			// aapt resource value: 0x7f010015
-			public static int mediaRouteTvIconDrawable = 2130771989;
-			
-			// aapt resource value: 0x7f01003a
-			public static int menu = 2130772026;
-			
-			// aapt resource value: 0x7f01007d
-			public static int multiChoiceItemLayout = 2130772093;
-			
-			// aapt resource value: 0x7f010124
-			public static int navigationContentDescription = 2130772260;
-			
-			// aapt resource value: 0x7f010123
-			public static int navigationIcon = 2130772259;
-			
-			// aapt resource value: 0x7f010060
-			public static int navigationMode = 2130772064;
-			
-			// aapt resource value: 0x7f010103
-			public static int overlapAnchor = 2130772227;
-			
-			// aapt resource value: 0x7f010129
-			public static int paddingEnd = 2130772265;
-			
-			// aapt resource value: 0x7f010128
-			public static int paddingStart = 2130772264;
-			
-			// aapt resource value: 0x7f0100ce
-			public static int panelBackground = 2130772174;
-			
-			// aapt resource value: 0x7f0100d0
-			public static int panelMenuListTheme = 2130772176;
-			
-			// aapt resource value: 0x7f0100cf
-			public static int panelMenuListWidth = 2130772175;
-			
-			// aapt resource value: 0x7f0100bc
-			public static int popupMenuStyle = 2130772156;
-			
-			// aapt resource value: 0x7f010077
-			public static int popupTheme = 2130772087;
-			
-			// aapt resource value: 0x7f0100bd
-			public static int popupWindowStyle = 2130772157;
-			
-			// aapt resource value: 0x7f010102
-			public static int preserveIconSpacing = 2130772226;
-			
-			// aapt resource value: 0x7f010036
-			public static int pressedTranslationZ = 2130772022;
-			
-			// aapt resource value: 0x7f01006f
-			public static int progressBarPadding = 2130772079;
-			
-			// aapt resource value: 0x7f01006d
-			public static int progressBarStyle = 2130772077;
-			
-			// aapt resource value: 0x7f010110
-			public static int queryBackground = 2130772240;
-			
-			// aapt resource value: 0x7f010107
-			public static int queryHint = 2130772231;
-			
-			// aapt resource value: 0x7f0100e9
-			public static int radioButtonStyle = 2130772201;
-			
-			// aapt resource value: 0x7f0100ea
-			public static int ratingBarStyle = 2130772202;
-			
-			// aapt resource value: 0x7f0100eb
-			public static int ratingBarStyleIndicator = 2130772203;
-			
-			// aapt resource value: 0x7f0100ec
-			public static int ratingBarStyleSmall = 2130772204;
-			
-			// aapt resource value: 0x7f01012f
-			public static int reverseLayout = 2130772271;
-			
-			// aapt resource value: 0x7f010034
-			public static int rippleColor = 2130772020;
-			
-			// aapt resource value: 0x7f01010c
-			public static int searchHintIcon = 2130772236;
-			
-			// aapt resource value: 0x7f01010b
-			public static int searchIcon = 2130772235;
-			
-			// aapt resource value: 0x7f0100c4
-			public static int searchViewStyle = 2130772164;
-			
-			// aapt resource value: 0x7f0100ed
-			public static int seekBarStyle = 2130772205;
-			
-			// aapt resource value: 0x7f0100b4
-			public static int selectableItemBackground = 2130772148;
-			
-			// aapt resource value: 0x7f0100b5
-			public static int selectableItemBackgroundBorderless = 2130772149;
-			
-			// aapt resource value: 0x7f0100fe
-			public static int showAsAction = 2130772222;
-			
-			// aapt resource value: 0x7f0100fc
-			public static int showDividers = 2130772220;
-			
-			// aapt resource value: 0x7f010118
-			public static int showText = 2130772248;
-			
-			// aapt resource value: 0x7f01007e
-			public static int singleChoiceItemLayout = 2130772094;
-			
-			// aapt resource value: 0x7f01012e
-			public static int spanCount = 2130772270;
-			
-			// aapt resource value: 0x7f0100f4
-			public static int spinBars = 2130772212;
-			
-			// aapt resource value: 0x7f0100af
-			public static int spinnerDropDownItemStyle = 2130772143;
-			
-			// aapt resource value: 0x7f0100ee
-			public static int spinnerStyle = 2130772206;
-			
-			// aapt resource value: 0x7f010117
-			public static int splitTrack = 2130772247;
-			
-			// aapt resource value: 0x7f010080
-			public static int srcCompat = 2130772096;
-			
-			// aapt resource value: 0x7f010130
-			public static int stackFromEnd = 2130772272;
-			
-			// aapt resource value: 0x7f010104
-			public static int state_above_anchor = 2130772228;
-			
-			// aapt resource value: 0x7f01002c
-			public static int statusBarBackground = 2130772012;
-			
-			// aapt resource value: 0x7f010026
-			public static int statusBarScrim = 2130772006;
-			
-			// aapt resource value: 0x7f010111
-			public static int submitBackground = 2130772241;
-			
-			// aapt resource value: 0x7f010062
-			public static int subtitle = 2130772066;
-			
-			// aapt resource value: 0x7f01011a
-			public static int subtitleTextAppearance = 2130772250;
-			
-			// aapt resource value: 0x7f010127
-			public static int subtitleTextColor = 2130772263;
-			
-			// aapt resource value: 0x7f010064
-			public static int subtitleTextStyle = 2130772068;
-			
-			// aapt resource value: 0x7f01010f
-			public static int suggestionRowLayout = 2130772239;
-			
-			// aapt resource value: 0x7f010115
-			public static int switchMinWidth = 2130772245;
-			
-			// aapt resource value: 0x7f010116
-			public static int switchPadding = 2130772246;
-			
-			// aapt resource value: 0x7f0100ef
-			public static int switchStyle = 2130772207;
-			
-			// aapt resource value: 0x7f010114
-			public static int switchTextAppearance = 2130772244;
-			
-			// aapt resource value: 0x7f010046
-			public static int tabBackground = 2130772038;
-			
-			// aapt resource value: 0x7f010045
-			public static int tabContentStart = 2130772037;
-			
-			// aapt resource value: 0x7f010048
-			public static int tabGravity = 2130772040;
-			
-			// aapt resource value: 0x7f010043
-			public static int tabIndicatorColor = 2130772035;
-			
-			// aapt resource value: 0x7f010044
-			public static int tabIndicatorHeight = 2130772036;
-			
-			// aapt resource value: 0x7f01004a
-			public static int tabMaxWidth = 2130772042;
-			
-			// aapt resource value: 0x7f010049
-			public static int tabMinWidth = 2130772041;
-			
-			// aapt resource value: 0x7f010047
-			public static int tabMode = 2130772039;
+			// aapt resource value: 0x7f010053
+			public static int actionBarTabBarStyle = 2130772051;
 			
 			// aapt resource value: 0x7f010052
-			public static int tabPadding = 2130772050;
+			public static int actionBarTabStyle = 2130772050;
 			
-			// aapt resource value: 0x7f010051
-			public static int tabPaddingBottom = 2130772049;
+			// aapt resource value: 0x7f010054
+			public static int actionBarTabTextStyle = 2130772052;
 			
-			// aapt resource value: 0x7f010050
-			public static int tabPaddingEnd = 2130772048;
+			// aapt resource value: 0x7f01005a
+			public static int actionBarTheme = 2130772058;
 			
-			// aapt resource value: 0x7f01004e
-			public static int tabPaddingStart = 2130772046;
+			// aapt resource value: 0x7f01005b
+			public static int actionBarWidgetTheme = 2130772059;
 			
-			// aapt resource value: 0x7f01004f
-			public static int tabPaddingTop = 2130772047;
+			// aapt resource value: 0x7f010078
+			public static int actionButtonStyle = 2130772088;
 			
-			// aapt resource value: 0x7f01004d
-			public static int tabSelectedTextColor = 2130772045;
+			// aapt resource value: 0x7f010074
+			public static int actionDropDownStyle = 2130772084;
 			
-			// aapt resource value: 0x7f01004b
-			public static int tabTextAppearance = 2130772043;
-			
-			// aapt resource value: 0x7f01004c
-			public static int tabTextColor = 2130772044;
-			
-			// aapt resource value: 0x7f010081
-			public static int textAllCaps = 2130772097;
-			
-			// aapt resource value: 0x7f0100a8
-			public static int textAppearanceLargePopupMenu = 2130772136;
-			
-			// aapt resource value: 0x7f0100cc
-			public static int textAppearanceListItem = 2130772172;
-			
-			// aapt resource value: 0x7f0100cd
-			public static int textAppearanceListItemSmall = 2130772173;
-			
-			// aapt resource value: 0x7f0100c2
-			public static int textAppearanceSearchResultSubtitle = 2130772162;
-			
-			// aapt resource value: 0x7f0100c1
-			public static int textAppearanceSearchResultTitle = 2130772161;
-			
-			// aapt resource value: 0x7f0100a9
-			public static int textAppearanceSmallPopupMenu = 2130772137;
-			
-			// aapt resource value: 0x7f0100df
-			public static int textColorAlertDialogListItem = 2130772191;
-			
-			// aapt resource value: 0x7f010033
-			public static int textColorError = 2130772019;
-			
-			// aapt resource value: 0x7f0100c3
-			public static int textColorSearchUrl = 2130772163;
-			
-			// aapt resource value: 0x7f01012a
-			public static int theme = 2130772266;
-			
-			// aapt resource value: 0x7f0100fa
-			public static int thickness = 2130772218;
-			
-			// aapt resource value: 0x7f010113
-			public static int thumbTextPadding = 2130772243;
+			// aapt resource value: 0x7f0100c9
+			public static int actionLayout = 2130772169;
 			
 			// aapt resource value: 0x7f01005f
-			public static int title = 2130772063;
+			public static int actionMenuTextAppearance = 2130772063;
 			
-			// aapt resource value: 0x7f01002a
-			public static int titleEnabled = 2130772010;
-			
-			// aapt resource value: 0x7f01011f
-			public static int titleMarginBottom = 2130772255;
-			
-			// aapt resource value: 0x7f01011d
-			public static int titleMarginEnd = 2130772253;
-			
-			// aapt resource value: 0x7f01011c
-			public static int titleMarginStart = 2130772252;
-			
-			// aapt resource value: 0x7f01011e
-			public static int titleMarginTop = 2130772254;
-			
-			// aapt resource value: 0x7f01011b
-			public static int titleMargins = 2130772251;
-			
-			// aapt resource value: 0x7f010119
-			public static int titleTextAppearance = 2130772249;
-			
-			// aapt resource value: 0x7f010126
-			public static int titleTextColor = 2130772262;
+			// aapt resource value: 0x7f010060
+			public static int actionMenuTextColor = 2130772064;
 			
 			// aapt resource value: 0x7f010063
-			public static int titleTextStyle = 2130772067;
+			public static int actionModeBackground = 2130772067;
 			
-			// aapt resource value: 0x7f010027
-			public static int toolbarId = 2130772007;
+			// aapt resource value: 0x7f010062
+			public static int actionModeCloseButtonStyle = 2130772066;
 			
-			// aapt resource value: 0x7f0100bb
-			public static int toolbarNavigationButtonStyle = 2130772155;
+			// aapt resource value: 0x7f010065
+			public static int actionModeCloseDrawable = 2130772069;
+			
+			// aapt resource value: 0x7f010067
+			public static int actionModeCopyDrawable = 2130772071;
+			
+			// aapt resource value: 0x7f010066
+			public static int actionModeCutDrawable = 2130772070;
+			
+			// aapt resource value: 0x7f01006b
+			public static int actionModeFindDrawable = 2130772075;
+			
+			// aapt resource value: 0x7f010068
+			public static int actionModePasteDrawable = 2130772072;
+			
+			// aapt resource value: 0x7f01006d
+			public static int actionModePopupWindowStyle = 2130772077;
+			
+			// aapt resource value: 0x7f010069
+			public static int actionModeSelectAllDrawable = 2130772073;
+			
+			// aapt resource value: 0x7f01006a
+			public static int actionModeShareDrawable = 2130772074;
+			
+			// aapt resource value: 0x7f010064
+			public static int actionModeSplitBackground = 2130772068;
+			
+			// aapt resource value: 0x7f010061
+			public static int actionModeStyle = 2130772065;
+			
+			// aapt resource value: 0x7f01006c
+			public static int actionModeWebSearchDrawable = 2130772076;
+			
+			// aapt resource value: 0x7f010055
+			public static int actionOverflowButtonStyle = 2130772053;
+			
+			// aapt resource value: 0x7f010056
+			public static int actionOverflowMenuStyle = 2130772054;
+			
+			// aapt resource value: 0x7f0100cb
+			public static int actionProviderClass = 2130772171;
+			
+			// aapt resource value: 0x7f0100ca
+			public static int actionViewClass = 2130772170;
+			
+			// aapt resource value: 0x7f010080
+			public static int activityChooserViewStyle = 2130772096;
+			
+			// aapt resource value: 0x7f0100a4
+			public static int alertDialogButtonGroupStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a5
+			public static int alertDialogCenterButtons = 2130772133;
+			
+			// aapt resource value: 0x7f0100a3
+			public static int alertDialogStyle = 2130772131;
+			
+			// aapt resource value: 0x7f0100a6
+			public static int alertDialogTheme = 2130772134;
+			
+			// aapt resource value: 0x7f0100b9
+			public static int allowStacking = 2130772153;
 			
 			// aapt resource value: 0x7f0100ba
-			public static int toolbarStyle = 2130772154;
+			public static int alpha = 2130772154;
 			
-			// aapt resource value: 0x7f010112
-			public static int track = 2130772242;
+			// aapt resource value: 0x7f0100c1
+			public static int arrowHeadLength = 2130772161;
 			
-			// aapt resource value: 0x7f010038
-			public static int useCompatPadding = 2130772024;
+			// aapt resource value: 0x7f0100c2
+			public static int arrowShaftLength = 2130772162;
 			
-			// aapt resource value: 0x7f01010d
-			public static int voiceIcon = 2130772237;
+			// aapt resource value: 0x7f0100ab
+			public static int autoCompleteTextViewStyle = 2130772139;
 			
-			// aapt resource value: 0x7f010082
-			public static int windowActionBar = 2130772098;
+			// aapt resource value: 0x7f010028
+			public static int background = 2130772008;
 			
-			// aapt resource value: 0x7f010084
-			public static int windowActionBarOverlay = 2130772100;
+			// aapt resource value: 0x7f01002a
+			public static int backgroundSplit = 2130772010;
 			
-			// aapt resource value: 0x7f010085
-			public static int windowActionModeOverlay = 2130772101;
+			// aapt resource value: 0x7f010029
+			public static int backgroundStacked = 2130772009;
 			
-			// aapt resource value: 0x7f010089
-			public static int windowFixedHeightMajor = 2130772105;
+			// aapt resource value: 0x7f0100fe
+			public static int backgroundTint = 2130772222;
 			
-			// aapt resource value: 0x7f010087
-			public static int windowFixedHeightMinor = 2130772103;
+			// aapt resource value: 0x7f0100ff
+			public static int backgroundTintMode = 2130772223;
+			
+			// aapt resource value: 0x7f0100c3
+			public static int barLength = 2130772163;
+			
+			// aapt resource value: 0x7f010129
+			public static int behavior_autoHide = 2130772265;
+			
+			// aapt resource value: 0x7f010106
+			public static int behavior_hideable = 2130772230;
+			
+			// aapt resource value: 0x7f010132
+			public static int behavior_overlapTop = 2130772274;
+			
+			// aapt resource value: 0x7f010105
+			public static int behavior_peekHeight = 2130772229;
+			
+			// aapt resource value: 0x7f010107
+			public static int behavior_skipCollapsed = 2130772231;
+			
+			// aapt resource value: 0x7f010127
+			public static int borderWidth = 2130772263;
+			
+			// aapt resource value: 0x7f01007d
+			public static int borderlessButtonStyle = 2130772093;
+			
+			// aapt resource value: 0x7f010121
+			public static int bottomSheetDialogTheme = 2130772257;
+			
+			// aapt resource value: 0x7f010122
+			public static int bottomSheetStyle = 2130772258;
+			
+			// aapt resource value: 0x7f01007a
+			public static int buttonBarButtonStyle = 2130772090;
+			
+			// aapt resource value: 0x7f0100a9
+			public static int buttonBarNegativeButtonStyle = 2130772137;
+			
+			// aapt resource value: 0x7f0100aa
+			public static int buttonBarNeutralButtonStyle = 2130772138;
+			
+			// aapt resource value: 0x7f0100a8
+			public static int buttonBarPositiveButtonStyle = 2130772136;
+			
+			// aapt resource value: 0x7f010079
+			public static int buttonBarStyle = 2130772089;
+			
+			// aapt resource value: 0x7f0100f3
+			public static int buttonGravity = 2130772211;
+			
+			// aapt resource value: 0x7f01003d
+			public static int buttonPanelSideLayout = 2130772029;
+			
+			// aapt resource value: 0x7f0100ac
+			public static int buttonStyle = 2130772140;
+			
+			// aapt resource value: 0x7f0100ad
+			public static int buttonStyleSmall = 2130772141;
+			
+			// aapt resource value: 0x7f0100bb
+			public static int buttonTint = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public static int buttonTintMode = 2130772156;
+			
+			// aapt resource value: 0x7f010011
+			public static int cardBackgroundColor = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public static int cardCornerRadius = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public static int cardElevation = 2130771987;
+			
+			// aapt resource value: 0x7f010014
+			public static int cardMaxElevation = 2130771988;
+			
+			// aapt resource value: 0x7f010016
+			public static int cardPreventCornerOverlap = 2130771990;
+			
+			// aapt resource value: 0x7f010015
+			public static int cardUseCompatPadding = 2130771989;
+			
+			// aapt resource value: 0x7f0100ae
+			public static int checkboxStyle = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public static int checkedTextViewStyle = 2130772143;
+			
+			// aapt resource value: 0x7f0100d6
+			public static int closeIcon = 2130772182;
+			
+			// aapt resource value: 0x7f01003a
+			public static int closeItemLayout = 2130772026;
+			
+			// aapt resource value: 0x7f0100f5
+			public static int collapseContentDescription = 2130772213;
+			
+			// aapt resource value: 0x7f0100f4
+			public static int collapseIcon = 2130772212;
+			
+			// aapt resource value: 0x7f010114
+			public static int collapsedTitleGravity = 2130772244;
+			
+			// aapt resource value: 0x7f01010e
+			public static int collapsedTitleTextAppearance = 2130772238;
+			
+			// aapt resource value: 0x7f0100bd
+			public static int color = 2130772157;
+			
+			// aapt resource value: 0x7f01009b
+			public static int colorAccent = 2130772123;
+			
+			// aapt resource value: 0x7f0100a2
+			public static int colorBackgroundFloating = 2130772130;
+			
+			// aapt resource value: 0x7f01009f
+			public static int colorButtonNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009d
+			public static int colorControlActivated = 2130772125;
+			
+			// aapt resource value: 0x7f01009e
+			public static int colorControlHighlight = 2130772126;
+			
+			// aapt resource value: 0x7f01009c
+			public static int colorControlNormal = 2130772124;
+			
+			// aapt resource value: 0x7f010099
+			public static int colorPrimary = 2130772121;
+			
+			// aapt resource value: 0x7f01009a
+			public static int colorPrimaryDark = 2130772122;
+			
+			// aapt resource value: 0x7f0100a0
+			public static int colorSwitchThumbNormal = 2130772128;
+			
+			// aapt resource value: 0x7f0100db
+			public static int commitIcon = 2130772187;
+			
+			// aapt resource value: 0x7f010033
+			public static int contentInsetEnd = 2130772019;
+			
+			// aapt resource value: 0x7f010037
+			public static int contentInsetEndWithActions = 2130772023;
+			
+			// aapt resource value: 0x7f010034
+			public static int contentInsetLeft = 2130772020;
+			
+			// aapt resource value: 0x7f010035
+			public static int contentInsetRight = 2130772021;
+			
+			// aapt resource value: 0x7f010032
+			public static int contentInsetStart = 2130772018;
+			
+			// aapt resource value: 0x7f010036
+			public static int contentInsetStartWithNavigation = 2130772022;
+			
+			// aapt resource value: 0x7f010017
+			public static int contentPadding = 2130771991;
+			
+			// aapt resource value: 0x7f01001b
+			public static int contentPaddingBottom = 2130771995;
+			
+			// aapt resource value: 0x7f010018
+			public static int contentPaddingLeft = 2130771992;
+			
+			// aapt resource value: 0x7f010019
+			public static int contentPaddingRight = 2130771993;
+			
+			// aapt resource value: 0x7f01001a
+			public static int contentPaddingTop = 2130771994;
+			
+			// aapt resource value: 0x7f01010f
+			public static int contentScrim = 2130772239;
+			
+			// aapt resource value: 0x7f0100a1
+			public static int controlBackground = 2130772129;
+			
+			// aapt resource value: 0x7f010148
+			public static int counterEnabled = 2130772296;
+			
+			// aapt resource value: 0x7f010149
+			public static int counterMaxLength = 2130772297;
+			
+			// aapt resource value: 0x7f01014b
+			public static int counterOverflowTextAppearance = 2130772299;
+			
+			// aapt resource value: 0x7f01014a
+			public static int counterTextAppearance = 2130772298;
+			
+			// aapt resource value: 0x7f01002b
+			public static int customNavigationLayout = 2130772011;
+			
+			// aapt resource value: 0x7f0100d5
+			public static int defaultQueryHint = 2130772181;
+			
+			// aapt resource value: 0x7f010072
+			public static int dialogPreferredPadding = 2130772082;
+			
+			// aapt resource value: 0x7f010071
+			public static int dialogTheme = 2130772081;
+			
+			// aapt resource value: 0x7f010021
+			public static int displayOptions = 2130772001;
+			
+			// aapt resource value: 0x7f010027
+			public static int divider = 2130772007;
+			
+			// aapt resource value: 0x7f01007f
+			public static int dividerHorizontal = 2130772095;
+			
+			// aapt resource value: 0x7f0100c7
+			public static int dividerPadding = 2130772167;
+			
+			// aapt resource value: 0x7f01007e
+			public static int dividerVertical = 2130772094;
+			
+			// aapt resource value: 0x7f0100bf
+			public static int drawableSize = 2130772159;
+			
+			// aapt resource value: 0x7f01001c
+			public static int drawerArrowStyle = 2130771996;
+			
+			// aapt resource value: 0x7f010091
+			public static int dropDownListViewStyle = 2130772113;
+			
+			// aapt resource value: 0x7f010075
+			public static int dropdownListPreferredItemHeight = 2130772085;
 			
 			// aapt resource value: 0x7f010086
-			public static int windowFixedWidthMajor = 2130772102;
+			public static int editTextBackground = 2130772102;
 			
-			// aapt resource value: 0x7f010088
-			public static int windowFixedWidthMinor = 2130772104;
+			// aapt resource value: 0x7f010085
+			public static int editTextColor = 2130772101;
 			
-			// aapt resource value: 0x7f01008a
-			public static int windowMinWidthMajor = 2130772106;
+			// aapt resource value: 0x7f0100b0
+			public static int editTextStyle = 2130772144;
 			
-			// aapt resource value: 0x7f01008b
-			public static int windowMinWidthMinor = 2130772107;
+			// aapt resource value: 0x7f010038
+			public static int elevation = 2130772024;
+			
+			// aapt resource value: 0x7f010146
+			public static int errorEnabled = 2130772294;
+			
+			// aapt resource value: 0x7f010147
+			public static int errorTextAppearance = 2130772295;
+			
+			// aapt resource value: 0x7f01003c
+			public static int expandActivityOverflowButtonDrawable = 2130772028;
+			
+			// aapt resource value: 0x7f010100
+			public static int expanded = 2130772224;
+			
+			// aapt resource value: 0x7f010115
+			public static int expandedTitleGravity = 2130772245;
+			
+			// aapt resource value: 0x7f010108
+			public static int expandedTitleMargin = 2130772232;
+			
+			// aapt resource value: 0x7f01010c
+			public static int expandedTitleMarginBottom = 2130772236;
+			
+			// aapt resource value: 0x7f01010b
+			public static int expandedTitleMarginEnd = 2130772235;
+			
+			// aapt resource value: 0x7f010109
+			public static int expandedTitleMarginStart = 2130772233;
+			
+			// aapt resource value: 0x7f01010a
+			public static int expandedTitleMarginTop = 2130772234;
+			
+			// aapt resource value: 0x7f01010d
+			public static int expandedTitleTextAppearance = 2130772237;
+			
+			// aapt resource value: 0x7f010010
+			public static int externalRouteEnabledDrawable = 2130771984;
+			
+			// aapt resource value: 0x7f010125
+			public static int fabSize = 2130772261;
+			
+			// aapt resource value: 0x7f010154
+			public static int fab_colorDisabled = 2130772308;
+			
+			// aapt resource value: 0x7f010153
+			public static int fab_colorNormal = 2130772307;
+			
+			// aapt resource value: 0x7f010152
+			public static int fab_colorPressed = 2130772306;
+			
+			// aapt resource value: 0x7f010155
+			public static int fab_colorRipple = 2130772309;
+			
+			// aapt resource value: 0x7f010156
+			public static int fab_shadow = 2130772310;
+			
+			// aapt resource value: 0x7f010157
+			public static int fab_size = 2130772311;
+			
+			// aapt resource value: 0x7f01012a
+			public static int foregroundInsidePadding = 2130772266;
+			
+			// aapt resource value: 0x7f0100c0
+			public static int gapBetweenBars = 2130772160;
+			
+			// aapt resource value: 0x7f0100d7
+			public static int goIcon = 2130772183;
+			
+			// aapt resource value: 0x7f010130
+			public static int headerLayout = 2130772272;
+			
+			// aapt resource value: 0x7f01001d
+			public static int height = 2130771997;
+			
+			// aapt resource value: 0x7f010031
+			public static int hideOnContentScroll = 2130772017;
+			
+			// aapt resource value: 0x7f01014c
+			public static int hintAnimationEnabled = 2130772300;
+			
+			// aapt resource value: 0x7f010145
+			public static int hintEnabled = 2130772293;
+			
+			// aapt resource value: 0x7f010144
+			public static int hintTextAppearance = 2130772292;
+			
+			// aapt resource value: 0x7f010077
+			public static int homeAsUpIndicator = 2130772087;
+			
+			// aapt resource value: 0x7f01002c
+			public static int homeLayout = 2130772012;
+			
+			// aapt resource value: 0x7f010025
+			public static int icon = 2130772005;
+			
+			// aapt resource value: 0x7f0100d3
+			public static int iconifiedByDefault = 2130772179;
+			
+			// aapt resource value: 0x7f010087
+			public static int imageButtonStyle = 2130772103;
+			
+			// aapt resource value: 0x7f01002e
+			public static int indeterminateProgressStyle = 2130772014;
+			
+			// aapt resource value: 0x7f01003b
+			public static int initialActivityCount = 2130772027;
+			
+			// aapt resource value: 0x7f010131
+			public static int insetForeground = 2130772273;
+			
+			// aapt resource value: 0x7f01001e
+			public static int isLightTheme = 2130771998;
+			
+			// aapt resource value: 0x7f01012e
+			public static int itemBackground = 2130772270;
+			
+			// aapt resource value: 0x7f01012c
+			public static int itemIconTint = 2130772268;
+			
+			// aapt resource value: 0x7f010030
+			public static int itemPadding = 2130772016;
+			
+			// aapt resource value: 0x7f01012f
+			public static int itemTextAppearance = 2130772271;
+			
+			// aapt resource value: 0x7f01012d
+			public static int itemTextColor = 2130772269;
+			
+			// aapt resource value: 0x7f010119
+			public static int keylines = 2130772249;
+			
+			// aapt resource value: 0x7f0100d2
+			public static int layout = 2130772178;
+			
+			// aapt resource value: 0x7f010000
+			public static int layoutManager = 2130771968;
+			
+			// aapt resource value: 0x7f01011c
+			public static int layout_anchor = 2130772252;
+			
+			// aapt resource value: 0x7f01011e
+			public static int layout_anchorGravity = 2130772254;
+			
+			// aapt resource value: 0x7f01011b
+			public static int layout_behavior = 2130772251;
+			
+			// aapt resource value: 0x7f010117
+			public static int layout_collapseMode = 2130772247;
+			
+			// aapt resource value: 0x7f010118
+			public static int layout_collapseParallaxMultiplier = 2130772248;
+			
+			// aapt resource value: 0x7f010120
+			public static int layout_dodgeInsetEdges = 2130772256;
+			
+			// aapt resource value: 0x7f01011f
+			public static int layout_insetEdge = 2130772255;
+			
+			// aapt resource value: 0x7f01011d
+			public static int layout_keyline = 2130772253;
+			
+			// aapt resource value: 0x7f010103
+			public static int layout_scrollFlags = 2130772227;
+			
+			// aapt resource value: 0x7f010104
+			public static int layout_scrollInterpolator = 2130772228;
+			
+			// aapt resource value: 0x7f010098
+			public static int listChoiceBackgroundIndicator = 2130772120;
+			
+			// aapt resource value: 0x7f010073
+			public static int listDividerAlertDialog = 2130772083;
+			
+			// aapt resource value: 0x7f010041
+			public static int listItemLayout = 2130772033;
+			
+			// aapt resource value: 0x7f01003e
+			public static int listLayout = 2130772030;
+			
+			// aapt resource value: 0x7f0100b8
+			public static int listMenuViewStyle = 2130772152;
+			
+			// aapt resource value: 0x7f010092
+			public static int listPopupWindowStyle = 2130772114;
+			
+			// aapt resource value: 0x7f01008c
+			public static int listPreferredItemHeight = 2130772108;
+			
+			// aapt resource value: 0x7f01008e
+			public static int listPreferredItemHeightLarge = 2130772110;
+			
+			// aapt resource value: 0x7f01008d
+			public static int listPreferredItemHeightSmall = 2130772109;
+			
+			// aapt resource value: 0x7f01008f
+			public static int listPreferredItemPaddingLeft = 2130772111;
+			
+			// aapt resource value: 0x7f010090
+			public static int listPreferredItemPaddingRight = 2130772112;
+			
+			// aapt resource value: 0x7f010026
+			public static int logo = 2130772006;
+			
+			// aapt resource value: 0x7f0100f8
+			public static int logoDescription = 2130772216;
+			
+			// aapt resource value: 0x7f010133
+			public static int maxActionInlineWidth = 2130772275;
+			
+			// aapt resource value: 0x7f0100f2
+			public static int maxButtonHeight = 2130772210;
+			
+			// aapt resource value: 0x7f0100c5
+			public static int measureWithLargestChild = 2130772165;
+			
+			// aapt resource value: 0x7f010004
+			public static int mediaRouteAudioTrackDrawable = 2130771972;
+			
+			// aapt resource value: 0x7f010005
+			public static int mediaRouteButtonStyle = 2130771973;
+			
+			// aapt resource value: 0x7f010006
+			public static int mediaRouteCloseDrawable = 2130771974;
+			
+			// aapt resource value: 0x7f010007
+			public static int mediaRouteControlPanelThemeOverlay = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public static int mediaRouteDefaultIconDrawable = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public static int mediaRoutePauseDrawable = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public static int mediaRoutePlayDrawable = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public static int mediaRouteSpeakerGroupIconDrawable = 2130771979;
+			
+			// aapt resource value: 0x7f01000c
+			public static int mediaRouteSpeakerIconDrawable = 2130771980;
+			
+			// aapt resource value: 0x7f01000d
+			public static int mediaRouteStopDrawable = 2130771981;
+			
+			// aapt resource value: 0x7f01000e
+			public static int mediaRouteTheme = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public static int mediaRouteTvIconDrawable = 2130771983;
+			
+			// aapt resource value: 0x7f01012b
+			public static int menu = 2130772267;
+			
+			// aapt resource value: 0x7f01003f
+			public static int multiChoiceItemLayout = 2130772031;
+			
+			// aapt resource value: 0x7f0100f7
+			public static int navigationContentDescription = 2130772215;
+			
+			// aapt resource value: 0x7f0100f6
+			public static int navigationIcon = 2130772214;
+			
+			// aapt resource value: 0x7f010020
+			public static int navigationMode = 2130772000;
+			
+			// aapt resource value: 0x7f0100ce
+			public static int overlapAnchor = 2130772174;
+			
+			// aapt resource value: 0x7f0100d0
+			public static int paddingBottomNoButtons = 2130772176;
+			
+			// aapt resource value: 0x7f0100fc
+			public static int paddingEnd = 2130772220;
+			
+			// aapt resource value: 0x7f0100fb
+			public static int paddingStart = 2130772219;
+			
+			// aapt resource value: 0x7f0100d1
+			public static int paddingTopNoTitle = 2130772177;
+			
+			// aapt resource value: 0x7f010095
+			public static int panelBackground = 2130772117;
+			
+			// aapt resource value: 0x7f010097
+			public static int panelMenuListTheme = 2130772119;
+			
+			// aapt resource value: 0x7f010096
+			public static int panelMenuListWidth = 2130772118;
+			
+			// aapt resource value: 0x7f01014f
+			public static int passwordToggleContentDescription = 2130772303;
+			
+			// aapt resource value: 0x7f01014e
+			public static int passwordToggleDrawable = 2130772302;
+			
+			// aapt resource value: 0x7f01014d
+			public static int passwordToggleEnabled = 2130772301;
+			
+			// aapt resource value: 0x7f010150
+			public static int passwordToggleTint = 2130772304;
+			
+			// aapt resource value: 0x7f010151
+			public static int passwordToggleTintMode = 2130772305;
 			
 			// aapt resource value: 0x7f010083
-			public static int windowNoTitle = 2130772099;
+			public static int popupMenuStyle = 2130772099;
+			
+			// aapt resource value: 0x7f010039
+			public static int popupTheme = 2130772025;
+			
+			// aapt resource value: 0x7f010084
+			public static int popupWindowStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100cc
+			public static int preserveIconSpacing = 2130772172;
+			
+			// aapt resource value: 0x7f010126
+			public static int pressedTranslationZ = 2130772262;
+			
+			// aapt resource value: 0x7f01002f
+			public static int progressBarPadding = 2130772015;
+			
+			// aapt resource value: 0x7f01002d
+			public static int progressBarStyle = 2130772013;
+			
+			// aapt resource value: 0x7f0100dd
+			public static int queryBackground = 2130772189;
+			
+			// aapt resource value: 0x7f0100d4
+			public static int queryHint = 2130772180;
+			
+			// aapt resource value: 0x7f0100b1
+			public static int radioButtonStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100b2
+			public static int ratingBarStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b3
+			public static int ratingBarStyleIndicator = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public static int ratingBarStyleSmall = 2130772148;
+			
+			// aapt resource value: 0x7f010002
+			public static int reverseLayout = 2130771970;
+			
+			// aapt resource value: 0x7f010124
+			public static int rippleColor = 2130772260;
+			
+			// aapt resource value: 0x7f010113
+			public static int scrimAnimationDuration = 2130772243;
+			
+			// aapt resource value: 0x7f010112
+			public static int scrimVisibleHeightTrigger = 2130772242;
+			
+			// aapt resource value: 0x7f0100d9
+			public static int searchHintIcon = 2130772185;
+			
+			// aapt resource value: 0x7f0100d8
+			public static int searchIcon = 2130772184;
+			
+			// aapt resource value: 0x7f01008b
+			public static int searchViewStyle = 2130772107;
+			
+			// aapt resource value: 0x7f0100b5
+			public static int seekBarStyle = 2130772149;
+			
+			// aapt resource value: 0x7f01007b
+			public static int selectableItemBackground = 2130772091;
+			
+			// aapt resource value: 0x7f01007c
+			public static int selectableItemBackgroundBorderless = 2130772092;
+			
+			// aapt resource value: 0x7f0100c8
+			public static int showAsAction = 2130772168;
+			
+			// aapt resource value: 0x7f0100c6
+			public static int showDividers = 2130772166;
+			
+			// aapt resource value: 0x7f0100e9
+			public static int showText = 2130772201;
+			
+			// aapt resource value: 0x7f010042
+			public static int showTitle = 2130772034;
+			
+			// aapt resource value: 0x7f010040
+			public static int singleChoiceItemLayout = 2130772032;
+			
+			// aapt resource value: 0x7f010001
+			public static int spanCount = 2130771969;
+			
+			// aapt resource value: 0x7f0100be
+			public static int spinBars = 2130772158;
+			
+			// aapt resource value: 0x7f010076
+			public static int spinnerDropDownItemStyle = 2130772086;
+			
+			// aapt resource value: 0x7f0100b6
+			public static int spinnerStyle = 2130772150;
+			
+			// aapt resource value: 0x7f0100e8
+			public static int splitTrack = 2130772200;
+			
+			// aapt resource value: 0x7f010043
+			public static int srcCompat = 2130772035;
+			
+			// aapt resource value: 0x7f010003
+			public static int stackFromEnd = 2130771971;
+			
+			// aapt resource value: 0x7f0100cf
+			public static int state_above_anchor = 2130772175;
+			
+			// aapt resource value: 0x7f010101
+			public static int state_collapsed = 2130772225;
+			
+			// aapt resource value: 0x7f010102
+			public static int state_collapsible = 2130772226;
+			
+			// aapt resource value: 0x7f01011a
+			public static int statusBarBackground = 2130772250;
+			
+			// aapt resource value: 0x7f010110
+			public static int statusBarScrim = 2130772240;
+			
+			// aapt resource value: 0x7f0100cd
+			public static int subMenuArrow = 2130772173;
+			
+			// aapt resource value: 0x7f0100de
+			public static int submitBackground = 2130772190;
+			
+			// aapt resource value: 0x7f010022
+			public static int subtitle = 2130772002;
+			
+			// aapt resource value: 0x7f0100eb
+			public static int subtitleTextAppearance = 2130772203;
+			
+			// aapt resource value: 0x7f0100fa
+			public static int subtitleTextColor = 2130772218;
+			
+			// aapt resource value: 0x7f010024
+			public static int subtitleTextStyle = 2130772004;
+			
+			// aapt resource value: 0x7f0100dc
+			public static int suggestionRowLayout = 2130772188;
+			
+			// aapt resource value: 0x7f0100e6
+			public static int switchMinWidth = 2130772198;
+			
+			// aapt resource value: 0x7f0100e7
+			public static int switchPadding = 2130772199;
+			
+			// aapt resource value: 0x7f0100b7
+			public static int switchStyle = 2130772151;
+			
+			// aapt resource value: 0x7f0100e5
+			public static int switchTextAppearance = 2130772197;
+			
+			// aapt resource value: 0x7f010137
+			public static int tabBackground = 2130772279;
+			
+			// aapt resource value: 0x7f010136
+			public static int tabContentStart = 2130772278;
+			
+			// aapt resource value: 0x7f010139
+			public static int tabGravity = 2130772281;
+			
+			// aapt resource value: 0x7f010134
+			public static int tabIndicatorColor = 2130772276;
+			
+			// aapt resource value: 0x7f010135
+			public static int tabIndicatorHeight = 2130772277;
+			
+			// aapt resource value: 0x7f01013b
+			public static int tabMaxWidth = 2130772283;
+			
+			// aapt resource value: 0x7f01013a
+			public static int tabMinWidth = 2130772282;
+			
+			// aapt resource value: 0x7f010138
+			public static int tabMode = 2130772280;
+			
+			// aapt resource value: 0x7f010143
+			public static int tabPadding = 2130772291;
+			
+			// aapt resource value: 0x7f010142
+			public static int tabPaddingBottom = 2130772290;
+			
+			// aapt resource value: 0x7f010141
+			public static int tabPaddingEnd = 2130772289;
+			
+			// aapt resource value: 0x7f01013f
+			public static int tabPaddingStart = 2130772287;
+			
+			// aapt resource value: 0x7f010140
+			public static int tabPaddingTop = 2130772288;
+			
+			// aapt resource value: 0x7f01013e
+			public static int tabSelectedTextColor = 2130772286;
+			
+			// aapt resource value: 0x7f01013c
+			public static int tabTextAppearance = 2130772284;
+			
+			// aapt resource value: 0x7f01013d
+			public static int tabTextColor = 2130772285;
+			
+			// aapt resource value: 0x7f010047
+			public static int textAllCaps = 2130772039;
+			
+			// aapt resource value: 0x7f01006e
+			public static int textAppearanceLargePopupMenu = 2130772078;
+			
+			// aapt resource value: 0x7f010093
+			public static int textAppearanceListItem = 2130772115;
+			
+			// aapt resource value: 0x7f010094
+			public static int textAppearanceListItemSmall = 2130772116;
+			
+			// aapt resource value: 0x7f010070
+			public static int textAppearancePopupMenuHeader = 2130772080;
+			
+			// aapt resource value: 0x7f010089
+			public static int textAppearanceSearchResultSubtitle = 2130772105;
+			
+			// aapt resource value: 0x7f010088
+			public static int textAppearanceSearchResultTitle = 2130772104;
+			
+			// aapt resource value: 0x7f01006f
+			public static int textAppearanceSmallPopupMenu = 2130772079;
+			
+			// aapt resource value: 0x7f0100a7
+			public static int textColorAlertDialogListItem = 2130772135;
+			
+			// aapt resource value: 0x7f010123
+			public static int textColorError = 2130772259;
+			
+			// aapt resource value: 0x7f01008a
+			public static int textColorSearchUrl = 2130772106;
+			
+			// aapt resource value: 0x7f0100fd
+			public static int theme = 2130772221;
+			
+			// aapt resource value: 0x7f0100c4
+			public static int thickness = 2130772164;
+			
+			// aapt resource value: 0x7f0100e4
+			public static int thumbTextPadding = 2130772196;
+			
+			// aapt resource value: 0x7f0100df
+			public static int thumbTint = 2130772191;
+			
+			// aapt resource value: 0x7f0100e0
+			public static int thumbTintMode = 2130772192;
+			
+			// aapt resource value: 0x7f010044
+			public static int tickMark = 2130772036;
+			
+			// aapt resource value: 0x7f010045
+			public static int tickMarkTint = 2130772037;
+			
+			// aapt resource value: 0x7f010046
+			public static int tickMarkTintMode = 2130772038;
+			
+			// aapt resource value: 0x7f01001f
+			public static int title = 2130771999;
+			
+			// aapt resource value: 0x7f010116
+			public static int titleEnabled = 2130772246;
+			
+			// aapt resource value: 0x7f0100ec
+			public static int titleMargin = 2130772204;
+			
+			// aapt resource value: 0x7f0100f0
+			public static int titleMarginBottom = 2130772208;
+			
+			// aapt resource value: 0x7f0100ee
+			public static int titleMarginEnd = 2130772206;
+			
+			// aapt resource value: 0x7f0100ed
+			public static int titleMarginStart = 2130772205;
+			
+			// aapt resource value: 0x7f0100ef
+			public static int titleMarginTop = 2130772207;
+			
+			// aapt resource value: 0x7f0100f1
+			public static int titleMargins = 2130772209;
+			
+			// aapt resource value: 0x7f0100ea
+			public static int titleTextAppearance = 2130772202;
+			
+			// aapt resource value: 0x7f0100f9
+			public static int titleTextColor = 2130772217;
+			
+			// aapt resource value: 0x7f010023
+			public static int titleTextStyle = 2130772003;
+			
+			// aapt resource value: 0x7f010111
+			public static int toolbarId = 2130772241;
+			
+			// aapt resource value: 0x7f010082
+			public static int toolbarNavigationButtonStyle = 2130772098;
+			
+			// aapt resource value: 0x7f010081
+			public static int toolbarStyle = 2130772097;
+			
+			// aapt resource value: 0x7f0100e1
+			public static int track = 2130772193;
+			
+			// aapt resource value: 0x7f0100e2
+			public static int trackTint = 2130772194;
+			
+			// aapt resource value: 0x7f0100e3
+			public static int trackTintMode = 2130772195;
+			
+			// aapt resource value: 0x7f010128
+			public static int useCompatPadding = 2130772264;
+			
+			// aapt resource value: 0x7f0100da
+			public static int voiceIcon = 2130772186;
+			
+			// aapt resource value: 0x7f010048
+			public static int windowActionBar = 2130772040;
+			
+			// aapt resource value: 0x7f01004a
+			public static int windowActionBarOverlay = 2130772042;
+			
+			// aapt resource value: 0x7f01004b
+			public static int windowActionModeOverlay = 2130772043;
+			
+			// aapt resource value: 0x7f01004f
+			public static int windowFixedHeightMajor = 2130772047;
+			
+			// aapt resource value: 0x7f01004d
+			public static int windowFixedHeightMinor = 2130772045;
+			
+			// aapt resource value: 0x7f01004c
+			public static int windowFixedWidthMajor = 2130772044;
+			
+			// aapt resource value: 0x7f01004e
+			public static int windowFixedWidthMinor = 2130772046;
+			
+			// aapt resource value: 0x7f010050
+			public static int windowMinWidthMajor = 2130772048;
+			
+			// aapt resource value: 0x7f010051
+			public static int windowMinWidthMinor = 2130772049;
+			
+			// aapt resource value: 0x7f010049
+			public static int windowNoTitle = 2130772041;
 			
 			static Attribute()
 			{
@@ -1067,29 +1149,20 @@ namespace FAB.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0c0003
-			public static int abc_action_bar_embed_tabs = 2131492867;
+			// aapt resource value: 0x7f0d0000
+			public static int abc_action_bar_embed_tabs = 2131558400;
 			
-			// aapt resource value: 0x7f0c0001
-			public static int abc_action_bar_embed_tabs_pre_jb = 2131492865;
+			// aapt resource value: 0x7f0d0001
+			public static int abc_allow_stacked_button_bar = 2131558401;
 			
-			// aapt resource value: 0x7f0c0004
-			public static int abc_action_bar_expanded_action_views_exclusive = 2131492868;
+			// aapt resource value: 0x7f0d0002
+			public static int abc_config_actionMenuItemAllCaps = 2131558402;
 			
-			// aapt resource value: 0x7f0c0000
-			public static int abc_allow_stacked_button_bar = 2131492864;
+			// aapt resource value: 0x7f0d0003
+			public static int abc_config_closeDialogWhenTouchOutside = 2131558403;
 			
-			// aapt resource value: 0x7f0c0005
-			public static int abc_config_actionMenuItemAllCaps = 2131492869;
-			
-			// aapt resource value: 0x7f0c0002
-			public static int abc_config_allowActionMenuItemTextWithIcon = 2131492866;
-			
-			// aapt resource value: 0x7f0c0006
-			public static int abc_config_closeDialogWhenTouchOutside = 2131492870;
-			
-			// aapt resource value: 0x7f0c0007
-			public static int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492871;
+			// aapt resource value: 0x7f0d0004
+			public static int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131558404;
 			
 			static Boolean()
 			{
@@ -1104,260 +1177,305 @@ namespace FAB.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0a0049
-			public static int abc_background_cache_hint_selector_material_dark = 2131361865;
+			// aapt resource value: 0x7f0c004b
+			public static int abc_background_cache_hint_selector_material_dark = 2131492939;
 			
-			// aapt resource value: 0x7f0a004a
-			public static int abc_background_cache_hint_selector_material_light = 2131361866;
+			// aapt resource value: 0x7f0c004c
+			public static int abc_background_cache_hint_selector_material_light = 2131492940;
 			
-			// aapt resource value: 0x7f0a004b
-			public static int abc_color_highlight_material = 2131361867;
+			// aapt resource value: 0x7f0c004d
+			public static int abc_btn_colored_borderless_text_material = 2131492941;
 			
-			// aapt resource value: 0x7f0a000a
-			public static int abc_input_method_navigation_guard = 2131361802;
+			// aapt resource value: 0x7f0c004e
+			public static int abc_btn_colored_text_material = 2131492942;
 			
-			// aapt resource value: 0x7f0a004c
-			public static int abc_primary_text_disable_only_material_dark = 2131361868;
+			// aapt resource value: 0x7f0c004f
+			public static int abc_color_highlight_material = 2131492943;
 			
-			// aapt resource value: 0x7f0a004d
-			public static int abc_primary_text_disable_only_material_light = 2131361869;
+			// aapt resource value: 0x7f0c0050
+			public static int abc_hint_foreground_material_dark = 2131492944;
 			
-			// aapt resource value: 0x7f0a004e
-			public static int abc_primary_text_material_dark = 2131361870;
+			// aapt resource value: 0x7f0c0051
+			public static int abc_hint_foreground_material_light = 2131492945;
 			
-			// aapt resource value: 0x7f0a004f
-			public static int abc_primary_text_material_light = 2131361871;
+			// aapt resource value: 0x7f0c0005
+			public static int abc_input_method_navigation_guard = 2131492869;
 			
-			// aapt resource value: 0x7f0a0050
-			public static int abc_search_url_text = 2131361872;
+			// aapt resource value: 0x7f0c0052
+			public static int abc_primary_text_disable_only_material_dark = 2131492946;
 			
-			// aapt resource value: 0x7f0a000b
-			public static int abc_search_url_text_normal = 2131361803;
+			// aapt resource value: 0x7f0c0053
+			public static int abc_primary_text_disable_only_material_light = 2131492947;
 			
-			// aapt resource value: 0x7f0a000c
-			public static int abc_search_url_text_pressed = 2131361804;
+			// aapt resource value: 0x7f0c0054
+			public static int abc_primary_text_material_dark = 2131492948;
 			
-			// aapt resource value: 0x7f0a000d
-			public static int abc_search_url_text_selected = 2131361805;
+			// aapt resource value: 0x7f0c0055
+			public static int abc_primary_text_material_light = 2131492949;
 			
-			// aapt resource value: 0x7f0a0051
-			public static int abc_secondary_text_material_dark = 2131361873;
+			// aapt resource value: 0x7f0c0056
+			public static int abc_search_url_text = 2131492950;
 			
-			// aapt resource value: 0x7f0a0052
-			public static int abc_secondary_text_material_light = 2131361874;
+			// aapt resource value: 0x7f0c0006
+			public static int abc_search_url_text_normal = 2131492870;
 			
-			// aapt resource value: 0x7f0a000e
-			public static int accent_material_dark = 2131361806;
+			// aapt resource value: 0x7f0c0007
+			public static int abc_search_url_text_pressed = 2131492871;
 			
-			// aapt resource value: 0x7f0a000f
-			public static int accent_material_light = 2131361807;
+			// aapt resource value: 0x7f0c0008
+			public static int abc_search_url_text_selected = 2131492872;
 			
-			// aapt resource value: 0x7f0a0010
-			public static int background_floating_material_dark = 2131361808;
+			// aapt resource value: 0x7f0c0057
+			public static int abc_secondary_text_material_dark = 2131492951;
 			
-			// aapt resource value: 0x7f0a0011
-			public static int background_floating_material_light = 2131361809;
+			// aapt resource value: 0x7f0c0058
+			public static int abc_secondary_text_material_light = 2131492952;
 			
-			// aapt resource value: 0x7f0a0012
-			public static int background_material_dark = 2131361810;
+			// aapt resource value: 0x7f0c0059
+			public static int abc_tint_btn_checkable = 2131492953;
 			
-			// aapt resource value: 0x7f0a0013
-			public static int background_material_light = 2131361811;
+			// aapt resource value: 0x7f0c005a
+			public static int abc_tint_default = 2131492954;
 			
-			// aapt resource value: 0x7f0a0014
-			public static int bright_foreground_disabled_material_dark = 2131361812;
+			// aapt resource value: 0x7f0c005b
+			public static int abc_tint_edittext = 2131492955;
 			
-			// aapt resource value: 0x7f0a0015
-			public static int bright_foreground_disabled_material_light = 2131361813;
+			// aapt resource value: 0x7f0c005c
+			public static int abc_tint_seek_thumb = 2131492956;
 			
-			// aapt resource value: 0x7f0a0016
-			public static int bright_foreground_inverse_material_dark = 2131361814;
+			// aapt resource value: 0x7f0c005d
+			public static int abc_tint_spinner = 2131492957;
 			
-			// aapt resource value: 0x7f0a0017
-			public static int bright_foreground_inverse_material_light = 2131361815;
+			// aapt resource value: 0x7f0c005e
+			public static int abc_tint_switch_thumb = 2131492958;
 			
-			// aapt resource value: 0x7f0a0018
-			public static int bright_foreground_material_dark = 2131361816;
+			// aapt resource value: 0x7f0c005f
+			public static int abc_tint_switch_track = 2131492959;
 			
-			// aapt resource value: 0x7f0a0019
-			public static int bright_foreground_material_light = 2131361817;
+			// aapt resource value: 0x7f0c0009
+			public static int accent_material_dark = 2131492873;
 			
-			// aapt resource value: 0x7f0a001a
-			public static int button_material_dark = 2131361818;
+			// aapt resource value: 0x7f0c000a
+			public static int accent_material_light = 2131492874;
 			
-			// aapt resource value: 0x7f0a001b
-			public static int button_material_light = 2131361819;
+			// aapt resource value: 0x7f0c000b
+			public static int background_floating_material_dark = 2131492875;
 			
-			// aapt resource value: 0x7f0a0044
-			public static int cardview_dark_background = 2131361860;
+			// aapt resource value: 0x7f0c000c
+			public static int background_floating_material_light = 2131492876;
 			
-			// aapt resource value: 0x7f0a0045
-			public static int cardview_light_background = 2131361861;
+			// aapt resource value: 0x7f0c000d
+			public static int background_material_dark = 2131492877;
 			
-			// aapt resource value: 0x7f0a0046
-			public static int cardview_shadow_end_color = 2131361862;
+			// aapt resource value: 0x7f0c000e
+			public static int background_material_light = 2131492878;
 			
-			// aapt resource value: 0x7f0a0047
-			public static int cardview_shadow_start_color = 2131361863;
+			// aapt resource value: 0x7f0c000f
+			public static int bright_foreground_disabled_material_dark = 2131492879;
 			
-			// aapt resource value: 0x7f0a0000
-			public static int design_fab_shadow_end_color = 2131361792;
+			// aapt resource value: 0x7f0c0010
+			public static int bright_foreground_disabled_material_light = 2131492880;
 			
-			// aapt resource value: 0x7f0a0001
-			public static int design_fab_shadow_mid_color = 2131361793;
+			// aapt resource value: 0x7f0c0011
+			public static int bright_foreground_inverse_material_dark = 2131492881;
 			
-			// aapt resource value: 0x7f0a0002
-			public static int design_fab_shadow_start_color = 2131361794;
+			// aapt resource value: 0x7f0c0012
+			public static int bright_foreground_inverse_material_light = 2131492882;
 			
-			// aapt resource value: 0x7f0a0003
-			public static int design_fab_stroke_end_inner_color = 2131361795;
+			// aapt resource value: 0x7f0c0013
+			public static int bright_foreground_material_dark = 2131492883;
 			
-			// aapt resource value: 0x7f0a0004
-			public static int design_fab_stroke_end_outer_color = 2131361796;
+			// aapt resource value: 0x7f0c0014
+			public static int bright_foreground_material_light = 2131492884;
 			
-			// aapt resource value: 0x7f0a0005
-			public static int design_fab_stroke_top_inner_color = 2131361797;
+			// aapt resource value: 0x7f0c0015
+			public static int button_material_dark = 2131492885;
 			
-			// aapt resource value: 0x7f0a0006
-			public static int design_fab_stroke_top_outer_color = 2131361798;
+			// aapt resource value: 0x7f0c0016
+			public static int button_material_light = 2131492886;
 			
-			// aapt resource value: 0x7f0a0007
-			public static int design_snackbar_background_color = 2131361799;
+			// aapt resource value: 0x7f0c0000
+			public static int cardview_dark_background = 2131492864;
 			
-			// aapt resource value: 0x7f0a0008
-			public static int design_textinput_error_color_dark = 2131361800;
+			// aapt resource value: 0x7f0c0001
+			public static int cardview_light_background = 2131492865;
 			
-			// aapt resource value: 0x7f0a0009
-			public static int design_textinput_error_color_light = 2131361801;
+			// aapt resource value: 0x7f0c0002
+			public static int cardview_shadow_end_color = 2131492866;
 			
-			// aapt resource value: 0x7f0a001c
-			public static int dim_foreground_disabled_material_dark = 2131361820;
+			// aapt resource value: 0x7f0c0003
+			public static int cardview_shadow_start_color = 2131492867;
 			
-			// aapt resource value: 0x7f0a001d
-			public static int dim_foreground_disabled_material_light = 2131361821;
+			// aapt resource value: 0x7f0c003f
+			public static int design_bottom_navigation_shadow_color = 2131492927;
 			
-			// aapt resource value: 0x7f0a001e
-			public static int dim_foreground_material_dark = 2131361822;
+			// aapt resource value: 0x7f0c0060
+			public static int design_error = 2131492960;
 			
-			// aapt resource value: 0x7f0a001f
-			public static int dim_foreground_material_light = 2131361823;
+			// aapt resource value: 0x7f0c0040
+			public static int design_fab_shadow_end_color = 2131492928;
 			
-			// aapt resource value: 0x7f0a0048
-			public static int fab_material_blue_500 = 2131361864;
+			// aapt resource value: 0x7f0c0041
+			public static int design_fab_shadow_mid_color = 2131492929;
 			
-			// aapt resource value: 0x7f0a0020
-			public static int foreground_material_dark = 2131361824;
+			// aapt resource value: 0x7f0c0042
+			public static int design_fab_shadow_start_color = 2131492930;
 			
-			// aapt resource value: 0x7f0a0021
-			public static int foreground_material_light = 2131361825;
+			// aapt resource value: 0x7f0c0043
+			public static int design_fab_stroke_end_inner_color = 2131492931;
 			
-			// aapt resource value: 0x7f0a0022
-			public static int highlighted_text_material_dark = 2131361826;
+			// aapt resource value: 0x7f0c0044
+			public static int design_fab_stroke_end_outer_color = 2131492932;
 			
-			// aapt resource value: 0x7f0a0023
-			public static int highlighted_text_material_light = 2131361827;
+			// aapt resource value: 0x7f0c0045
+			public static int design_fab_stroke_top_inner_color = 2131492933;
 			
-			// aapt resource value: 0x7f0a0024
-			public static int hint_foreground_material_dark = 2131361828;
+			// aapt resource value: 0x7f0c0046
+			public static int design_fab_stroke_top_outer_color = 2131492934;
 			
-			// aapt resource value: 0x7f0a0025
-			public static int hint_foreground_material_light = 2131361829;
+			// aapt resource value: 0x7f0c0047
+			public static int design_snackbar_background_color = 2131492935;
 			
-			// aapt resource value: 0x7f0a0026
-			public static int material_blue_grey_800 = 2131361830;
+			// aapt resource value: 0x7f0c0048
+			public static int design_textinput_error_color_dark = 2131492936;
 			
-			// aapt resource value: 0x7f0a0027
-			public static int material_blue_grey_900 = 2131361831;
+			// aapt resource value: 0x7f0c0049
+			public static int design_textinput_error_color_light = 2131492937;
 			
-			// aapt resource value: 0x7f0a0028
-			public static int material_blue_grey_950 = 2131361832;
+			// aapt resource value: 0x7f0c0061
+			public static int design_tint_password_toggle = 2131492961;
 			
-			// aapt resource value: 0x7f0a0029
-			public static int material_deep_teal_200 = 2131361833;
+			// aapt resource value: 0x7f0c0017
+			public static int dim_foreground_disabled_material_dark = 2131492887;
 			
-			// aapt resource value: 0x7f0a002a
-			public static int material_deep_teal_500 = 2131361834;
+			// aapt resource value: 0x7f0c0018
+			public static int dim_foreground_disabled_material_light = 2131492888;
 			
-			// aapt resource value: 0x7f0a002b
-			public static int material_grey_100 = 2131361835;
+			// aapt resource value: 0x7f0c0019
+			public static int dim_foreground_material_dark = 2131492889;
 			
-			// aapt resource value: 0x7f0a002c
-			public static int material_grey_300 = 2131361836;
+			// aapt resource value: 0x7f0c001a
+			public static int dim_foreground_material_light = 2131492890;
 			
-			// aapt resource value: 0x7f0a002d
-			public static int material_grey_50 = 2131361837;
+			// aapt resource value: 0x7f0c004a
+			public static int fab_material_blue_500 = 2131492938;
 			
-			// aapt resource value: 0x7f0a002e
-			public static int material_grey_600 = 2131361838;
+			// aapt resource value: 0x7f0c001b
+			public static int foreground_material_dark = 2131492891;
 			
-			// aapt resource value: 0x7f0a002f
-			public static int material_grey_800 = 2131361839;
+			// aapt resource value: 0x7f0c001c
+			public static int foreground_material_light = 2131492892;
 			
-			// aapt resource value: 0x7f0a0030
-			public static int material_grey_850 = 2131361840;
+			// aapt resource value: 0x7f0c001d
+			public static int highlighted_text_material_dark = 2131492893;
 			
-			// aapt resource value: 0x7f0a0031
-			public static int material_grey_900 = 2131361841;
+			// aapt resource value: 0x7f0c001e
+			public static int highlighted_text_material_light = 2131492894;
 			
-			// aapt resource value: 0x7f0a0032
-			public static int primary_dark_material_dark = 2131361842;
+			// aapt resource value: 0x7f0c001f
+			public static int material_blue_grey_800 = 2131492895;
 			
-			// aapt resource value: 0x7f0a0033
-			public static int primary_dark_material_light = 2131361843;
+			// aapt resource value: 0x7f0c0020
+			public static int material_blue_grey_900 = 2131492896;
 			
-			// aapt resource value: 0x7f0a0034
-			public static int primary_material_dark = 2131361844;
+			// aapt resource value: 0x7f0c0021
+			public static int material_blue_grey_950 = 2131492897;
 			
-			// aapt resource value: 0x7f0a0035
-			public static int primary_material_light = 2131361845;
+			// aapt resource value: 0x7f0c0022
+			public static int material_deep_teal_200 = 2131492898;
 			
-			// aapt resource value: 0x7f0a0036
-			public static int primary_text_default_material_dark = 2131361846;
+			// aapt resource value: 0x7f0c0023
+			public static int material_deep_teal_500 = 2131492899;
 			
-			// aapt resource value: 0x7f0a0037
-			public static int primary_text_default_material_light = 2131361847;
+			// aapt resource value: 0x7f0c0024
+			public static int material_grey_100 = 2131492900;
 			
-			// aapt resource value: 0x7f0a0038
-			public static int primary_text_disabled_material_dark = 2131361848;
+			// aapt resource value: 0x7f0c0025
+			public static int material_grey_300 = 2131492901;
 			
-			// aapt resource value: 0x7f0a0039
-			public static int primary_text_disabled_material_light = 2131361849;
+			// aapt resource value: 0x7f0c0026
+			public static int material_grey_50 = 2131492902;
 			
-			// aapt resource value: 0x7f0a003a
-			public static int ripple_material_dark = 2131361850;
+			// aapt resource value: 0x7f0c0027
+			public static int material_grey_600 = 2131492903;
 			
-			// aapt resource value: 0x7f0a003b
-			public static int ripple_material_light = 2131361851;
+			// aapt resource value: 0x7f0c0028
+			public static int material_grey_800 = 2131492904;
 			
-			// aapt resource value: 0x7f0a003c
-			public static int secondary_text_default_material_dark = 2131361852;
+			// aapt resource value: 0x7f0c0029
+			public static int material_grey_850 = 2131492905;
 			
-			// aapt resource value: 0x7f0a003d
-			public static int secondary_text_default_material_light = 2131361853;
+			// aapt resource value: 0x7f0c002a
+			public static int material_grey_900 = 2131492906;
 			
-			// aapt resource value: 0x7f0a003e
-			public static int secondary_text_disabled_material_dark = 2131361854;
+			// aapt resource value: 0x7f0c0004
+			public static int notification_action_color_filter = 2131492868;
 			
-			// aapt resource value: 0x7f0a003f
-			public static int secondary_text_disabled_material_light = 2131361855;
+			// aapt resource value: 0x7f0c002b
+			public static int notification_icon_bg_color = 2131492907;
 			
-			// aapt resource value: 0x7f0a0040
-			public static int switch_thumb_disabled_material_dark = 2131361856;
+			// aapt resource value: 0x7f0c002c
+			public static int notification_material_background_media_default_color = 2131492908;
 			
-			// aapt resource value: 0x7f0a0041
-			public static int switch_thumb_disabled_material_light = 2131361857;
+			// aapt resource value: 0x7f0c002d
+			public static int primary_dark_material_dark = 2131492909;
 			
-			// aapt resource value: 0x7f0a0053
-			public static int switch_thumb_material_dark = 2131361875;
+			// aapt resource value: 0x7f0c002e
+			public static int primary_dark_material_light = 2131492910;
 			
-			// aapt resource value: 0x7f0a0054
-			public static int switch_thumb_material_light = 2131361876;
+			// aapt resource value: 0x7f0c002f
+			public static int primary_material_dark = 2131492911;
 			
-			// aapt resource value: 0x7f0a0042
-			public static int switch_thumb_normal_material_dark = 2131361858;
+			// aapt resource value: 0x7f0c0030
+			public static int primary_material_light = 2131492912;
 			
-			// aapt resource value: 0x7f0a0043
-			public static int switch_thumb_normal_material_light = 2131361859;
+			// aapt resource value: 0x7f0c0031
+			public static int primary_text_default_material_dark = 2131492913;
+			
+			// aapt resource value: 0x7f0c0032
+			public static int primary_text_default_material_light = 2131492914;
+			
+			// aapt resource value: 0x7f0c0033
+			public static int primary_text_disabled_material_dark = 2131492915;
+			
+			// aapt resource value: 0x7f0c0034
+			public static int primary_text_disabled_material_light = 2131492916;
+			
+			// aapt resource value: 0x7f0c0035
+			public static int ripple_material_dark = 2131492917;
+			
+			// aapt resource value: 0x7f0c0036
+			public static int ripple_material_light = 2131492918;
+			
+			// aapt resource value: 0x7f0c0037
+			public static int secondary_text_default_material_dark = 2131492919;
+			
+			// aapt resource value: 0x7f0c0038
+			public static int secondary_text_default_material_light = 2131492920;
+			
+			// aapt resource value: 0x7f0c0039
+			public static int secondary_text_disabled_material_dark = 2131492921;
+			
+			// aapt resource value: 0x7f0c003a
+			public static int secondary_text_disabled_material_light = 2131492922;
+			
+			// aapt resource value: 0x7f0c003b
+			public static int switch_thumb_disabled_material_dark = 2131492923;
+			
+			// aapt resource value: 0x7f0c003c
+			public static int switch_thumb_disabled_material_light = 2131492924;
+			
+			// aapt resource value: 0x7f0c0062
+			public static int switch_thumb_material_dark = 2131492962;
+			
+			// aapt resource value: 0x7f0c0063
+			public static int switch_thumb_material_light = 2131492963;
+			
+			// aapt resource value: 0x7f0c003d
+			public static int switch_thumb_normal_material_dark = 2131492925;
+			
+			// aapt resource value: 0x7f0c003e
+			public static int switch_thumb_normal_material_light = 2131492926;
 			
 			static Color()
 			{
@@ -1372,368 +1490,464 @@ namespace FAB.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f070030
-			public static int abc_action_bar_content_inset_material = 2131165232;
-			
-			// aapt resource value: 0x7f070024
-			public static int abc_action_bar_default_height_material = 2131165220;
-			
-			// aapt resource value: 0x7f070031
-			public static int abc_action_bar_default_padding_end_material = 2131165233;
-			
-			// aapt resource value: 0x7f070032
-			public static int abc_action_bar_default_padding_start_material = 2131165234;
-			
-			// aapt resource value: 0x7f070034
-			public static int abc_action_bar_icon_vertical_padding_material = 2131165236;
-			
-			// aapt resource value: 0x7f070035
-			public static int abc_action_bar_overflow_padding_end_material = 2131165237;
-			
-			// aapt resource value: 0x7f070036
-			public static int abc_action_bar_overflow_padding_start_material = 2131165238;
-			
-			// aapt resource value: 0x7f070025
-			public static int abc_action_bar_progress_bar_size = 2131165221;
-			
-			// aapt resource value: 0x7f070037
-			public static int abc_action_bar_stacked_max_height = 2131165239;
-			
-			// aapt resource value: 0x7f070038
-			public static int abc_action_bar_stacked_tab_max_width = 2131165240;
-			
-			// aapt resource value: 0x7f070039
-			public static int abc_action_bar_subtitle_bottom_margin_material = 2131165241;
-			
-			// aapt resource value: 0x7f07003a
-			public static int abc_action_bar_subtitle_top_margin_material = 2131165242;
-			
-			// aapt resource value: 0x7f07003b
-			public static int abc_action_button_min_height_material = 2131165243;
-			
-			// aapt resource value: 0x7f07003c
-			public static int abc_action_button_min_width_material = 2131165244;
-			
-			// aapt resource value: 0x7f07003d
-			public static int abc_action_button_min_width_overflow_material = 2131165245;
-			
-			// aapt resource value: 0x7f070023
-			public static int abc_alert_dialog_button_bar_height = 2131165219;
-			
-			// aapt resource value: 0x7f07003e
-			public static int abc_button_inset_horizontal_material = 2131165246;
-			
-			// aapt resource value: 0x7f07003f
-			public static int abc_button_inset_vertical_material = 2131165247;
-			
-			// aapt resource value: 0x7f070040
-			public static int abc_button_padding_horizontal_material = 2131165248;
-			
-			// aapt resource value: 0x7f070041
-			public static int abc_button_padding_vertical_material = 2131165249;
-			
-			// aapt resource value: 0x7f070028
-			public static int abc_config_prefDialogWidth = 2131165224;
-			
-			// aapt resource value: 0x7f070042
-			public static int abc_control_corner_material = 2131165250;
-			
-			// aapt resource value: 0x7f070043
-			public static int abc_control_inset_material = 2131165251;
-			
-			// aapt resource value: 0x7f070044
-			public static int abc_control_padding_material = 2131165252;
-			
-			// aapt resource value: 0x7f070029
-			public static int abc_dialog_fixed_height_major = 2131165225;
-			
-			// aapt resource value: 0x7f07002a
-			public static int abc_dialog_fixed_height_minor = 2131165226;
-			
-			// aapt resource value: 0x7f07002b
-			public static int abc_dialog_fixed_width_major = 2131165227;
-			
-			// aapt resource value: 0x7f07002c
-			public static int abc_dialog_fixed_width_minor = 2131165228;
-			
-			// aapt resource value: 0x7f070045
-			public static int abc_dialog_list_padding_vertical_material = 2131165253;
-			
-			// aapt resource value: 0x7f07002d
-			public static int abc_dialog_min_width_major = 2131165229;
-			
-			// aapt resource value: 0x7f07002e
-			public static int abc_dialog_min_width_minor = 2131165230;
-			
-			// aapt resource value: 0x7f070046
-			public static int abc_dialog_padding_material = 2131165254;
-			
-			// aapt resource value: 0x7f070047
-			public static int abc_dialog_padding_top_material = 2131165255;
-			
-			// aapt resource value: 0x7f070048
-			public static int abc_disabled_alpha_material_dark = 2131165256;
-			
-			// aapt resource value: 0x7f070049
-			public static int abc_disabled_alpha_material_light = 2131165257;
-			
-			// aapt resource value: 0x7f07004a
-			public static int abc_dropdownitem_icon_width = 2131165258;
-			
-			// aapt resource value: 0x7f07004b
-			public static int abc_dropdownitem_text_padding_left = 2131165259;
-			
-			// aapt resource value: 0x7f07004c
-			public static int abc_dropdownitem_text_padding_right = 2131165260;
-			
-			// aapt resource value: 0x7f07004d
-			public static int abc_edit_text_inset_bottom_material = 2131165261;
-			
-			// aapt resource value: 0x7f07004e
-			public static int abc_edit_text_inset_horizontal_material = 2131165262;
-			
-			// aapt resource value: 0x7f07004f
-			public static int abc_edit_text_inset_top_material = 2131165263;
-			
-			// aapt resource value: 0x7f070050
-			public static int abc_floating_window_z = 2131165264;
-			
-			// aapt resource value: 0x7f070051
-			public static int abc_list_item_padding_horizontal_material = 2131165265;
-			
-			// aapt resource value: 0x7f070052
-			public static int abc_panel_menu_list_width = 2131165266;
-			
-			// aapt resource value: 0x7f070053
-			public static int abc_search_view_preferred_width = 2131165267;
-			
-			// aapt resource value: 0x7f07002f
-			public static int abc_search_view_text_min_width = 2131165231;
-			
-			// aapt resource value: 0x7f070054
-			public static int abc_seekbar_track_background_height_material = 2131165268;
-			
-			// aapt resource value: 0x7f070055
-			public static int abc_seekbar_track_progress_height_material = 2131165269;
-			
-			// aapt resource value: 0x7f070056
-			public static int abc_select_dialog_padding_start_material = 2131165270;
-			
-			// aapt resource value: 0x7f070033
-			public static int abc_switch_padding = 2131165235;
-			
-			// aapt resource value: 0x7f070057
-			public static int abc_text_size_body_1_material = 2131165271;
-			
-			// aapt resource value: 0x7f070058
-			public static int abc_text_size_body_2_material = 2131165272;
-			
-			// aapt resource value: 0x7f070059
-			public static int abc_text_size_button_material = 2131165273;
-			
-			// aapt resource value: 0x7f07005a
-			public static int abc_text_size_caption_material = 2131165274;
-			
-			// aapt resource value: 0x7f07005b
-			public static int abc_text_size_display_1_material = 2131165275;
-			
-			// aapt resource value: 0x7f07005c
-			public static int abc_text_size_display_2_material = 2131165276;
-			
-			// aapt resource value: 0x7f07005d
-			public static int abc_text_size_display_3_material = 2131165277;
-			
-			// aapt resource value: 0x7f07005e
-			public static int abc_text_size_display_4_material = 2131165278;
-			
-			// aapt resource value: 0x7f07005f
-			public static int abc_text_size_headline_material = 2131165279;
-			
-			// aapt resource value: 0x7f070060
-			public static int abc_text_size_large_material = 2131165280;
-			
-			// aapt resource value: 0x7f070061
-			public static int abc_text_size_medium_material = 2131165281;
-			
-			// aapt resource value: 0x7f070062
-			public static int abc_text_size_menu_material = 2131165282;
-			
-			// aapt resource value: 0x7f070063
-			public static int abc_text_size_small_material = 2131165283;
-			
-			// aapt resource value: 0x7f070064
-			public static int abc_text_size_subhead_material = 2131165284;
-			
-			// aapt resource value: 0x7f070026
-			public static int abc_text_size_subtitle_material_toolbar = 2131165222;
-			
-			// aapt resource value: 0x7f070065
-			public static int abc_text_size_title_material = 2131165285;
-			
-			// aapt resource value: 0x7f070027
-			public static int abc_text_size_title_material_toolbar = 2131165223;
-			
-			// aapt resource value: 0x7f070071
-			public static int cardview_compat_inset_shadow = 2131165297;
-			
-			// aapt resource value: 0x7f070072
-			public static int cardview_default_elevation = 2131165298;
-			
-			// aapt resource value: 0x7f070073
-			public static int cardview_default_radius = 2131165299;
-			
-			// aapt resource value: 0x7f07000e
-			public static int design_appbar_elevation = 2131165198;
-			
-			// aapt resource value: 0x7f07000f
-			public static int design_bottom_sheet_modal_elevation = 2131165199;
-			
-			// aapt resource value: 0x7f070010
-			public static int design_bottom_sheet_modal_peek_height = 2131165200;
-			
-			// aapt resource value: 0x7f070011
-			public static int design_fab_border_width = 2131165201;
-			
-			// aapt resource value: 0x7f070012
-			public static int design_fab_elevation = 2131165202;
-			
-			// aapt resource value: 0x7f070013
-			public static int design_fab_image_size = 2131165203;
-			
-			// aapt resource value: 0x7f070014
-			public static int design_fab_size_mini = 2131165204;
-			
-			// aapt resource value: 0x7f070015
-			public static int design_fab_size_normal = 2131165205;
-			
-			// aapt resource value: 0x7f070016
-			public static int design_fab_translation_z_pressed = 2131165206;
-			
-			// aapt resource value: 0x7f070017
-			public static int design_navigation_elevation = 2131165207;
-			
 			// aapt resource value: 0x7f070018
-			public static int design_navigation_icon_padding = 2131165208;
+			public static int abc_action_bar_content_inset_material = 2131165208;
 			
 			// aapt resource value: 0x7f070019
-			public static int design_navigation_icon_size = 2131165209;
-			
-			// aapt resource value: 0x7f070006
-			public static int design_navigation_max_width = 2131165190;
-			
-			// aapt resource value: 0x7f07001a
-			public static int design_navigation_padding_bottom = 2131165210;
-			
-			// aapt resource value: 0x7f07001b
-			public static int design_navigation_separator_vertical_padding = 2131165211;
-			
-			// aapt resource value: 0x7f070007
-			public static int design_snackbar_action_inline_max_width = 2131165191;
-			
-			// aapt resource value: 0x7f070008
-			public static int design_snackbar_background_corner_radius = 2131165192;
-			
-			// aapt resource value: 0x7f07001c
-			public static int design_snackbar_elevation = 2131165212;
-			
-			// aapt resource value: 0x7f070009
-			public static int design_snackbar_extra_spacing_horizontal = 2131165193;
-			
-			// aapt resource value: 0x7f07000a
-			public static int design_snackbar_max_width = 2131165194;
-			
-			// aapt resource value: 0x7f07000b
-			public static int design_snackbar_min_width = 2131165195;
-			
-			// aapt resource value: 0x7f07001d
-			public static int design_snackbar_padding_horizontal = 2131165213;
-			
-			// aapt resource value: 0x7f07001e
-			public static int design_snackbar_padding_vertical = 2131165214;
-			
-			// aapt resource value: 0x7f07000c
-			public static int design_snackbar_padding_vertical_2lines = 2131165196;
-			
-			// aapt resource value: 0x7f07001f
-			public static int design_snackbar_text_size = 2131165215;
-			
-			// aapt resource value: 0x7f070020
-			public static int design_tab_max_width = 2131165216;
+			public static int abc_action_bar_content_inset_with_nav = 2131165209;
 			
 			// aapt resource value: 0x7f07000d
-			public static int design_tab_scrollable_min_width = 2131165197;
+			public static int abc_action_bar_default_height_material = 2131165197;
+			
+			// aapt resource value: 0x7f07001a
+			public static int abc_action_bar_default_padding_end_material = 2131165210;
+			
+			// aapt resource value: 0x7f07001b
+			public static int abc_action_bar_default_padding_start_material = 2131165211;
 			
 			// aapt resource value: 0x7f070021
-			public static int design_tab_text_size = 2131165217;
+			public static int abc_action_bar_elevation_material = 2131165217;
 			
 			// aapt resource value: 0x7f070022
-			public static int design_tab_text_size_2line = 2131165218;
+			public static int abc_action_bar_icon_vertical_padding_material = 2131165218;
 			
-			// aapt resource value: 0x7f070066
-			public static int disabled_alpha_material_dark = 2131165286;
+			// aapt resource value: 0x7f070023
+			public static int abc_action_bar_overflow_padding_end_material = 2131165219;
 			
-			// aapt resource value: 0x7f070067
-			public static int disabled_alpha_material_light = 2131165287;
+			// aapt resource value: 0x7f070024
+			public static int abc_action_bar_overflow_padding_start_material = 2131165220;
 			
-			// aapt resource value: 0x7f070078
-			public static int fab_elevation_lollipop = 2131165304;
+			// aapt resource value: 0x7f07000e
+			public static int abc_action_bar_progress_bar_size = 2131165198;
 			
-			// aapt resource value: 0x7f070077
-			public static int fab_scroll_threshold = 2131165303;
+			// aapt resource value: 0x7f070025
+			public static int abc_action_bar_stacked_max_height = 2131165221;
+			
+			// aapt resource value: 0x7f070026
+			public static int abc_action_bar_stacked_tab_max_width = 2131165222;
+			
+			// aapt resource value: 0x7f070027
+			public static int abc_action_bar_subtitle_bottom_margin_material = 2131165223;
+			
+			// aapt resource value: 0x7f070028
+			public static int abc_action_bar_subtitle_top_margin_material = 2131165224;
+			
+			// aapt resource value: 0x7f070029
+			public static int abc_action_button_min_height_material = 2131165225;
+			
+			// aapt resource value: 0x7f07002a
+			public static int abc_action_button_min_width_material = 2131165226;
+			
+			// aapt resource value: 0x7f07002b
+			public static int abc_action_button_min_width_overflow_material = 2131165227;
+			
+			// aapt resource value: 0x7f07000c
+			public static int abc_alert_dialog_button_bar_height = 2131165196;
+			
+			// aapt resource value: 0x7f07002c
+			public static int abc_button_inset_horizontal_material = 2131165228;
+			
+			// aapt resource value: 0x7f07002d
+			public static int abc_button_inset_vertical_material = 2131165229;
+			
+			// aapt resource value: 0x7f07002e
+			public static int abc_button_padding_horizontal_material = 2131165230;
+			
+			// aapt resource value: 0x7f07002f
+			public static int abc_button_padding_vertical_material = 2131165231;
+			
+			// aapt resource value: 0x7f070030
+			public static int abc_cascading_menus_min_smallest_width = 2131165232;
+			
+			// aapt resource value: 0x7f070011
+			public static int abc_config_prefDialogWidth = 2131165201;
+			
+			// aapt resource value: 0x7f070031
+			public static int abc_control_corner_material = 2131165233;
+			
+			// aapt resource value: 0x7f070032
+			public static int abc_control_inset_material = 2131165234;
+			
+			// aapt resource value: 0x7f070033
+			public static int abc_control_padding_material = 2131165235;
+			
+			// aapt resource value: 0x7f070012
+			public static int abc_dialog_fixed_height_major = 2131165202;
+			
+			// aapt resource value: 0x7f070013
+			public static int abc_dialog_fixed_height_minor = 2131165203;
+			
+			// aapt resource value: 0x7f070014
+			public static int abc_dialog_fixed_width_major = 2131165204;
+			
+			// aapt resource value: 0x7f070015
+			public static int abc_dialog_fixed_width_minor = 2131165205;
+			
+			// aapt resource value: 0x7f070034
+			public static int abc_dialog_list_padding_bottom_no_buttons = 2131165236;
+			
+			// aapt resource value: 0x7f070035
+			public static int abc_dialog_list_padding_top_no_title = 2131165237;
+			
+			// aapt resource value: 0x7f070016
+			public static int abc_dialog_min_width_major = 2131165206;
+			
+			// aapt resource value: 0x7f070017
+			public static int abc_dialog_min_width_minor = 2131165207;
+			
+			// aapt resource value: 0x7f070036
+			public static int abc_dialog_padding_material = 2131165238;
+			
+			// aapt resource value: 0x7f070037
+			public static int abc_dialog_padding_top_material = 2131165239;
+			
+			// aapt resource value: 0x7f070038
+			public static int abc_dialog_title_divider_material = 2131165240;
+			
+			// aapt resource value: 0x7f070039
+			public static int abc_disabled_alpha_material_dark = 2131165241;
+			
+			// aapt resource value: 0x7f07003a
+			public static int abc_disabled_alpha_material_light = 2131165242;
+			
+			// aapt resource value: 0x7f07003b
+			public static int abc_dropdownitem_icon_width = 2131165243;
+			
+			// aapt resource value: 0x7f07003c
+			public static int abc_dropdownitem_text_padding_left = 2131165244;
+			
+			// aapt resource value: 0x7f07003d
+			public static int abc_dropdownitem_text_padding_right = 2131165245;
+			
+			// aapt resource value: 0x7f07003e
+			public static int abc_edit_text_inset_bottom_material = 2131165246;
+			
+			// aapt resource value: 0x7f07003f
+			public static int abc_edit_text_inset_horizontal_material = 2131165247;
+			
+			// aapt resource value: 0x7f070040
+			public static int abc_edit_text_inset_top_material = 2131165248;
+			
+			// aapt resource value: 0x7f070041
+			public static int abc_floating_window_z = 2131165249;
+			
+			// aapt resource value: 0x7f070042
+			public static int abc_list_item_padding_horizontal_material = 2131165250;
+			
+			// aapt resource value: 0x7f070043
+			public static int abc_panel_menu_list_width = 2131165251;
+			
+			// aapt resource value: 0x7f070044
+			public static int abc_progress_bar_height_material = 2131165252;
+			
+			// aapt resource value: 0x7f070045
+			public static int abc_search_view_preferred_height = 2131165253;
+			
+			// aapt resource value: 0x7f070046
+			public static int abc_search_view_preferred_width = 2131165254;
+			
+			// aapt resource value: 0x7f070047
+			public static int abc_seekbar_track_background_height_material = 2131165255;
+			
+			// aapt resource value: 0x7f070048
+			public static int abc_seekbar_track_progress_height_material = 2131165256;
+			
+			// aapt resource value: 0x7f070049
+			public static int abc_select_dialog_padding_start_material = 2131165257;
+			
+			// aapt resource value: 0x7f07001d
+			public static int abc_switch_padding = 2131165213;
+			
+			// aapt resource value: 0x7f07004a
+			public static int abc_text_size_body_1_material = 2131165258;
+			
+			// aapt resource value: 0x7f07004b
+			public static int abc_text_size_body_2_material = 2131165259;
+			
+			// aapt resource value: 0x7f07004c
+			public static int abc_text_size_button_material = 2131165260;
+			
+			// aapt resource value: 0x7f07004d
+			public static int abc_text_size_caption_material = 2131165261;
+			
+			// aapt resource value: 0x7f07004e
+			public static int abc_text_size_display_1_material = 2131165262;
+			
+			// aapt resource value: 0x7f07004f
+			public static int abc_text_size_display_2_material = 2131165263;
+			
+			// aapt resource value: 0x7f070050
+			public static int abc_text_size_display_3_material = 2131165264;
+			
+			// aapt resource value: 0x7f070051
+			public static int abc_text_size_display_4_material = 2131165265;
+			
+			// aapt resource value: 0x7f070052
+			public static int abc_text_size_headline_material = 2131165266;
+			
+			// aapt resource value: 0x7f070053
+			public static int abc_text_size_large_material = 2131165267;
+			
+			// aapt resource value: 0x7f070054
+			public static int abc_text_size_medium_material = 2131165268;
+			
+			// aapt resource value: 0x7f070055
+			public static int abc_text_size_menu_header_material = 2131165269;
+			
+			// aapt resource value: 0x7f070056
+			public static int abc_text_size_menu_material = 2131165270;
+			
+			// aapt resource value: 0x7f070057
+			public static int abc_text_size_small_material = 2131165271;
+			
+			// aapt resource value: 0x7f070058
+			public static int abc_text_size_subhead_material = 2131165272;
+			
+			// aapt resource value: 0x7f07000f
+			public static int abc_text_size_subtitle_material_toolbar = 2131165199;
+			
+			// aapt resource value: 0x7f070059
+			public static int abc_text_size_title_material = 2131165273;
+			
+			// aapt resource value: 0x7f070010
+			public static int abc_text_size_title_material_toolbar = 2131165200;
+			
+			// aapt resource value: 0x7f070009
+			public static int cardview_compat_inset_shadow = 2131165193;
+			
+			// aapt resource value: 0x7f07000a
+			public static int cardview_default_elevation = 2131165194;
+			
+			// aapt resource value: 0x7f07000b
+			public static int cardview_default_radius = 2131165195;
 			
 			// aapt resource value: 0x7f070076
-			public static int fab_shadow_size = 2131165302;
+			public static int design_appbar_elevation = 2131165302;
 			
-			// aapt resource value: 0x7f070075
-			public static int fab_size_mini = 2131165301;
+			// aapt resource value: 0x7f070077
+			public static int design_bottom_navigation_active_item_max_width = 2131165303;
 			
-			// aapt resource value: 0x7f070074
-			public static int fab_size_normal = 2131165300;
+			// aapt resource value: 0x7f070078
+			public static int design_bottom_navigation_active_text_size = 2131165304;
 			
-			// aapt resource value: 0x7f070068
-			public static int highlight_alpha_material_colored = 2131165288;
+			// aapt resource value: 0x7f070079
+			public static int design_bottom_navigation_elevation = 2131165305;
 			
-			// aapt resource value: 0x7f070069
-			public static int highlight_alpha_material_dark = 2131165289;
+			// aapt resource value: 0x7f07007a
+			public static int design_bottom_navigation_height = 2131165306;
 			
-			// aapt resource value: 0x7f07006a
-			public static int highlight_alpha_material_light = 2131165290;
+			// aapt resource value: 0x7f07007b
+			public static int design_bottom_navigation_item_max_width = 2131165307;
+			
+			// aapt resource value: 0x7f07007c
+			public static int design_bottom_navigation_item_min_width = 2131165308;
+			
+			// aapt resource value: 0x7f07007d
+			public static int design_bottom_navigation_margin = 2131165309;
+			
+			// aapt resource value: 0x7f07007e
+			public static int design_bottom_navigation_shadow_height = 2131165310;
+			
+			// aapt resource value: 0x7f07007f
+			public static int design_bottom_navigation_text_size = 2131165311;
+			
+			// aapt resource value: 0x7f070080
+			public static int design_bottom_sheet_modal_elevation = 2131165312;
+			
+			// aapt resource value: 0x7f070081
+			public static int design_bottom_sheet_peek_height_min = 2131165313;
+			
+			// aapt resource value: 0x7f070082
+			public static int design_fab_border_width = 2131165314;
+			
+			// aapt resource value: 0x7f070083
+			public static int design_fab_elevation = 2131165315;
+			
+			// aapt resource value: 0x7f070084
+			public static int design_fab_image_size = 2131165316;
+			
+			// aapt resource value: 0x7f070085
+			public static int design_fab_size_mini = 2131165317;
+			
+			// aapt resource value: 0x7f070086
+			public static int design_fab_size_normal = 2131165318;
+			
+			// aapt resource value: 0x7f070087
+			public static int design_fab_translation_z_pressed = 2131165319;
+			
+			// aapt resource value: 0x7f070088
+			public static int design_navigation_elevation = 2131165320;
+			
+			// aapt resource value: 0x7f070089
+			public static int design_navigation_icon_padding = 2131165321;
+			
+			// aapt resource value: 0x7f07008a
+			public static int design_navigation_icon_size = 2131165322;
 			
 			// aapt resource value: 0x7f07006e
-			public static int item_touch_helper_max_drag_scroll_per_frame = 2131165294;
+			public static int design_navigation_max_width = 2131165294;
+			
+			// aapt resource value: 0x7f07008b
+			public static int design_navigation_padding_bottom = 2131165323;
+			
+			// aapt resource value: 0x7f07008c
+			public static int design_navigation_separator_vertical_padding = 2131165324;
 			
 			// aapt resource value: 0x7f07006f
-			public static int item_touch_helper_swipe_escape_max_velocity = 2131165295;
+			public static int design_snackbar_action_inline_max_width = 2131165295;
 			
 			// aapt resource value: 0x7f070070
-			public static int item_touch_helper_swipe_escape_velocity = 2131165296;
+			public static int design_snackbar_background_corner_radius = 2131165296;
+			
+			// aapt resource value: 0x7f07008d
+			public static int design_snackbar_elevation = 2131165325;
+			
+			// aapt resource value: 0x7f070071
+			public static int design_snackbar_extra_spacing_horizontal = 2131165297;
+			
+			// aapt resource value: 0x7f070072
+			public static int design_snackbar_max_width = 2131165298;
+			
+			// aapt resource value: 0x7f070073
+			public static int design_snackbar_min_width = 2131165299;
+			
+			// aapt resource value: 0x7f07008e
+			public static int design_snackbar_padding_horizontal = 2131165326;
+			
+			// aapt resource value: 0x7f07008f
+			public static int design_snackbar_padding_vertical = 2131165327;
+			
+			// aapt resource value: 0x7f070074
+			public static int design_snackbar_padding_vertical_2lines = 2131165300;
+			
+			// aapt resource value: 0x7f070090
+			public static int design_snackbar_text_size = 2131165328;
+			
+			// aapt resource value: 0x7f070091
+			public static int design_tab_max_width = 2131165329;
+			
+			// aapt resource value: 0x7f070075
+			public static int design_tab_scrollable_min_width = 2131165301;
+			
+			// aapt resource value: 0x7f070092
+			public static int design_tab_text_size = 2131165330;
+			
+			// aapt resource value: 0x7f070093
+			public static int design_tab_text_size_2line = 2131165331;
+			
+			// aapt resource value: 0x7f07005a
+			public static int disabled_alpha_material_dark = 2131165274;
+			
+			// aapt resource value: 0x7f07005b
+			public static int disabled_alpha_material_light = 2131165275;
+			
+			// aapt resource value: 0x7f070098
+			public static int fab_elevation_lollipop = 2131165336;
+			
+			// aapt resource value: 0x7f070097
+			public static int fab_scroll_threshold = 2131165335;
+			
+			// aapt resource value: 0x7f070096
+			public static int fab_shadow_size = 2131165334;
+			
+			// aapt resource value: 0x7f070095
+			public static int fab_size_mini = 2131165333;
+			
+			// aapt resource value: 0x7f070094
+			public static int fab_size_normal = 2131165332;
+			
+			// aapt resource value: 0x7f07005c
+			public static int highlight_alpha_material_colored = 2131165276;
+			
+			// aapt resource value: 0x7f07005d
+			public static int highlight_alpha_material_dark = 2131165277;
+			
+			// aapt resource value: 0x7f07005e
+			public static int highlight_alpha_material_light = 2131165278;
+			
+			// aapt resource value: 0x7f07005f
+			public static int hint_alpha_material_dark = 2131165279;
+			
+			// aapt resource value: 0x7f070060
+			public static int hint_alpha_material_light = 2131165280;
+			
+			// aapt resource value: 0x7f070061
+			public static int hint_pressed_alpha_material_dark = 2131165281;
+			
+			// aapt resource value: 0x7f070062
+			public static int hint_pressed_alpha_material_light = 2131165282;
 			
 			// aapt resource value: 0x7f070000
-			public static int mr_controller_volume_group_list_item_height = 2131165184;
+			public static int item_touch_helper_max_drag_scroll_per_frame = 2131165184;
 			
 			// aapt resource value: 0x7f070001
-			public static int mr_controller_volume_group_list_item_icon_size = 2131165185;
+			public static int item_touch_helper_swipe_escape_max_velocity = 2131165185;
 			
 			// aapt resource value: 0x7f070002
-			public static int mr_controller_volume_group_list_max_height = 2131165186;
-			
-			// aapt resource value: 0x7f070005
-			public static int mr_controller_volume_group_list_padding_top = 2131165189;
+			public static int item_touch_helper_swipe_escape_velocity = 2131165186;
 			
 			// aapt resource value: 0x7f070003
-			public static int mr_dialog_fixed_width_major = 2131165187;
+			public static int mr_controller_volume_group_list_item_height = 2131165187;
 			
 			// aapt resource value: 0x7f070004
-			public static int mr_dialog_fixed_width_minor = 2131165188;
+			public static int mr_controller_volume_group_list_item_icon_size = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public static int mr_controller_volume_group_list_max_height = 2131165189;
+			
+			// aapt resource value: 0x7f070008
+			public static int mr_controller_volume_group_list_padding_top = 2131165192;
+			
+			// aapt resource value: 0x7f070006
+			public static int mr_dialog_fixed_width_major = 2131165190;
+			
+			// aapt resource value: 0x7f070007
+			public static int mr_dialog_fixed_width_minor = 2131165191;
+			
+			// aapt resource value: 0x7f070063
+			public static int notification_action_icon_size = 2131165283;
+			
+			// aapt resource value: 0x7f070064
+			public static int notification_action_text_size = 2131165284;
+			
+			// aapt resource value: 0x7f070065
+			public static int notification_big_circle_margin = 2131165285;
+			
+			// aapt resource value: 0x7f07001e
+			public static int notification_content_margin_start = 2131165214;
+			
+			// aapt resource value: 0x7f070066
+			public static int notification_large_icon_height = 2131165286;
+			
+			// aapt resource value: 0x7f070067
+			public static int notification_large_icon_width = 2131165287;
+			
+			// aapt resource value: 0x7f07001f
+			public static int notification_main_column_padding_top = 2131165215;
+			
+			// aapt resource value: 0x7f070020
+			public static int notification_media_narrow_margin = 2131165216;
+			
+			// aapt resource value: 0x7f070068
+			public static int notification_right_icon_size = 2131165288;
+			
+			// aapt resource value: 0x7f07001c
+			public static int notification_right_side_padding_top = 2131165212;
+			
+			// aapt resource value: 0x7f070069
+			public static int notification_small_icon_background_padding = 2131165289;
+			
+			// aapt resource value: 0x7f07006a
+			public static int notification_small_icon_size_as_large = 2131165290;
 			
 			// aapt resource value: 0x7f07006b
-			public static int notification_large_icon_height = 2131165291;
+			public static int notification_subtext_size = 2131165291;
 			
 			// aapt resource value: 0x7f07006c
-			public static int notification_large_icon_width = 2131165292;
+			public static int notification_top_pad = 2131165292;
 			
 			// aapt resource value: 0x7f07006d
-			public static int notification_subtext_size = 2131165293;
+			public static int notification_top_pad_large_text = 2131165293;
 			
 			static Dimension()
 			{
@@ -1782,85 +1996,85 @@ namespace FAB.Droid
 			public static int abc_btn_radio_to_on_mtrl_015 = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public static int abc_btn_rating_star_off_mtrl_alpha = 2130837515;
+			public static int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public static int abc_btn_rating_star_on_mtrl_alpha = 2130837516;
+			public static int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public static int abc_btn_switch_to_on_mtrl_00001 = 2130837517;
+			public static int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public static int abc_btn_switch_to_on_mtrl_00012 = 2130837518;
+			public static int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public static int abc_cab_background_internal_bg = 2130837519;
+			public static int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public static int abc_cab_background_top_material = 2130837520;
+			public static int abc_control_background_material = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public static int abc_cab_background_top_mtrl_alpha = 2130837521;
+			public static int abc_dialog_material_background = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public static int abc_control_background_material = 2130837522;
+			public static int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public static int abc_dialog_material_background_dark = 2130837523;
+			public static int abc_ic_ab_back_material = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public static int abc_dialog_material_background_light = 2130837524;
+			public static int abc_ic_arrow_drop_right_black_24dp = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public static int abc_edit_text_material = 2130837525;
+			public static int abc_ic_clear_material = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public static int abc_ic_ab_back_mtrl_am_alpha = 2130837526;
+			public static int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public static int abc_ic_clear_mtrl_alpha = 2130837527;
+			public static int abc_ic_go_search_api_material = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public static int abc_ic_commit_search_api_mtrl_alpha = 2130837528;
+			public static int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public static int abc_ic_go_search_api_mtrl_alpha = 2130837529;
+			public static int abc_ic_menu_cut_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public static int abc_ic_menu_copy_mtrl_am_alpha = 2130837530;
+			public static int abc_ic_menu_overflow_material = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public static int abc_ic_menu_cut_mtrl_alpha = 2130837531;
+			public static int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public static int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837532;
+			public static int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public static int abc_ic_menu_paste_mtrl_am_alpha = 2130837533;
+			public static int abc_ic_menu_share_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public static int abc_ic_menu_selectall_mtrl_alpha = 2130837534;
+			public static int abc_ic_search_api_material = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public static int abc_ic_menu_share_mtrl_alpha = 2130837535;
+			public static int abc_ic_star_black_16dp = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public static int abc_ic_search_api_mtrl_alpha = 2130837536;
+			public static int abc_ic_star_black_36dp = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public static int abc_ic_star_black_16dp = 2130837537;
+			public static int abc_ic_star_black_48dp = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public static int abc_ic_star_black_36dp = 2130837538;
+			public static int abc_ic_star_half_black_16dp = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public static int abc_ic_star_half_black_16dp = 2130837539;
+			public static int abc_ic_star_half_black_36dp = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public static int abc_ic_star_half_black_36dp = 2130837540;
+			public static int abc_ic_star_half_black_48dp = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public static int abc_ic_voice_search_api_mtrl_alpha = 2130837541;
+			public static int abc_ic_voice_search_api_material = 2130837541;
 			
 			// aapt resource value: 0x7f020026
 			public static int abc_item_background_holo_dark = 2130837542;
@@ -1908,10 +2122,10 @@ namespace FAB.Droid
 			public static int abc_popup_background_mtrl_mult = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public static int abc_ratingbar_full_material = 2130837557;
+			public static int abc_ratingbar_indicator_material = 2130837557;
 			
 			// aapt resource value: 0x7f020036
-			public static int abc_ratingbar_indicator_material = 2130837558;
+			public static int abc_ratingbar_material = 2130837558;
 			
 			// aapt resource value: 0x7f020037
 			public static int abc_ratingbar_small_material = 2130837559;
@@ -1935,307 +2149,649 @@ namespace FAB.Droid
 			public static int abc_seekbar_thumb_material = 2130837565;
 			
 			// aapt resource value: 0x7f02003e
-			public static int abc_seekbar_track_material = 2130837566;
+			public static int abc_seekbar_tick_mark_material = 2130837566;
 			
 			// aapt resource value: 0x7f02003f
-			public static int abc_spinner_mtrl_am_alpha = 2130837567;
+			public static int abc_seekbar_track_material = 2130837567;
 			
 			// aapt resource value: 0x7f020040
-			public static int abc_spinner_textfield_background_material = 2130837568;
+			public static int abc_spinner_mtrl_am_alpha = 2130837568;
 			
 			// aapt resource value: 0x7f020041
-			public static int abc_switch_thumb_material = 2130837569;
+			public static int abc_spinner_textfield_background_material = 2130837569;
 			
 			// aapt resource value: 0x7f020042
-			public static int abc_switch_track_mtrl_alpha = 2130837570;
+			public static int abc_switch_thumb_material = 2130837570;
 			
 			// aapt resource value: 0x7f020043
-			public static int abc_tab_indicator_material = 2130837571;
+			public static int abc_switch_track_mtrl_alpha = 2130837571;
 			
 			// aapt resource value: 0x7f020044
-			public static int abc_tab_indicator_mtrl_alpha = 2130837572;
+			public static int abc_tab_indicator_material = 2130837572;
 			
 			// aapt resource value: 0x7f020045
-			public static int abc_text_cursor_material = 2130837573;
+			public static int abc_tab_indicator_mtrl_alpha = 2130837573;
 			
 			// aapt resource value: 0x7f020046
-			public static int abc_textfield_activated_mtrl_alpha = 2130837574;
+			public static int abc_text_cursor_material = 2130837574;
 			
 			// aapt resource value: 0x7f020047
-			public static int abc_textfield_default_mtrl_alpha = 2130837575;
+			public static int abc_text_select_handle_left_mtrl_dark = 2130837575;
 			
 			// aapt resource value: 0x7f020048
-			public static int abc_textfield_search_activated_mtrl_alpha = 2130837576;
+			public static int abc_text_select_handle_left_mtrl_light = 2130837576;
 			
 			// aapt resource value: 0x7f020049
-			public static int abc_textfield_search_default_mtrl_alpha = 2130837577;
+			public static int abc_text_select_handle_middle_mtrl_dark = 2130837577;
 			
 			// aapt resource value: 0x7f02004a
-			public static int abc_textfield_search_material = 2130837578;
+			public static int abc_text_select_handle_middle_mtrl_light = 2130837578;
 			
 			// aapt resource value: 0x7f02004b
-			public static int design_fab_background = 2130837579;
+			public static int abc_text_select_handle_right_mtrl_dark = 2130837579;
 			
 			// aapt resource value: 0x7f02004c
-			public static int design_snackbar_background = 2130837580;
+			public static int abc_text_select_handle_right_mtrl_light = 2130837580;
 			
 			// aapt resource value: 0x7f02004d
-			public static int fab_shadow = 2130837581;
+			public static int abc_textfield_activated_mtrl_alpha = 2130837581;
 			
 			// aapt resource value: 0x7f02004e
-			public static int fab_shadow_mini = 2130837582;
+			public static int abc_textfield_default_mtrl_alpha = 2130837582;
 			
 			// aapt resource value: 0x7f02004f
-			public static int ic_audiotrack = 2130837583;
+			public static int abc_textfield_search_activated_mtrl_alpha = 2130837583;
 			
 			// aapt resource value: 0x7f020050
-			public static int ic_audiotrack_light = 2130837584;
+			public static int abc_textfield_search_default_mtrl_alpha = 2130837584;
 			
 			// aapt resource value: 0x7f020051
-			public static int ic_bluetooth_grey = 2130837585;
+			public static int abc_textfield_search_material = 2130837585;
 			
 			// aapt resource value: 0x7f020052
-			public static int ic_bluetooth_white = 2130837586;
+			public static int abc_vector_test = 2130837586;
 			
 			// aapt resource value: 0x7f020053
-			public static int ic_cast_dark = 2130837587;
+			public static int avd_hide_password = 2130837587;
+			
+			// aapt resource value: 0x7f02010f
+			public static int avd_hide_password_1 = 2130837775;
+			
+			// aapt resource value: 0x7f020110
+			public static int avd_hide_password_2 = 2130837776;
+			
+			// aapt resource value: 0x7f020111
+			public static int avd_hide_password_3 = 2130837777;
 			
 			// aapt resource value: 0x7f020054
-			public static int ic_cast_disabled_light = 2130837588;
+			public static int avd_show_password = 2130837588;
+			
+			// aapt resource value: 0x7f020112
+			public static int avd_show_password_1 = 2130837778;
+			
+			// aapt resource value: 0x7f020113
+			public static int avd_show_password_2 = 2130837779;
+			
+			// aapt resource value: 0x7f020114
+			public static int avd_show_password_3 = 2130837780;
 			
 			// aapt resource value: 0x7f020055
-			public static int ic_cast_grey = 2130837589;
+			public static int design_bottom_navigation_item_background = 2130837589;
 			
 			// aapt resource value: 0x7f020056
-			public static int ic_cast_light = 2130837590;
+			public static int design_fab_background = 2130837590;
 			
 			// aapt resource value: 0x7f020057
-			public static int ic_cast_off_light = 2130837591;
+			public static int design_ic_visibility = 2130837591;
 			
 			// aapt resource value: 0x7f020058
-			public static int ic_cast_on_0_light = 2130837592;
+			public static int design_ic_visibility_off = 2130837592;
 			
 			// aapt resource value: 0x7f020059
-			public static int ic_cast_on_1_light = 2130837593;
+			public static int design_password_eye = 2130837593;
 			
 			// aapt resource value: 0x7f02005a
-			public static int ic_cast_on_2_light = 2130837594;
+			public static int design_snackbar_background = 2130837594;
 			
 			// aapt resource value: 0x7f02005b
-			public static int ic_cast_on_light = 2130837595;
+			public static int fab_shadow = 2130837595;
 			
 			// aapt resource value: 0x7f02005c
-			public static int ic_cast_white = 2130837596;
+			public static int fab_shadow_mini = 2130837596;
 			
 			// aapt resource value: 0x7f02005d
-			public static int ic_close_dark = 2130837597;
+			public static int ic_audiotrack_dark = 2130837597;
 			
 			// aapt resource value: 0x7f02005e
-			public static int ic_close_light = 2130837598;
+			public static int ic_audiotrack_light = 2130837598;
 			
 			// aapt resource value: 0x7f02005f
-			public static int ic_collapse = 2130837599;
+			public static int ic_dialog_close_dark = 2130837599;
 			
 			// aapt resource value: 0x7f020060
-			public static int ic_collapse_00000 = 2130837600;
+			public static int ic_dialog_close_light = 2130837600;
 			
 			// aapt resource value: 0x7f020061
-			public static int ic_collapse_00001 = 2130837601;
+			public static int ic_group_collapse_00 = 2130837601;
 			
 			// aapt resource value: 0x7f020062
-			public static int ic_collapse_00002 = 2130837602;
+			public static int ic_group_collapse_01 = 2130837602;
 			
 			// aapt resource value: 0x7f020063
-			public static int ic_collapse_00003 = 2130837603;
+			public static int ic_group_collapse_02 = 2130837603;
 			
 			// aapt resource value: 0x7f020064
-			public static int ic_collapse_00004 = 2130837604;
+			public static int ic_group_collapse_03 = 2130837604;
 			
 			// aapt resource value: 0x7f020065
-			public static int ic_collapse_00005 = 2130837605;
+			public static int ic_group_collapse_04 = 2130837605;
 			
 			// aapt resource value: 0x7f020066
-			public static int ic_collapse_00006 = 2130837606;
+			public static int ic_group_collapse_05 = 2130837606;
 			
 			// aapt resource value: 0x7f020067
-			public static int ic_collapse_00007 = 2130837607;
+			public static int ic_group_collapse_06 = 2130837607;
 			
 			// aapt resource value: 0x7f020068
-			public static int ic_collapse_00008 = 2130837608;
+			public static int ic_group_collapse_07 = 2130837608;
 			
 			// aapt resource value: 0x7f020069
-			public static int ic_collapse_00009 = 2130837609;
+			public static int ic_group_collapse_08 = 2130837609;
 			
 			// aapt resource value: 0x7f02006a
-			public static int ic_collapse_00010 = 2130837610;
+			public static int ic_group_collapse_09 = 2130837610;
 			
 			// aapt resource value: 0x7f02006b
-			public static int ic_collapse_00011 = 2130837611;
+			public static int ic_group_collapse_10 = 2130837611;
 			
 			// aapt resource value: 0x7f02006c
-			public static int ic_collapse_00012 = 2130837612;
+			public static int ic_group_collapse_11 = 2130837612;
 			
 			// aapt resource value: 0x7f02006d
-			public static int ic_collapse_00013 = 2130837613;
+			public static int ic_group_collapse_12 = 2130837613;
 			
 			// aapt resource value: 0x7f02006e
-			public static int ic_collapse_00014 = 2130837614;
+			public static int ic_group_collapse_13 = 2130837614;
 			
 			// aapt resource value: 0x7f02006f
-			public static int ic_collapse_00015 = 2130837615;
+			public static int ic_group_collapse_14 = 2130837615;
 			
 			// aapt resource value: 0x7f020070
-			public static int ic_expand = 2130837616;
+			public static int ic_group_collapse_15 = 2130837616;
 			
 			// aapt resource value: 0x7f020071
-			public static int ic_expand_00000 = 2130837617;
+			public static int ic_group_expand_00 = 2130837617;
 			
 			// aapt resource value: 0x7f020072
-			public static int ic_expand_00001 = 2130837618;
+			public static int ic_group_expand_01 = 2130837618;
 			
 			// aapt resource value: 0x7f020073
-			public static int ic_expand_00002 = 2130837619;
+			public static int ic_group_expand_02 = 2130837619;
 			
 			// aapt resource value: 0x7f020074
-			public static int ic_expand_00003 = 2130837620;
+			public static int ic_group_expand_03 = 2130837620;
 			
 			// aapt resource value: 0x7f020075
-			public static int ic_expand_00004 = 2130837621;
+			public static int ic_group_expand_04 = 2130837621;
 			
 			// aapt resource value: 0x7f020076
-			public static int ic_expand_00005 = 2130837622;
+			public static int ic_group_expand_05 = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public static int ic_expand_00006 = 2130837623;
+			public static int ic_group_expand_06 = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public static int ic_expand_00007 = 2130837624;
+			public static int ic_group_expand_07 = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public static int ic_expand_00008 = 2130837625;
+			public static int ic_group_expand_08 = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public static int ic_expand_00009 = 2130837626;
+			public static int ic_group_expand_09 = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public static int ic_expand_00010 = 2130837627;
+			public static int ic_group_expand_10 = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public static int ic_expand_00011 = 2130837628;
+			public static int ic_group_expand_11 = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public static int ic_expand_00012 = 2130837629;
+			public static int ic_group_expand_12 = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public static int ic_expand_00013 = 2130837630;
+			public static int ic_group_expand_13 = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public static int ic_expand_00014 = 2130837631;
+			public static int ic_group_expand_14 = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public static int ic_expand_00015 = 2130837632;
+			public static int ic_group_expand_15 = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public static int ic_media_pause = 2130837633;
+			public static int ic_media_pause_dark = 2130837633;
 			
 			// aapt resource value: 0x7f020082
-			public static int ic_media_play = 2130837634;
+			public static int ic_media_pause_light = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public static int ic_media_route_disabled_mono_dark = 2130837635;
+			public static int ic_media_play_dark = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public static int ic_media_route_off_mono_dark = 2130837636;
+			public static int ic_media_play_light = 2130837636;
 			
 			// aapt resource value: 0x7f020085
-			public static int ic_media_route_on_0_mono_dark = 2130837637;
+			public static int ic_media_stop_dark = 2130837637;
 			
 			// aapt resource value: 0x7f020086
-			public static int ic_media_route_on_1_mono_dark = 2130837638;
+			public static int ic_media_stop_light = 2130837638;
 			
 			// aapt resource value: 0x7f020087
-			public static int ic_media_route_on_2_mono_dark = 2130837639;
+			public static int ic_mr_button_connected_00_dark = 2130837639;
 			
 			// aapt resource value: 0x7f020088
-			public static int ic_media_route_on_mono_dark = 2130837640;
+			public static int ic_mr_button_connected_00_light = 2130837640;
 			
 			// aapt resource value: 0x7f020089
-			public static int ic_pause_dark = 2130837641;
+			public static int ic_mr_button_connected_01_dark = 2130837641;
 			
 			// aapt resource value: 0x7f02008a
-			public static int ic_pause_light = 2130837642;
+			public static int ic_mr_button_connected_01_light = 2130837642;
 			
 			// aapt resource value: 0x7f02008b
-			public static int ic_play_dark = 2130837643;
+			public static int ic_mr_button_connected_02_dark = 2130837643;
 			
 			// aapt resource value: 0x7f02008c
-			public static int ic_play_light = 2130837644;
+			public static int ic_mr_button_connected_02_light = 2130837644;
 			
 			// aapt resource value: 0x7f02008d
-			public static int ic_speaker_dark = 2130837645;
+			public static int ic_mr_button_connected_03_dark = 2130837645;
 			
 			// aapt resource value: 0x7f02008e
-			public static int ic_speaker_group_dark = 2130837646;
+			public static int ic_mr_button_connected_03_light = 2130837646;
 			
 			// aapt resource value: 0x7f02008f
-			public static int ic_speaker_group_light = 2130837647;
+			public static int ic_mr_button_connected_04_dark = 2130837647;
 			
 			// aapt resource value: 0x7f020090
-			public static int ic_speaker_light = 2130837648;
+			public static int ic_mr_button_connected_04_light = 2130837648;
 			
 			// aapt resource value: 0x7f020091
-			public static int ic_tv_dark = 2130837649;
+			public static int ic_mr_button_connected_05_dark = 2130837649;
 			
 			// aapt resource value: 0x7f020092
-			public static int ic_tv_light = 2130837650;
+			public static int ic_mr_button_connected_05_light = 2130837650;
 			
 			// aapt resource value: 0x7f020093
-			public static int mr_dialog_material_background_dark = 2130837651;
+			public static int ic_mr_button_connected_06_dark = 2130837651;
 			
 			// aapt resource value: 0x7f020094
-			public static int mr_dialog_material_background_light = 2130837652;
+			public static int ic_mr_button_connected_06_light = 2130837652;
 			
 			// aapt resource value: 0x7f020095
-			public static int mr_ic_audiotrack_light = 2130837653;
+			public static int ic_mr_button_connected_07_dark = 2130837653;
 			
 			// aapt resource value: 0x7f020096
-			public static int mr_ic_cast_dark = 2130837654;
+			public static int ic_mr_button_connected_07_light = 2130837654;
 			
 			// aapt resource value: 0x7f020097
-			public static int mr_ic_cast_light = 2130837655;
+			public static int ic_mr_button_connected_08_dark = 2130837655;
 			
 			// aapt resource value: 0x7f020098
-			public static int mr_ic_close_dark = 2130837656;
+			public static int ic_mr_button_connected_08_light = 2130837656;
 			
 			// aapt resource value: 0x7f020099
-			public static int mr_ic_close_light = 2130837657;
+			public static int ic_mr_button_connected_09_dark = 2130837657;
 			
 			// aapt resource value: 0x7f02009a
-			public static int mr_ic_media_route_connecting_mono_dark = 2130837658;
+			public static int ic_mr_button_connected_09_light = 2130837658;
 			
 			// aapt resource value: 0x7f02009b
-			public static int mr_ic_media_route_connecting_mono_light = 2130837659;
+			public static int ic_mr_button_connected_10_dark = 2130837659;
 			
 			// aapt resource value: 0x7f02009c
-			public static int mr_ic_media_route_mono_dark = 2130837660;
+			public static int ic_mr_button_connected_10_light = 2130837660;
 			
 			// aapt resource value: 0x7f02009d
-			public static int mr_ic_media_route_mono_light = 2130837661;
+			public static int ic_mr_button_connected_11_dark = 2130837661;
 			
 			// aapt resource value: 0x7f02009e
-			public static int mr_ic_pause_dark = 2130837662;
+			public static int ic_mr_button_connected_11_light = 2130837662;
 			
 			// aapt resource value: 0x7f02009f
-			public static int mr_ic_pause_light = 2130837663;
+			public static int ic_mr_button_connected_12_dark = 2130837663;
 			
 			// aapt resource value: 0x7f0200a0
-			public static int mr_ic_play_dark = 2130837664;
+			public static int ic_mr_button_connected_12_light = 2130837664;
 			
 			// aapt resource value: 0x7f0200a1
-			public static int mr_ic_play_light = 2130837665;
+			public static int ic_mr_button_connected_13_dark = 2130837665;
 			
 			// aapt resource value: 0x7f0200a2
-			public static int notification_template_icon_bg = 2130837666;
+			public static int ic_mr_button_connected_13_light = 2130837666;
+			
+			// aapt resource value: 0x7f0200a3
+			public static int ic_mr_button_connected_14_dark = 2130837667;
+			
+			// aapt resource value: 0x7f0200a4
+			public static int ic_mr_button_connected_14_light = 2130837668;
+			
+			// aapt resource value: 0x7f0200a5
+			public static int ic_mr_button_connected_15_dark = 2130837669;
+			
+			// aapt resource value: 0x7f0200a6
+			public static int ic_mr_button_connected_15_light = 2130837670;
+			
+			// aapt resource value: 0x7f0200a7
+			public static int ic_mr_button_connected_16_dark = 2130837671;
+			
+			// aapt resource value: 0x7f0200a8
+			public static int ic_mr_button_connected_16_light = 2130837672;
+			
+			// aapt resource value: 0x7f0200a9
+			public static int ic_mr_button_connected_17_dark = 2130837673;
+			
+			// aapt resource value: 0x7f0200aa
+			public static int ic_mr_button_connected_17_light = 2130837674;
+			
+			// aapt resource value: 0x7f0200ab
+			public static int ic_mr_button_connected_18_dark = 2130837675;
+			
+			// aapt resource value: 0x7f0200ac
+			public static int ic_mr_button_connected_18_light = 2130837676;
+			
+			// aapt resource value: 0x7f0200ad
+			public static int ic_mr_button_connected_19_dark = 2130837677;
+			
+			// aapt resource value: 0x7f0200ae
+			public static int ic_mr_button_connected_19_light = 2130837678;
+			
+			// aapt resource value: 0x7f0200af
+			public static int ic_mr_button_connected_20_dark = 2130837679;
+			
+			// aapt resource value: 0x7f0200b0
+			public static int ic_mr_button_connected_20_light = 2130837680;
+			
+			// aapt resource value: 0x7f0200b1
+			public static int ic_mr_button_connected_21_dark = 2130837681;
+			
+			// aapt resource value: 0x7f0200b2
+			public static int ic_mr_button_connected_21_light = 2130837682;
+			
+			// aapt resource value: 0x7f0200b3
+			public static int ic_mr_button_connected_22_dark = 2130837683;
+			
+			// aapt resource value: 0x7f0200b4
+			public static int ic_mr_button_connected_22_light = 2130837684;
+			
+			// aapt resource value: 0x7f0200b5
+			public static int ic_mr_button_connecting_00_dark = 2130837685;
+			
+			// aapt resource value: 0x7f0200b6
+			public static int ic_mr_button_connecting_00_light = 2130837686;
+			
+			// aapt resource value: 0x7f0200b7
+			public static int ic_mr_button_connecting_01_dark = 2130837687;
+			
+			// aapt resource value: 0x7f0200b8
+			public static int ic_mr_button_connecting_01_light = 2130837688;
+			
+			// aapt resource value: 0x7f0200b9
+			public static int ic_mr_button_connecting_02_dark = 2130837689;
+			
+			// aapt resource value: 0x7f0200ba
+			public static int ic_mr_button_connecting_02_light = 2130837690;
+			
+			// aapt resource value: 0x7f0200bb
+			public static int ic_mr_button_connecting_03_dark = 2130837691;
+			
+			// aapt resource value: 0x7f0200bc
+			public static int ic_mr_button_connecting_03_light = 2130837692;
+			
+			// aapt resource value: 0x7f0200bd
+			public static int ic_mr_button_connecting_04_dark = 2130837693;
+			
+			// aapt resource value: 0x7f0200be
+			public static int ic_mr_button_connecting_04_light = 2130837694;
+			
+			// aapt resource value: 0x7f0200bf
+			public static int ic_mr_button_connecting_05_dark = 2130837695;
+			
+			// aapt resource value: 0x7f0200c0
+			public static int ic_mr_button_connecting_05_light = 2130837696;
+			
+			// aapt resource value: 0x7f0200c1
+			public static int ic_mr_button_connecting_06_dark = 2130837697;
+			
+			// aapt resource value: 0x7f0200c2
+			public static int ic_mr_button_connecting_06_light = 2130837698;
+			
+			// aapt resource value: 0x7f0200c3
+			public static int ic_mr_button_connecting_07_dark = 2130837699;
+			
+			// aapt resource value: 0x7f0200c4
+			public static int ic_mr_button_connecting_07_light = 2130837700;
+			
+			// aapt resource value: 0x7f0200c5
+			public static int ic_mr_button_connecting_08_dark = 2130837701;
+			
+			// aapt resource value: 0x7f0200c6
+			public static int ic_mr_button_connecting_08_light = 2130837702;
+			
+			// aapt resource value: 0x7f0200c7
+			public static int ic_mr_button_connecting_09_dark = 2130837703;
+			
+			// aapt resource value: 0x7f0200c8
+			public static int ic_mr_button_connecting_09_light = 2130837704;
+			
+			// aapt resource value: 0x7f0200c9
+			public static int ic_mr_button_connecting_10_dark = 2130837705;
+			
+			// aapt resource value: 0x7f0200ca
+			public static int ic_mr_button_connecting_10_light = 2130837706;
+			
+			// aapt resource value: 0x7f0200cb
+			public static int ic_mr_button_connecting_11_dark = 2130837707;
+			
+			// aapt resource value: 0x7f0200cc
+			public static int ic_mr_button_connecting_11_light = 2130837708;
+			
+			// aapt resource value: 0x7f0200cd
+			public static int ic_mr_button_connecting_12_dark = 2130837709;
+			
+			// aapt resource value: 0x7f0200ce
+			public static int ic_mr_button_connecting_12_light = 2130837710;
+			
+			// aapt resource value: 0x7f0200cf
+			public static int ic_mr_button_connecting_13_dark = 2130837711;
+			
+			// aapt resource value: 0x7f0200d0
+			public static int ic_mr_button_connecting_13_light = 2130837712;
+			
+			// aapt resource value: 0x7f0200d1
+			public static int ic_mr_button_connecting_14_dark = 2130837713;
+			
+			// aapt resource value: 0x7f0200d2
+			public static int ic_mr_button_connecting_14_light = 2130837714;
+			
+			// aapt resource value: 0x7f0200d3
+			public static int ic_mr_button_connecting_15_dark = 2130837715;
+			
+			// aapt resource value: 0x7f0200d4
+			public static int ic_mr_button_connecting_15_light = 2130837716;
+			
+			// aapt resource value: 0x7f0200d5
+			public static int ic_mr_button_connecting_16_dark = 2130837717;
+			
+			// aapt resource value: 0x7f0200d6
+			public static int ic_mr_button_connecting_16_light = 2130837718;
+			
+			// aapt resource value: 0x7f0200d7
+			public static int ic_mr_button_connecting_17_dark = 2130837719;
+			
+			// aapt resource value: 0x7f0200d8
+			public static int ic_mr_button_connecting_17_light = 2130837720;
+			
+			// aapt resource value: 0x7f0200d9
+			public static int ic_mr_button_connecting_18_dark = 2130837721;
+			
+			// aapt resource value: 0x7f0200da
+			public static int ic_mr_button_connecting_18_light = 2130837722;
+			
+			// aapt resource value: 0x7f0200db
+			public static int ic_mr_button_connecting_19_dark = 2130837723;
+			
+			// aapt resource value: 0x7f0200dc
+			public static int ic_mr_button_connecting_19_light = 2130837724;
+			
+			// aapt resource value: 0x7f0200dd
+			public static int ic_mr_button_connecting_20_dark = 2130837725;
+			
+			// aapt resource value: 0x7f0200de
+			public static int ic_mr_button_connecting_20_light = 2130837726;
+			
+			// aapt resource value: 0x7f0200df
+			public static int ic_mr_button_connecting_21_dark = 2130837727;
+			
+			// aapt resource value: 0x7f0200e0
+			public static int ic_mr_button_connecting_21_light = 2130837728;
+			
+			// aapt resource value: 0x7f0200e1
+			public static int ic_mr_button_connecting_22_dark = 2130837729;
+			
+			// aapt resource value: 0x7f0200e2
+			public static int ic_mr_button_connecting_22_light = 2130837730;
+			
+			// aapt resource value: 0x7f0200e3
+			public static int ic_mr_button_disabled_dark = 2130837731;
+			
+			// aapt resource value: 0x7f0200e4
+			public static int ic_mr_button_disabled_light = 2130837732;
+			
+			// aapt resource value: 0x7f0200e5
+			public static int ic_mr_button_disconnected_dark = 2130837733;
+			
+			// aapt resource value: 0x7f0200e6
+			public static int ic_mr_button_disconnected_light = 2130837734;
+			
+			// aapt resource value: 0x7f0200e7
+			public static int ic_mr_button_grey = 2130837735;
+			
+			// aapt resource value: 0x7f0200e8
+			public static int ic_vol_type_speaker_dark = 2130837736;
+			
+			// aapt resource value: 0x7f0200e9
+			public static int ic_vol_type_speaker_group_dark = 2130837737;
+			
+			// aapt resource value: 0x7f0200ea
+			public static int ic_vol_type_speaker_group_light = 2130837738;
+			
+			// aapt resource value: 0x7f0200eb
+			public static int ic_vol_type_speaker_light = 2130837739;
+			
+			// aapt resource value: 0x7f0200ec
+			public static int ic_vol_type_tv_dark = 2130837740;
+			
+			// aapt resource value: 0x7f0200ed
+			public static int ic_vol_type_tv_light = 2130837741;
+			
+			// aapt resource value: 0x7f0200ee
+			public static int mr_button_connected_dark = 2130837742;
+			
+			// aapt resource value: 0x7f0200ef
+			public static int mr_button_connected_light = 2130837743;
+			
+			// aapt resource value: 0x7f0200f0
+			public static int mr_button_connecting_dark = 2130837744;
+			
+			// aapt resource value: 0x7f0200f1
+			public static int mr_button_connecting_light = 2130837745;
+			
+			// aapt resource value: 0x7f0200f2
+			public static int mr_button_dark = 2130837746;
+			
+			// aapt resource value: 0x7f0200f3
+			public static int mr_button_light = 2130837747;
+			
+			// aapt resource value: 0x7f0200f4
+			public static int mr_dialog_close_dark = 2130837748;
+			
+			// aapt resource value: 0x7f0200f5
+			public static int mr_dialog_close_light = 2130837749;
+			
+			// aapt resource value: 0x7f0200f6
+			public static int mr_dialog_material_background_dark = 2130837750;
+			
+			// aapt resource value: 0x7f0200f7
+			public static int mr_dialog_material_background_light = 2130837751;
+			
+			// aapt resource value: 0x7f0200f8
+			public static int mr_group_collapse = 2130837752;
+			
+			// aapt resource value: 0x7f0200f9
+			public static int mr_group_expand = 2130837753;
+			
+			// aapt resource value: 0x7f0200fa
+			public static int mr_media_pause_dark = 2130837754;
+			
+			// aapt resource value: 0x7f0200fb
+			public static int mr_media_pause_light = 2130837755;
+			
+			// aapt resource value: 0x7f0200fc
+			public static int mr_media_play_dark = 2130837756;
+			
+			// aapt resource value: 0x7f0200fd
+			public static int mr_media_play_light = 2130837757;
+			
+			// aapt resource value: 0x7f0200fe
+			public static int mr_media_stop_dark = 2130837758;
+			
+			// aapt resource value: 0x7f0200ff
+			public static int mr_media_stop_light = 2130837759;
+			
+			// aapt resource value: 0x7f020100
+			public static int mr_vol_type_audiotrack_dark = 2130837760;
+			
+			// aapt resource value: 0x7f020101
+			public static int mr_vol_type_audiotrack_light = 2130837761;
+			
+			// aapt resource value: 0x7f020102
+			public static int navigation_empty_icon = 2130837762;
+			
+			// aapt resource value: 0x7f020103
+			public static int notification_action_background = 2130837763;
+			
+			// aapt resource value: 0x7f020104
+			public static int notification_bg = 2130837764;
+			
+			// aapt resource value: 0x7f020105
+			public static int notification_bg_low = 2130837765;
+			
+			// aapt resource value: 0x7f020106
+			public static int notification_bg_low_normal = 2130837766;
+			
+			// aapt resource value: 0x7f020107
+			public static int notification_bg_low_pressed = 2130837767;
+			
+			// aapt resource value: 0x7f020108
+			public static int notification_bg_normal = 2130837768;
+			
+			// aapt resource value: 0x7f020109
+			public static int notification_bg_normal_pressed = 2130837769;
+			
+			// aapt resource value: 0x7f02010a
+			public static int notification_icon_background = 2130837770;
+			
+			// aapt resource value: 0x7f02010d
+			public static int notification_template_icon_bg = 2130837773;
+			
+			// aapt resource value: 0x7f02010e
+			public static int notification_template_icon_low_bg = 2130837774;
+			
+			// aapt resource value: 0x7f02010b
+			public static int notification_tile_bg = 2130837771;
+			
+			// aapt resource value: 0x7f02010c
+			public static int notify_panel_notification_icon_bg = 2130837772;
 			
 			static Drawable()
 			{
@@ -2250,461 +2806,539 @@ namespace FAB.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0b008b
-			public static int action0 = 2131427467;
+			// aapt resource value: 0x7f08009c
+			public static int action0 = 2131230876;
 			
-			// aapt resource value: 0x7f0b005a
-			public static int action_bar = 2131427418;
+			// aapt resource value: 0x7f080064
+			public static int action_bar = 2131230820;
 			
-			// aapt resource value: 0x7f0b0001
-			public static int action_bar_activity_content = 2131427329;
+			// aapt resource value: 0x7f080001
+			public static int action_bar_activity_content = 2131230721;
 			
-			// aapt resource value: 0x7f0b0059
-			public static int action_bar_container = 2131427417;
+			// aapt resource value: 0x7f080063
+			public static int action_bar_container = 2131230819;
 			
-			// aapt resource value: 0x7f0b0055
-			public static int action_bar_root = 2131427413;
+			// aapt resource value: 0x7f08005f
+			public static int action_bar_root = 2131230815;
 			
-			// aapt resource value: 0x7f0b0002
-			public static int action_bar_spinner = 2131427330;
+			// aapt resource value: 0x7f080002
+			public static int action_bar_spinner = 2131230722;
 			
-			// aapt resource value: 0x7f0b003b
-			public static int action_bar_subtitle = 2131427387;
+			// aapt resource value: 0x7f080042
+			public static int action_bar_subtitle = 2131230786;
 			
-			// aapt resource value: 0x7f0b003a
-			public static int action_bar_title = 2131427386;
+			// aapt resource value: 0x7f080041
+			public static int action_bar_title = 2131230785;
 			
-			// aapt resource value: 0x7f0b005b
-			public static int action_context_bar = 2131427419;
+			// aapt resource value: 0x7f080099
+			public static int action_container = 2131230873;
 			
-			// aapt resource value: 0x7f0b008f
-			public static int action_divider = 2131427471;
+			// aapt resource value: 0x7f080065
+			public static int action_context_bar = 2131230821;
 			
-			// aapt resource value: 0x7f0b0003
-			public static int action_menu_divider = 2131427331;
+			// aapt resource value: 0x7f0800a0
+			public static int action_divider = 2131230880;
 			
-			// aapt resource value: 0x7f0b0004
-			public static int action_menu_presenter = 2131427332;
+			// aapt resource value: 0x7f08009a
+			public static int action_image = 2131230874;
 			
-			// aapt resource value: 0x7f0b0057
-			public static int action_mode_bar = 2131427415;
+			// aapt resource value: 0x7f080003
+			public static int action_menu_divider = 2131230723;
 			
-			// aapt resource value: 0x7f0b0056
-			public static int action_mode_bar_stub = 2131427414;
+			// aapt resource value: 0x7f080004
+			public static int action_menu_presenter = 2131230724;
 			
-			// aapt resource value: 0x7f0b003c
-			public static int action_mode_close_button = 2131427388;
+			// aapt resource value: 0x7f080061
+			public static int action_mode_bar = 2131230817;
 			
-			// aapt resource value: 0x7f0b003d
-			public static int activity_chooser_view_content = 2131427389;
+			// aapt resource value: 0x7f080060
+			public static int action_mode_bar_stub = 2131230816;
 			
-			// aapt resource value: 0x7f0b0049
-			public static int alertTitle = 2131427401;
+			// aapt resource value: 0x7f080043
+			public static int action_mode_close_button = 2131230787;
 			
-			// aapt resource value: 0x7f0b0035
-			public static int always = 2131427381;
+			// aapt resource value: 0x7f08009b
+			public static int action_text = 2131230875;
 			
-			// aapt resource value: 0x7f0b0033
-			public static int beginning = 2131427379;
+			// aapt resource value: 0x7f0800a9
+			public static int actions = 2131230889;
 			
-			// aapt resource value: 0x7f0b0013
-			public static int bottom = 2131427347;
+			// aapt resource value: 0x7f080044
+			public static int activity_chooser_view_content = 2131230788;
 			
-			// aapt resource value: 0x7f0b0044
-			public static int buttonPanel = 2131427396;
+			// aapt resource value: 0x7f080019
+			public static int add = 2131230745;
 			
-			// aapt resource value: 0x7f0b008c
-			public static int cancel_action = 2131427468;
+			// aapt resource value: 0x7f080058
+			public static int alertTitle = 2131230808;
 			
-			// aapt resource value: 0x7f0b0014
-			public static int center = 2131427348;
+			// aapt resource value: 0x7f08003d
+			public static int all = 2131230781;
 			
-			// aapt resource value: 0x7f0b0015
-			public static int center_horizontal = 2131427349;
+			// aapt resource value: 0x7f080023
+			public static int always = 2131230755;
 			
-			// aapt resource value: 0x7f0b0016
-			public static int center_vertical = 2131427350;
+			// aapt resource value: 0x7f08002f
+			public static int auto = 2131230767;
 			
-			// aapt resource value: 0x7f0b0052
-			public static int checkbox = 2131427410;
+			// aapt resource value: 0x7f080020
+			public static int beginning = 2131230752;
 			
-			// aapt resource value: 0x7f0b0092
-			public static int chronometer = 2131427474;
+			// aapt resource value: 0x7f080028
+			public static int bottom = 2131230760;
 			
-			// aapt resource value: 0x7f0b001d
-			public static int clip_horizontal = 2131427357;
+			// aapt resource value: 0x7f08004b
+			public static int buttonPanel = 2131230795;
 			
-			// aapt resource value: 0x7f0b001e
-			public static int clip_vertical = 2131427358;
+			// aapt resource value: 0x7f08009d
+			public static int cancel_action = 2131230877;
 			
-			// aapt resource value: 0x7f0b0036
-			public static int collapseActionView = 2131427382;
+			// aapt resource value: 0x7f080030
+			public static int center = 2131230768;
 			
-			// aapt resource value: 0x7f0b004a
-			public static int contentPanel = 2131427402;
+			// aapt resource value: 0x7f080031
+			public static int center_horizontal = 2131230769;
 			
-			// aapt resource value: 0x7f0b0050
-			public static int custom = 2131427408;
+			// aapt resource value: 0x7f080032
+			public static int center_vertical = 2131230770;
 			
-			// aapt resource value: 0x7f0b004f
-			public static int customPanel = 2131427407;
+			// aapt resource value: 0x7f08005b
+			public static int checkbox = 2131230811;
 			
-			// aapt resource value: 0x7f0b0058
-			public static int decor_content_parent = 2131427416;
+			// aapt resource value: 0x7f0800a5
+			public static int chronometer = 2131230885;
 			
-			// aapt resource value: 0x7f0b0040
-			public static int default_activity_button = 2131427392;
+			// aapt resource value: 0x7f080039
+			public static int clip_horizontal = 2131230777;
 			
-			// aapt resource value: 0x7f0b006a
-			public static int design_bottom_sheet = 2131427434;
+			// aapt resource value: 0x7f08003a
+			public static int clip_vertical = 2131230778;
 			
-			// aapt resource value: 0x7f0b0071
-			public static int design_menu_item_action_area = 2131427441;
+			// aapt resource value: 0x7f080024
+			public static int collapseActionView = 2131230756;
 			
-			// aapt resource value: 0x7f0b0070
-			public static int design_menu_item_action_area_stub = 2131427440;
+			// aapt resource value: 0x7f08004e
+			public static int contentPanel = 2131230798;
 			
-			// aapt resource value: 0x7f0b006f
-			public static int design_menu_item_text = 2131427439;
+			// aapt resource value: 0x7f080055
+			public static int custom = 2131230805;
 			
-			// aapt resource value: 0x7f0b006e
-			public static int design_navigation_view = 2131427438;
+			// aapt resource value: 0x7f080054
+			public static int customPanel = 2131230804;
 			
-			// aapt resource value: 0x7f0b0027
-			public static int disableHome = 2131427367;
+			// aapt resource value: 0x7f080062
+			public static int decor_content_parent = 2131230818;
 			
-			// aapt resource value: 0x7f0b005c
-			public static int edit_query = 2131427420;
+			// aapt resource value: 0x7f080047
+			public static int default_activity_button = 2131230791;
 			
-			// aapt resource value: 0x7f0b0017
-			public static int end = 2131427351;
+			// aapt resource value: 0x7f080076
+			public static int design_bottom_sheet = 2131230838;
 			
-			// aapt resource value: 0x7f0b0097
-			public static int end_padder = 2131427479;
+			// aapt resource value: 0x7f08007d
+			public static int design_menu_item_action_area = 2131230845;
 			
-			// aapt resource value: 0x7f0b000b
-			public static int enterAlways = 2131427339;
+			// aapt resource value: 0x7f08007c
+			public static int design_menu_item_action_area_stub = 2131230844;
 			
-			// aapt resource value: 0x7f0b000c
-			public static int enterAlwaysCollapsed = 2131427340;
+			// aapt resource value: 0x7f08007b
+			public static int design_menu_item_text = 2131230843;
 			
-			// aapt resource value: 0x7f0b000d
-			public static int exitUntilCollapsed = 2131427341;
+			// aapt resource value: 0x7f08007a
+			public static int design_navigation_view = 2131230842;
 			
-			// aapt resource value: 0x7f0b003e
-			public static int expand_activities_button = 2131427390;
+			// aapt resource value: 0x7f080012
+			public static int disableHome = 2131230738;
 			
-			// aapt resource value: 0x7f0b0051
-			public static int expanded_menu = 2131427409;
+			// aapt resource value: 0x7f080066
+			public static int edit_query = 2131230822;
 			
-			// aapt resource value: 0x7f0b001f
-			public static int fill = 2131427359;
+			// aapt resource value: 0x7f080021
+			public static int end = 2131230753;
 			
-			// aapt resource value: 0x7f0b0020
-			public static int fill_horizontal = 2131427360;
+			// aapt resource value: 0x7f0800af
+			public static int end_padder = 2131230895;
 			
-			// aapt resource value: 0x7f0b0018
-			public static int fill_vertical = 2131427352;
+			// aapt resource value: 0x7f08002a
+			public static int enterAlways = 2131230762;
 			
-			// aapt resource value: 0x7f0b0023
-			public static int @fixed = 2131427363;
+			// aapt resource value: 0x7f08002b
+			public static int enterAlwaysCollapsed = 2131230763;
 			
-			// aapt resource value: 0x7f0b0005
-			public static int home = 2131427333;
+			// aapt resource value: 0x7f08002c
+			public static int exitUntilCollapsed = 2131230764;
 			
-			// aapt resource value: 0x7f0b0028
-			public static int homeAsUp = 2131427368;
+			// aapt resource value: 0x7f080045
+			public static int expand_activities_button = 2131230789;
 			
-			// aapt resource value: 0x7f0b0042
-			public static int icon = 2131427394;
+			// aapt resource value: 0x7f08005a
+			public static int expanded_menu = 2131230810;
 			
-			// aapt resource value: 0x7f0b0037
-			public static int ifRoom = 2131427383;
+			// aapt resource value: 0x7f08003b
+			public static int fill = 2131230779;
 			
-			// aapt resource value: 0x7f0b003f
-			public static int image = 2131427391;
+			// aapt resource value: 0x7f08003c
+			public static int fill_horizontal = 2131230780;
 			
-			// aapt resource value: 0x7f0b0096
-			public static int info = 2131427478;
+			// aapt resource value: 0x7f080033
+			public static int fill_vertical = 2131230771;
 			
-			// aapt resource value: 0x7f0b000a
-			public static int item_touch_helper_previous_elevation = 2131427338;
+			// aapt resource value: 0x7f08003f
+			public static int @fixed = 2131230783;
 			
-			// aapt resource value: 0x7f0b0019
-			public static int left = 2131427353;
+			// aapt resource value: 0x7f080005
+			public static int home = 2131230725;
 			
-			// aapt resource value: 0x7f0b0090
-			public static int line1 = 2131427472;
+			// aapt resource value: 0x7f080013
+			public static int homeAsUp = 2131230739;
 			
-			// aapt resource value: 0x7f0b0094
-			public static int line3 = 2131427476;
+			// aapt resource value: 0x7f080049
+			public static int icon = 2131230793;
 			
-			// aapt resource value: 0x7f0b0025
-			public static int listMode = 2131427365;
+			// aapt resource value: 0x7f0800aa
+			public static int icon_group = 2131230890;
 			
-			// aapt resource value: 0x7f0b0041
-			public static int list_item = 2131427393;
+			// aapt resource value: 0x7f080025
+			public static int ifRoom = 2131230757;
 			
-			// aapt resource value: 0x7f0b008e
-			public static int media_actions = 2131427470;
+			// aapt resource value: 0x7f080046
+			public static int image = 2131230790;
 			
-			// aapt resource value: 0x7f0b0034
-			public static int middle = 2131427380;
+			// aapt resource value: 0x7f0800a6
+			public static int info = 2131230886;
 			
-			// aapt resource value: 0x7f0b0021
-			public static int mini = 2131427361;
+			// aapt resource value: 0x7f080000
+			public static int item_touch_helper_previous_elevation = 2131230720;
 			
-			// aapt resource value: 0x7f0b007d
-			public static int mr_art = 2131427453;
+			// aapt resource value: 0x7f080074
+			public static int largeLabel = 2131230836;
 			
-			// aapt resource value: 0x7f0b0072
-			public static int mr_chooser_list = 2131427442;
+			// aapt resource value: 0x7f080034
+			public static int left = 2131230772;
 			
-			// aapt resource value: 0x7f0b0075
-			public static int mr_chooser_route_desc = 2131427445;
+			// aapt resource value: 0x7f0800ab
+			public static int line1 = 2131230891;
 			
-			// aapt resource value: 0x7f0b0073
-			public static int mr_chooser_route_icon = 2131427443;
+			// aapt resource value: 0x7f0800ad
+			public static int line3 = 2131230893;
 			
-			// aapt resource value: 0x7f0b0074
-			public static int mr_chooser_route_name = 2131427444;
+			// aapt resource value: 0x7f08000f
+			public static int listMode = 2131230735;
 			
-			// aapt resource value: 0x7f0b007a
-			public static int mr_close = 2131427450;
+			// aapt resource value: 0x7f080048
+			public static int list_item = 2131230792;
 			
-			// aapt resource value: 0x7f0b0080
-			public static int mr_control_divider = 2131427456;
+			// aapt resource value: 0x7f0800b1
+			public static int masked = 2131230897;
 			
-			// aapt resource value: 0x7f0b0086
-			public static int mr_control_play_pause = 2131427462;
+			// aapt resource value: 0x7f08009f
+			public static int media_actions = 2131230879;
 			
-			// aapt resource value: 0x7f0b0089
-			public static int mr_control_subtitle = 2131427465;
+			// aapt resource value: 0x7f080022
+			public static int middle = 2131230754;
 			
-			// aapt resource value: 0x7f0b0088
-			public static int mr_control_title = 2131427464;
+			// aapt resource value: 0x7f08003e
+			public static int mini = 2131230782;
 			
-			// aapt resource value: 0x7f0b0087
-			public static int mr_control_title_container = 2131427463;
+			// aapt resource value: 0x7f08008b
+			public static int mr_art = 2131230859;
 			
-			// aapt resource value: 0x7f0b007b
-			public static int mr_custom_control = 2131427451;
+			// aapt resource value: 0x7f080080
+			public static int mr_chooser_list = 2131230848;
 			
-			// aapt resource value: 0x7f0b007c
-			public static int mr_default_control = 2131427452;
+			// aapt resource value: 0x7f080083
+			public static int mr_chooser_route_desc = 2131230851;
 			
-			// aapt resource value: 0x7f0b0077
-			public static int mr_dialog_area = 2131427447;
+			// aapt resource value: 0x7f080081
+			public static int mr_chooser_route_icon = 2131230849;
 			
-			// aapt resource value: 0x7f0b0076
-			public static int mr_expandable_area = 2131427446;
+			// aapt resource value: 0x7f080082
+			public static int mr_chooser_route_name = 2131230850;
 			
-			// aapt resource value: 0x7f0b008a
-			public static int mr_group_expand_collapse = 2131427466;
+			// aapt resource value: 0x7f08007f
+			public static int mr_chooser_title = 2131230847;
 			
-			// aapt resource value: 0x7f0b007e
-			public static int mr_media_main_control = 2131427454;
+			// aapt resource value: 0x7f080088
+			public static int mr_close = 2131230856;
 			
-			// aapt resource value: 0x7f0b0079
-			public static int mr_name = 2131427449;
+			// aapt resource value: 0x7f08008e
+			public static int mr_control_divider = 2131230862;
 			
-			// aapt resource value: 0x7f0b007f
-			public static int mr_playback_control = 2131427455;
+			// aapt resource value: 0x7f080094
+			public static int mr_control_playback_ctrl = 2131230868;
 			
-			// aapt resource value: 0x7f0b0078
-			public static int mr_title_bar = 2131427448;
+			// aapt resource value: 0x7f080097
+			public static int mr_control_subtitle = 2131230871;
 			
-			// aapt resource value: 0x7f0b0081
-			public static int mr_volume_control = 2131427457;
+			// aapt resource value: 0x7f080096
+			public static int mr_control_title = 2131230870;
 			
-			// aapt resource value: 0x7f0b0082
-			public static int mr_volume_group_list = 2131427458;
+			// aapt resource value: 0x7f080095
+			public static int mr_control_title_container = 2131230869;
 			
-			// aapt resource value: 0x7f0b0084
-			public static int mr_volume_item_icon = 2131427460;
+			// aapt resource value: 0x7f080089
+			public static int mr_custom_control = 2131230857;
 			
-			// aapt resource value: 0x7f0b0085
-			public static int mr_volume_slider = 2131427461;
+			// aapt resource value: 0x7f08008a
+			public static int mr_default_control = 2131230858;
 			
-			// aapt resource value: 0x7f0b002e
-			public static int multiply = 2131427374;
+			// aapt resource value: 0x7f080085
+			public static int mr_dialog_area = 2131230853;
 			
-			// aapt resource value: 0x7f0b006d
-			public static int navigation_header_container = 2131427437;
+			// aapt resource value: 0x7f080084
+			public static int mr_expandable_area = 2131230852;
 			
-			// aapt resource value: 0x7f0b0038
-			public static int never = 2131427384;
+			// aapt resource value: 0x7f080098
+			public static int mr_group_expand_collapse = 2131230872;
 			
-			// aapt resource value: 0x7f0b0010
-			public static int none = 2131427344;
+			// aapt resource value: 0x7f08008c
+			public static int mr_media_main_control = 2131230860;
 			
-			// aapt resource value: 0x7f0b0022
-			public static int normal = 2131427362;
+			// aapt resource value: 0x7f080087
+			public static int mr_name = 2131230855;
 			
-			// aapt resource value: 0x7f0b0011
-			public static int parallax = 2131427345;
+			// aapt resource value: 0x7f08008d
+			public static int mr_playback_control = 2131230861;
 			
-			// aapt resource value: 0x7f0b0046
-			public static int parentPanel = 2131427398;
+			// aapt resource value: 0x7f080086
+			public static int mr_title_bar = 2131230854;
 			
-			// aapt resource value: 0x7f0b0012
-			public static int pin = 2131427346;
+			// aapt resource value: 0x7f08008f
+			public static int mr_volume_control = 2131230863;
 			
-			// aapt resource value: 0x7f0b0006
-			public static int progress_circular = 2131427334;
+			// aapt resource value: 0x7f080090
+			public static int mr_volume_group_list = 2131230864;
 			
-			// aapt resource value: 0x7f0b0007
-			public static int progress_horizontal = 2131427335;
+			// aapt resource value: 0x7f080092
+			public static int mr_volume_item_icon = 2131230866;
 			
-			// aapt resource value: 0x7f0b0054
-			public static int radio = 2131427412;
+			// aapt resource value: 0x7f080093
+			public static int mr_volume_slider = 2131230867;
 			
-			// aapt resource value: 0x7f0b001a
-			public static int right = 2131427354;
+			// aapt resource value: 0x7f08001a
+			public static int multiply = 2131230746;
 			
-			// aapt resource value: 0x7f0b002f
-			public static int screen = 2131427375;
+			// aapt resource value: 0x7f080079
+			public static int navigation_header_container = 2131230841;
 			
-			// aapt resource value: 0x7f0b000e
-			public static int scroll = 2131427342;
+			// aapt resource value: 0x7f080026
+			public static int never = 2131230758;
 			
-			// aapt resource value: 0x7f0b004e
-			public static int scrollIndicatorDown = 2131427406;
+			// aapt resource value: 0x7f080014
+			public static int none = 2131230740;
 			
-			// aapt resource value: 0x7f0b004b
-			public static int scrollIndicatorUp = 2131427403;
+			// aapt resource value: 0x7f080010
+			public static int normal = 2131230736;
 			
-			// aapt resource value: 0x7f0b004c
-			public static int scrollView = 2131427404;
+			// aapt resource value: 0x7f0800a8
+			public static int notification_background = 2131230888;
 			
-			// aapt resource value: 0x7f0b0024
-			public static int scrollable = 2131427364;
+			// aapt resource value: 0x7f0800a2
+			public static int notification_main_column = 2131230882;
 			
-			// aapt resource value: 0x7f0b005e
-			public static int search_badge = 2131427422;
+			// aapt resource value: 0x7f0800a1
+			public static int notification_main_column_container = 2131230881;
 			
-			// aapt resource value: 0x7f0b005d
-			public static int search_bar = 2131427421;
+			// aapt resource value: 0x7f080037
+			public static int parallax = 2131230775;
 			
-			// aapt resource value: 0x7f0b005f
-			public static int search_button = 2131427423;
+			// aapt resource value: 0x7f08004d
+			public static int parentPanel = 2131230797;
 			
-			// aapt resource value: 0x7f0b0064
-			public static int search_close_btn = 2131427428;
+			// aapt resource value: 0x7f080038
+			public static int pin = 2131230776;
 			
-			// aapt resource value: 0x7f0b0060
-			public static int search_edit_frame = 2131427424;
+			// aapt resource value: 0x7f080006
+			public static int progress_circular = 2131230726;
 			
-			// aapt resource value: 0x7f0b0066
-			public static int search_go_btn = 2131427430;
+			// aapt resource value: 0x7f080007
+			public static int progress_horizontal = 2131230727;
 			
-			// aapt resource value: 0x7f0b0061
-			public static int search_mag_icon = 2131427425;
+			// aapt resource value: 0x7f08005d
+			public static int radio = 2131230813;
 			
-			// aapt resource value: 0x7f0b0062
-			public static int search_plate = 2131427426;
+			// aapt resource value: 0x7f080035
+			public static int right = 2131230773;
 			
-			// aapt resource value: 0x7f0b0063
-			public static int search_src_text = 2131427427;
+			// aapt resource value: 0x7f0800a7
+			public static int right_icon = 2131230887;
 			
-			// aapt resource value: 0x7f0b0067
-			public static int search_voice_btn = 2131427431;
+			// aapt resource value: 0x7f0800a3
+			public static int right_side = 2131230883;
 			
-			// aapt resource value: 0x7f0b0068
-			public static int select_dialog_listview = 2131427432;
+			// aapt resource value: 0x7f08001b
+			public static int screen = 2131230747;
 			
-			// aapt resource value: 0x7f0b0053
-			public static int shortcut = 2131427411;
+			// aapt resource value: 0x7f08002d
+			public static int scroll = 2131230765;
 			
-			// aapt resource value: 0x7f0b0029
-			public static int showCustom = 2131427369;
+			// aapt resource value: 0x7f080053
+			public static int scrollIndicatorDown = 2131230803;
 			
-			// aapt resource value: 0x7f0b002a
-			public static int showHome = 2131427370;
+			// aapt resource value: 0x7f08004f
+			public static int scrollIndicatorUp = 2131230799;
 			
-			// aapt resource value: 0x7f0b002b
-			public static int showTitle = 2131427371;
+			// aapt resource value: 0x7f080050
+			public static int scrollView = 2131230800;
 			
-			// aapt resource value: 0x7f0b006c
-			public static int snackbar_action = 2131427436;
+			// aapt resource value: 0x7f080040
+			public static int scrollable = 2131230784;
 			
-			// aapt resource value: 0x7f0b006b
-			public static int snackbar_text = 2131427435;
+			// aapt resource value: 0x7f080068
+			public static int search_badge = 2131230824;
 			
-			// aapt resource value: 0x7f0b000f
-			public static int snap = 2131427343;
+			// aapt resource value: 0x7f080067
+			public static int search_bar = 2131230823;
 			
-			// aapt resource value: 0x7f0b0045
-			public static int spacer = 2131427397;
+			// aapt resource value: 0x7f080069
+			public static int search_button = 2131230825;
 			
-			// aapt resource value: 0x7f0b0008
-			public static int split_action_bar = 2131427336;
+			// aapt resource value: 0x7f08006e
+			public static int search_close_btn = 2131230830;
 			
-			// aapt resource value: 0x7f0b0030
-			public static int src_atop = 2131427376;
+			// aapt resource value: 0x7f08006a
+			public static int search_edit_frame = 2131230826;
 			
-			// aapt resource value: 0x7f0b0031
-			public static int src_in = 2131427377;
+			// aapt resource value: 0x7f080070
+			public static int search_go_btn = 2131230832;
 			
-			// aapt resource value: 0x7f0b0032
-			public static int src_over = 2131427378;
+			// aapt resource value: 0x7f08006b
+			public static int search_mag_icon = 2131230827;
 			
-			// aapt resource value: 0x7f0b001b
-			public static int start = 2131427355;
+			// aapt resource value: 0x7f08006c
+			public static int search_plate = 2131230828;
 			
-			// aapt resource value: 0x7f0b008d
-			public static int status_bar_latest_event_content = 2131427469;
+			// aapt resource value: 0x7f08006d
+			public static int search_src_text = 2131230829;
 			
-			// aapt resource value: 0x7f0b0065
-			public static int submit_area = 2131427429;
+			// aapt resource value: 0x7f080071
+			public static int search_voice_btn = 2131230833;
 			
-			// aapt resource value: 0x7f0b0026
-			public static int tabMode = 2131427366;
+			// aapt resource value: 0x7f080072
+			public static int select_dialog_listview = 2131230834;
 			
-			// aapt resource value: 0x7f0b0095
-			public static int text = 2131427477;
+			// aapt resource value: 0x7f08005c
+			public static int shortcut = 2131230812;
 			
-			// aapt resource value: 0x7f0b0093
-			public static int text2 = 2131427475;
+			// aapt resource value: 0x7f080015
+			public static int showCustom = 2131230741;
 			
-			// aapt resource value: 0x7f0b004d
-			public static int textSpacerNoButtons = 2131427405;
+			// aapt resource value: 0x7f080016
+			public static int showHome = 2131230742;
 			
-			// aapt resource value: 0x7f0b0091
-			public static int time = 2131427473;
+			// aapt resource value: 0x7f080017
+			public static int showTitle = 2131230743;
 			
-			// aapt resource value: 0x7f0b0043
-			public static int title = 2131427395;
+			// aapt resource value: 0x7f080073
+			public static int smallLabel = 2131230835;
 			
-			// aapt resource value: 0x7f0b0048
-			public static int title_template = 2131427400;
+			// aapt resource value: 0x7f080078
+			public static int snackbar_action = 2131230840;
 			
-			// aapt resource value: 0x7f0b001c
-			public static int top = 2131427356;
+			// aapt resource value: 0x7f080077
+			public static int snackbar_text = 2131230839;
 			
-			// aapt resource value: 0x7f0b0047
-			public static int topPanel = 2131427399;
+			// aapt resource value: 0x7f08002e
+			public static int snap = 2131230766;
 			
-			// aapt resource value: 0x7f0b0069
-			public static int touch_outside = 2131427433;
+			// aapt resource value: 0x7f08004c
+			public static int spacer = 2131230796;
 			
-			// aapt resource value: 0x7f0b0009
-			public static int up = 2131427337;
+			// aapt resource value: 0x7f080008
+			public static int split_action_bar = 2131230728;
 			
-			// aapt resource value: 0x7f0b002c
-			public static int useLogo = 2131427372;
+			// aapt resource value: 0x7f08001c
+			public static int src_atop = 2131230748;
 			
-			// aapt resource value: 0x7f0b0000
-			public static int view_offset_helper = 2131427328;
+			// aapt resource value: 0x7f08001d
+			public static int src_in = 2131230749;
 			
-			// aapt resource value: 0x7f0b0083
-			public static int volume_item_container = 2131427459;
+			// aapt resource value: 0x7f08001e
+			public static int src_over = 2131230750;
 			
-			// aapt resource value: 0x7f0b0039
-			public static int withText = 2131427385;
+			// aapt resource value: 0x7f080036
+			public static int start = 2131230774;
 			
-			// aapt resource value: 0x7f0b002d
-			public static int wrap_content = 2131427373;
+			// aapt resource value: 0x7f08009e
+			public static int status_bar_latest_event_content = 2131230878;
+			
+			// aapt resource value: 0x7f08005e
+			public static int submenuarrow = 2131230814;
+			
+			// aapt resource value: 0x7f08006f
+			public static int submit_area = 2131230831;
+			
+			// aapt resource value: 0x7f080011
+			public static int tabMode = 2131230737;
+			
+			// aapt resource value: 0x7f0800ae
+			public static int text = 2131230894;
+			
+			// aapt resource value: 0x7f0800ac
+			public static int text2 = 2131230892;
+			
+			// aapt resource value: 0x7f080052
+			public static int textSpacerNoButtons = 2131230802;
+			
+			// aapt resource value: 0x7f080051
+			public static int textSpacerNoTitle = 2131230801;
+			
+			// aapt resource value: 0x7f08007e
+			public static int text_input_password_toggle = 2131230846;
+			
+			// aapt resource value: 0x7f08000c
+			public static int textinput_counter = 2131230732;
+			
+			// aapt resource value: 0x7f08000d
+			public static int textinput_error = 2131230733;
+			
+			// aapt resource value: 0x7f0800a4
+			public static int time = 2131230884;
+			
+			// aapt resource value: 0x7f08004a
+			public static int title = 2131230794;
+			
+			// aapt resource value: 0x7f080059
+			public static int titleDividerNoCustom = 2131230809;
+			
+			// aapt resource value: 0x7f080057
+			public static int title_template = 2131230807;
+			
+			// aapt resource value: 0x7f080029
+			public static int top = 2131230761;
+			
+			// aapt resource value: 0x7f080056
+			public static int topPanel = 2131230806;
+			
+			// aapt resource value: 0x7f080075
+			public static int touch_outside = 2131230837;
+			
+			// aapt resource value: 0x7f08000a
+			public static int transition_current_scene = 2131230730;
+			
+			// aapt resource value: 0x7f08000b
+			public static int transition_scene_layoutid_cache = 2131230731;
+			
+			// aapt resource value: 0x7f080009
+			public static int up = 2131230729;
+			
+			// aapt resource value: 0x7f080018
+			public static int useLogo = 2131230744;
+			
+			// aapt resource value: 0x7f08000e
+			public static int view_offset_helper = 2131230734;
+			
+			// aapt resource value: 0x7f0800b0
+			public static int visible = 2131230896;
+			
+			// aapt resource value: 0x7f080091
+			public static int volume_item_container = 2131230865;
+			
+			// aapt resource value: 0x7f080027
+			public static int withText = 2131230759;
+			
+			// aapt resource value: 0x7f08001f
+			public static int wrap_content = 2131230751;
 			
 			static Id()
 			{
@@ -2719,35 +3353,41 @@ namespace FAB.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f080006
-			public static int abc_config_activityDefaultDur = 2131230726;
+			// aapt resource value: 0x7f0a0003
+			public static int abc_config_activityDefaultDur = 2131361795;
 			
-			// aapt resource value: 0x7f080007
-			public static int abc_config_activityShortDur = 2131230727;
+			// aapt resource value: 0x7f0a0004
+			public static int abc_config_activityShortDur = 2131361796;
 			
-			// aapt resource value: 0x7f080005
-			public static int abc_max_action_buttons = 2131230725;
+			// aapt resource value: 0x7f0a0008
+			public static int app_bar_elevation_anim_duration = 2131361800;
 			
-			// aapt resource value: 0x7f080004
-			public static int bottom_sheet_slide_duration = 2131230724;
+			// aapt resource value: 0x7f0a0009
+			public static int bottom_sheet_slide_duration = 2131361801;
 			
-			// aapt resource value: 0x7f080008
-			public static int cancel_button_image_alpha = 2131230728;
+			// aapt resource value: 0x7f0a0005
+			public static int cancel_button_image_alpha = 2131361797;
 			
-			// aapt resource value: 0x7f080003
-			public static int design_snackbar_text_max_lines = 2131230723;
+			// aapt resource value: 0x7f0a0007
+			public static int design_snackbar_text_max_lines = 2131361799;
 			
-			// aapt resource value: 0x7f080000
-			public static int mr_controller_volume_group_list_animation_duration_ms = 2131230720;
+			// aapt resource value: 0x7f0a000a
+			public static int hide_password_duration = 2131361802;
 			
-			// aapt resource value: 0x7f080001
-			public static int mr_controller_volume_group_list_fade_in_duration_ms = 2131230721;
+			// aapt resource value: 0x7f0a0000
+			public static int mr_controller_volume_group_list_animation_duration_ms = 2131361792;
 			
-			// aapt resource value: 0x7f080002
-			public static int mr_controller_volume_group_list_fade_out_duration_ms = 2131230722;
+			// aapt resource value: 0x7f0a0001
+			public static int mr_controller_volume_group_list_fade_in_duration_ms = 2131361793;
 			
-			// aapt resource value: 0x7f080009
-			public static int status_bar_notification_info_maxnum = 2131230729;
+			// aapt resource value: 0x7f0a0002
+			public static int mr_controller_volume_group_list_fade_out_duration_ms = 2131361794;
+			
+			// aapt resource value: 0x7f0a000b
+			public static int show_password_duration = 2131361803;
+			
+			// aapt resource value: 0x7f0a0006
+			public static int status_bar_notification_info_maxnum = 2131361798;
 			
 			static Integer()
 			{
@@ -2762,11 +3402,11 @@ namespace FAB.Droid
 		public partial class Interpolator
 		{
 			
-			// aapt resource value: 0x7f050000
-			public static int mr_fast_out_slow_in = 2131034112;
+			// aapt resource value: 0x7f060000
+			public static int mr_fast_out_slow_in = 2131099648;
 			
-			// aapt resource value: 0x7f050001
-			public static int mr_linear_out_slow_in = 2131034113;
+			// aapt resource value: 0x7f060001
+			public static int mr_linear_out_slow_in = 2131099649;
 			
 			static Interpolator()
 			{
@@ -2815,142 +3455,175 @@ namespace FAB.Droid
 			public static int abc_alert_dialog_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public static int abc_dialog_title_material = 2130903051;
+			public static int abc_alert_dialog_title_material = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public static int abc_expanded_menu_layout = 2130903052;
+			public static int abc_dialog_title_material = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public static int abc_list_menu_item_checkbox = 2130903053;
+			public static int abc_expanded_menu_layout = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public static int abc_list_menu_item_icon = 2130903054;
+			public static int abc_list_menu_item_checkbox = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public static int abc_list_menu_item_layout = 2130903055;
+			public static int abc_list_menu_item_icon = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public static int abc_list_menu_item_radio = 2130903056;
+			public static int abc_list_menu_item_layout = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public static int abc_popup_menu_item_layout = 2130903057;
+			public static int abc_list_menu_item_radio = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public static int abc_screen_content_include = 2130903058;
+			public static int abc_popup_menu_header_item_layout = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public static int abc_screen_simple = 2130903059;
+			public static int abc_popup_menu_item_layout = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public static int abc_screen_simple_overlay_action_mode = 2130903060;
+			public static int abc_screen_content_include = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public static int abc_screen_toolbar = 2130903061;
+			public static int abc_screen_simple = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public static int abc_search_dropdown_item_icons_2line = 2130903062;
+			public static int abc_screen_simple_overlay_action_mode = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public static int abc_search_view = 2130903063;
+			public static int abc_screen_toolbar = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public static int abc_select_dialog_material = 2130903064;
+			public static int abc_search_dropdown_item_icons_2line = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public static int design_bottom_sheet_dialog = 2130903065;
+			public static int abc_search_view = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public static int design_layout_snackbar = 2130903066;
+			public static int abc_select_dialog_material = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public static int design_layout_snackbar_include = 2130903067;
+			public static int design_bottom_navigation_item = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public static int design_layout_tab_icon = 2130903068;
+			public static int design_bottom_sheet_dialog = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public static int design_layout_tab_text = 2130903069;
+			public static int design_layout_snackbar = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public static int design_menu_item_action_area = 2130903070;
+			public static int design_layout_snackbar_include = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public static int design_navigation_item = 2130903071;
+			public static int design_layout_tab_icon = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public static int design_navigation_item_header = 2130903072;
+			public static int design_layout_tab_text = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public static int design_navigation_item_separator = 2130903073;
+			public static int design_menu_item_action_area = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public static int design_navigation_item_subheader = 2130903074;
+			public static int design_navigation_item = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public static int design_navigation_menu = 2130903075;
+			public static int design_navigation_item_header = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public static int design_navigation_menu_item = 2130903076;
+			public static int design_navigation_item_separator = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public static int mini_fab = 2130903077;
+			public static int design_navigation_item_subheader = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public static int mr_chooser_dialog = 2130903078;
+			public static int design_navigation_menu = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public static int mr_chooser_list_item = 2130903079;
+			public static int design_navigation_menu_item = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public static int mr_controller_material_dialog_b = 2130903080;
+			public static int design_text_input_password_icon = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public static int mr_controller_volume_item = 2130903081;
+			public static int mini_fab = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public static int mr_playback_control = 2130903082;
+			public static int mr_chooser_dialog = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public static int mr_volume_control = 2130903083;
+			public static int mr_chooser_list_item = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public static int normal_fab = 2130903084;
+			public static int mr_controller_material_dialog_b = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public static int notification_media_action = 2130903085;
+			public static int mr_controller_volume_item = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public static int notification_media_cancel_action = 2130903086;
+			public static int mr_playback_control = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public static int notification_template_big_media = 2130903087;
+			public static int mr_volume_control = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public static int notification_template_big_media_narrow = 2130903088;
+			public static int normal_fab = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public static int notification_template_lines = 2130903089;
+			public static int notification_action = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public static int notification_template_media = 2130903090;
+			public static int notification_action_tombstone = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public static int notification_template_part_chronometer = 2130903091;
+			public static int notification_media_action = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public static int notification_template_part_time = 2130903092;
+			public static int notification_media_cancel_action = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public static int select_dialog_item_material = 2130903093;
+			public static int notification_template_big_media = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public static int select_dialog_multichoice_material = 2130903094;
+			public static int notification_template_big_media_custom = 2130903094;
 			
 			// aapt resource value: 0x7f030037
-			public static int select_dialog_singlechoice_material = 2130903095;
+			public static int notification_template_big_media_narrow = 2130903095;
 			
 			// aapt resource value: 0x7f030038
-			public static int support_simple_spinner_dropdown_item = 2130903096;
+			public static int notification_template_big_media_narrow_custom = 2130903096;
+			
+			// aapt resource value: 0x7f030039
+			public static int notification_template_custom_big = 2130903097;
+			
+			// aapt resource value: 0x7f03003a
+			public static int notification_template_icon_group = 2130903098;
+			
+			// aapt resource value: 0x7f03003b
+			public static int notification_template_lines_media = 2130903099;
+			
+			// aapt resource value: 0x7f03003c
+			public static int notification_template_media = 2130903100;
+			
+			// aapt resource value: 0x7f03003d
+			public static int notification_template_media_custom = 2130903101;
+			
+			// aapt resource value: 0x7f03003e
+			public static int notification_template_part_chronometer = 2130903102;
+			
+			// aapt resource value: 0x7f03003f
+			public static int notification_template_part_time = 2130903103;
+			
+			// aapt resource value: 0x7f030040
+			public static int select_dialog_item_material = 2130903104;
+			
+			// aapt resource value: 0x7f030041
+			public static int select_dialog_multichoice_material = 2130903105;
+			
+			// aapt resource value: 0x7f030042
+			public static int select_dialog_singlechoice_material = 2130903106;
+			
+			// aapt resource value: 0x7f030043
+			public static int support_simple_spinner_dropdown_item = 2130903107;
 			
 			static Layout()
 			{
@@ -2965,152 +3638,224 @@ namespace FAB.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f060012
-			public static int abc_action_bar_home_description = 2131099666;
+			// aapt resource value: 0x7f090015
+			public static int abc_action_bar_home_description = 2131296277;
 			
-			// aapt resource value: 0x7f060013
-			public static int abc_action_bar_home_description_format = 2131099667;
+			// aapt resource value: 0x7f090016
+			public static int abc_action_bar_home_description_format = 2131296278;
 			
-			// aapt resource value: 0x7f060014
-			public static int abc_action_bar_home_subtitle_description_format = 2131099668;
+			// aapt resource value: 0x7f090017
+			public static int abc_action_bar_home_subtitle_description_format = 2131296279;
 			
-			// aapt resource value: 0x7f060015
-			public static int abc_action_bar_up_description = 2131099669;
+			// aapt resource value: 0x7f090018
+			public static int abc_action_bar_up_description = 2131296280;
 			
-			// aapt resource value: 0x7f060016
-			public static int abc_action_menu_overflow_description = 2131099670;
+			// aapt resource value: 0x7f090019
+			public static int abc_action_menu_overflow_description = 2131296281;
 			
-			// aapt resource value: 0x7f060017
-			public static int abc_action_mode_done = 2131099671;
+			// aapt resource value: 0x7f09001a
+			public static int abc_action_mode_done = 2131296282;
 			
-			// aapt resource value: 0x7f060018
-			public static int abc_activity_chooser_view_see_all = 2131099672;
+			// aapt resource value: 0x7f09001b
+			public static int abc_activity_chooser_view_see_all = 2131296283;
 			
-			// aapt resource value: 0x7f060019
-			public static int abc_activitychooserview_choose_application = 2131099673;
+			// aapt resource value: 0x7f09001c
+			public static int abc_activitychooserview_choose_application = 2131296284;
 			
-			// aapt resource value: 0x7f06001a
-			public static int abc_capital_off = 2131099674;
+			// aapt resource value: 0x7f09001d
+			public static int abc_capital_off = 2131296285;
 			
-			// aapt resource value: 0x7f06001b
-			public static int abc_capital_on = 2131099675;
+			// aapt resource value: 0x7f09001e
+			public static int abc_capital_on = 2131296286;
 			
-			// aapt resource value: 0x7f06001c
-			public static int abc_search_hint = 2131099676;
+			// aapt resource value: 0x7f09002a
+			public static int abc_font_family_body_1_material = 2131296298;
 			
-			// aapt resource value: 0x7f06001d
-			public static int abc_searchview_description_clear = 2131099677;
+			// aapt resource value: 0x7f09002b
+			public static int abc_font_family_body_2_material = 2131296299;
 			
-			// aapt resource value: 0x7f06001e
-			public static int abc_searchview_description_query = 2131099678;
+			// aapt resource value: 0x7f09002c
+			public static int abc_font_family_button_material = 2131296300;
 			
-			// aapt resource value: 0x7f06001f
-			public static int abc_searchview_description_search = 2131099679;
+			// aapt resource value: 0x7f09002d
+			public static int abc_font_family_caption_material = 2131296301;
 			
-			// aapt resource value: 0x7f060020
-			public static int abc_searchview_description_submit = 2131099680;
+			// aapt resource value: 0x7f09002e
+			public static int abc_font_family_display_1_material = 2131296302;
 			
-			// aapt resource value: 0x7f060021
-			public static int abc_searchview_description_voice = 2131099681;
+			// aapt resource value: 0x7f09002f
+			public static int abc_font_family_display_2_material = 2131296303;
 			
-			// aapt resource value: 0x7f060022
-			public static int abc_shareactionprovider_share_with = 2131099682;
+			// aapt resource value: 0x7f090030
+			public static int abc_font_family_display_3_material = 2131296304;
 			
-			// aapt resource value: 0x7f060023
-			public static int abc_shareactionprovider_share_with_application = 2131099683;
+			// aapt resource value: 0x7f090031
+			public static int abc_font_family_display_4_material = 2131296305;
 			
-			// aapt resource value: 0x7f060024
-			public static int abc_toolbar_collapse_description = 2131099684;
+			// aapt resource value: 0x7f090032
+			public static int abc_font_family_headline_material = 2131296306;
 			
-			// aapt resource value: 0x7f06000f
-			public static int appbar_scrolling_view_behavior = 2131099663;
+			// aapt resource value: 0x7f090033
+			public static int abc_font_family_menu_material = 2131296307;
 			
-			// aapt resource value: 0x7f060010
-			public static int bottom_sheet_behavior = 2131099664;
+			// aapt resource value: 0x7f090034
+			public static int abc_font_family_subhead_material = 2131296308;
 			
-			// aapt resource value: 0x7f060011
-			public static int character_counter_pattern = 2131099665;
+			// aapt resource value: 0x7f090035
+			public static int abc_font_family_title_material = 2131296309;
 			
-			// aapt resource value: 0x7f060026
-			public static int define_FloatingActionButton = 2131099686;
+			// aapt resource value: 0x7f09001f
+			public static int abc_search_hint = 2131296287;
 			
-			// aapt resource value: 0x7f060027
-			public static int library_FloatingActionButton_author = 2131099687;
+			// aapt resource value: 0x7f090020
+			public static int abc_searchview_description_clear = 2131296288;
 			
-			// aapt resource value: 0x7f060028
-			public static int library_FloatingActionButton_authorWebsite = 2131099688;
+			// aapt resource value: 0x7f090021
+			public static int abc_searchview_description_query = 2131296289;
 			
-			// aapt resource value: 0x7f06002d
-			public static int library_FloatingActionButton_isOpenSource = 2131099693;
+			// aapt resource value: 0x7f090022
+			public static int abc_searchview_description_search = 2131296290;
 			
-			// aapt resource value: 0x7f06002a
-			public static int library_FloatingActionButton_libraryDescription = 2131099690;
+			// aapt resource value: 0x7f090023
+			public static int abc_searchview_description_submit = 2131296291;
 			
-			// aapt resource value: 0x7f060029
-			public static int library_FloatingActionButton_libraryName = 2131099689;
+			// aapt resource value: 0x7f090024
+			public static int abc_searchview_description_voice = 2131296292;
 			
-			// aapt resource value: 0x7f06002c
-			public static int library_FloatingActionButton_libraryVersion = 2131099692;
+			// aapt resource value: 0x7f090025
+			public static int abc_shareactionprovider_share_with = 2131296293;
 			
-			// aapt resource value: 0x7f06002b
-			public static int library_FloatingActionButton_libraryWebsite = 2131099691;
+			// aapt resource value: 0x7f090026
+			public static int abc_shareactionprovider_share_with_application = 2131296294;
 			
-			// aapt resource value: 0x7f06002f
-			public static int library_FloatingActionButton_licenseId = 2131099695;
+			// aapt resource value: 0x7f090027
+			public static int abc_toolbar_collapse_description = 2131296295;
 			
-			// aapt resource value: 0x7f06002e
-			public static int library_FloatingActionButton_repositoryLink = 2131099694;
+			// aapt resource value: 0x7f090036
+			public static int appbar_scrolling_view_behavior = 2131296310;
 			
-			// aapt resource value: 0x7f060030
-			public static int library_name = 2131099696;
+			// aapt resource value: 0x7f090037
+			public static int bottom_sheet_behavior = 2131296311;
 			
-			// aapt resource value: 0x7f060000
-			public static int mr_button_content_description = 2131099648;
+			// aapt resource value: 0x7f090038
+			public static int character_counter_pattern = 2131296312;
 			
-			// aapt resource value: 0x7f060001
-			public static int mr_chooser_searching = 2131099649;
+			// aapt resource value: 0x7f09003e
+			public static int define_FloatingActionButton = 2131296318;
 			
-			// aapt resource value: 0x7f060002
-			public static int mr_chooser_title = 2131099650;
+			// aapt resource value: 0x7f09003f
+			public static int library_FloatingActionButton_author = 2131296319;
 			
-			// aapt resource value: 0x7f060003
-			public static int mr_controller_casting_screen = 2131099651;
+			// aapt resource value: 0x7f090040
+			public static int library_FloatingActionButton_authorWebsite = 2131296320;
 			
-			// aapt resource value: 0x7f060004
-			public static int mr_controller_close_description = 2131099652;
+			// aapt resource value: 0x7f090045
+			public static int library_FloatingActionButton_isOpenSource = 2131296325;
 			
-			// aapt resource value: 0x7f060005
-			public static int mr_controller_collapse_group = 2131099653;
+			// aapt resource value: 0x7f090042
+			public static int library_FloatingActionButton_libraryDescription = 2131296322;
 			
-			// aapt resource value: 0x7f060006
-			public static int mr_controller_disconnect = 2131099654;
+			// aapt resource value: 0x7f090041
+			public static int library_FloatingActionButton_libraryName = 2131296321;
 			
-			// aapt resource value: 0x7f060007
-			public static int mr_controller_expand_group = 2131099655;
+			// aapt resource value: 0x7f090044
+			public static int library_FloatingActionButton_libraryVersion = 2131296324;
 			
-			// aapt resource value: 0x7f060008
-			public static int mr_controller_no_info_available = 2131099656;
+			// aapt resource value: 0x7f090043
+			public static int library_FloatingActionButton_libraryWebsite = 2131296323;
 			
-			// aapt resource value: 0x7f060009
-			public static int mr_controller_no_media_selected = 2131099657;
+			// aapt resource value: 0x7f090047
+			public static int library_FloatingActionButton_licenseId = 2131296327;
 			
-			// aapt resource value: 0x7f06000a
-			public static int mr_controller_pause = 2131099658;
+			// aapt resource value: 0x7f090046
+			public static int library_FloatingActionButton_repositoryLink = 2131296326;
 			
-			// aapt resource value: 0x7f06000b
-			public static int mr_controller_play = 2131099659;
+			// aapt resource value: 0x7f090048
+			public static int library_name = 2131296328;
 			
-			// aapt resource value: 0x7f06000c
-			public static int mr_controller_stop = 2131099660;
+			// aapt resource value: 0x7f090000
+			public static int mr_button_content_description = 2131296256;
 			
-			// aapt resource value: 0x7f06000d
-			public static int mr_system_route_name = 2131099661;
+			// aapt resource value: 0x7f090001
+			public static int mr_cast_button_connected = 2131296257;
 			
-			// aapt resource value: 0x7f06000e
-			public static int mr_user_route_category_name = 2131099662;
+			// aapt resource value: 0x7f090002
+			public static int mr_cast_button_connecting = 2131296258;
 			
-			// aapt resource value: 0x7f060025
-			public static int status_bar_notification_info_overflow = 2131099685;
+			// aapt resource value: 0x7f090003
+			public static int mr_cast_button_disconnected = 2131296259;
+			
+			// aapt resource value: 0x7f090004
+			public static int mr_chooser_searching = 2131296260;
+			
+			// aapt resource value: 0x7f090005
+			public static int mr_chooser_title = 2131296261;
+			
+			// aapt resource value: 0x7f090006
+			public static int mr_controller_album_art = 2131296262;
+			
+			// aapt resource value: 0x7f090007
+			public static int mr_controller_casting_screen = 2131296263;
+			
+			// aapt resource value: 0x7f090008
+			public static int mr_controller_close_description = 2131296264;
+			
+			// aapt resource value: 0x7f090009
+			public static int mr_controller_collapse_group = 2131296265;
+			
+			// aapt resource value: 0x7f09000a
+			public static int mr_controller_disconnect = 2131296266;
+			
+			// aapt resource value: 0x7f09000b
+			public static int mr_controller_expand_group = 2131296267;
+			
+			// aapt resource value: 0x7f09000c
+			public static int mr_controller_no_info_available = 2131296268;
+			
+			// aapt resource value: 0x7f09000d
+			public static int mr_controller_no_media_selected = 2131296269;
+			
+			// aapt resource value: 0x7f09000e
+			public static int mr_controller_pause = 2131296270;
+			
+			// aapt resource value: 0x7f09000f
+			public static int mr_controller_play = 2131296271;
+			
+			// aapt resource value: 0x7f090014
+			public static int mr_controller_stop = 2131296276;
+			
+			// aapt resource value: 0x7f090010
+			public static int mr_controller_stop_casting = 2131296272;
+			
+			// aapt resource value: 0x7f090011
+			public static int mr_controller_volume_slider = 2131296273;
+			
+			// aapt resource value: 0x7f090012
+			public static int mr_system_route_name = 2131296274;
+			
+			// aapt resource value: 0x7f090013
+			public static int mr_user_route_category_name = 2131296275;
+			
+			// aapt resource value: 0x7f090039
+			public static int password_toggle_content_description = 2131296313;
+			
+			// aapt resource value: 0x7f09003a
+			public static int path_password_eye = 2131296314;
+			
+			// aapt resource value: 0x7f09003b
+			public static int path_password_eye_mask_strike_through = 2131296315;
+			
+			// aapt resource value: 0x7f09003c
+			public static int path_password_eye_mask_visible = 2131296316;
+			
+			// aapt resource value: 0x7f09003d
+			public static int path_password_strike_through = 2131296317;
+			
+			// aapt resource value: 0x7f090028
+			public static int search_menu_title = 2131296296;
+			
+			// aapt resource value: 0x7f090029
+			public static int status_bar_notification_info_overflow = 2131296297;
 			
 			static String()
 			{
@@ -3125,1115 +3870,1184 @@ namespace FAB.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0900b6
-			public static int AlertDialog_AppCompat = 2131296438;
+			// aapt resource value: 0x7f0b00ae
+			public static int AlertDialog_AppCompat = 2131427502;
 			
-			// aapt resource value: 0x7f0900b7
-			public static int AlertDialog_AppCompat_Light = 2131296439;
+			// aapt resource value: 0x7f0b00af
+			public static int AlertDialog_AppCompat_Light = 2131427503;
 			
-			// aapt resource value: 0x7f0900b8
-			public static int Animation_AppCompat_Dialog = 2131296440;
+			// aapt resource value: 0x7f0b00b0
+			public static int Animation_AppCompat_Dialog = 2131427504;
 			
-			// aapt resource value: 0x7f0900b9
-			public static int Animation_AppCompat_DropDownUp = 2131296441;
+			// aapt resource value: 0x7f0b00b1
+			public static int Animation_AppCompat_DropDownUp = 2131427505;
 			
-			// aapt resource value: 0x7f090018
-			public static int Animation_Design_BottomSheetDialog = 2131296280;
+			// aapt resource value: 0x7f0b0170
+			public static int Animation_Design_BottomSheetDialog = 2131427696;
 			
-			// aapt resource value: 0x7f0900ba
-			public static int Base_AlertDialog_AppCompat = 2131296442;
+			// aapt resource value: 0x7f0b00b2
+			public static int Base_AlertDialog_AppCompat = 2131427506;
 			
-			// aapt resource value: 0x7f0900bb
-			public static int Base_AlertDialog_AppCompat_Light = 2131296443;
+			// aapt resource value: 0x7f0b00b3
+			public static int Base_AlertDialog_AppCompat_Light = 2131427507;
 			
-			// aapt resource value: 0x7f0900bc
-			public static int Base_Animation_AppCompat_Dialog = 2131296444;
+			// aapt resource value: 0x7f0b00b4
+			public static int Base_Animation_AppCompat_Dialog = 2131427508;
 			
-			// aapt resource value: 0x7f0900bd
-			public static int Base_Animation_AppCompat_DropDownUp = 2131296445;
+			// aapt resource value: 0x7f0b00b5
+			public static int Base_Animation_AppCompat_DropDownUp = 2131427509;
 			
-			// aapt resource value: 0x7f09016f
-			public static int Base_CardView = 2131296623;
+			// aapt resource value: 0x7f0b000c
+			public static int Base_CardView = 2131427340;
 			
-			// aapt resource value: 0x7f0900be
-			public static int Base_DialogWindowTitle_AppCompat = 2131296446;
+			// aapt resource value: 0x7f0b00b6
+			public static int Base_DialogWindowTitle_AppCompat = 2131427510;
 			
-			// aapt resource value: 0x7f0900bf
-			public static int Base_DialogWindowTitleBackground_AppCompat = 2131296447;
+			// aapt resource value: 0x7f0b00b7
+			public static int Base_DialogWindowTitleBackground_AppCompat = 2131427511;
 			
-			// aapt resource value: 0x7f090066
-			public static int Base_TextAppearance_AppCompat = 2131296358;
+			// aapt resource value: 0x7f0b004e
+			public static int Base_TextAppearance_AppCompat = 2131427406;
 			
-			// aapt resource value: 0x7f090067
-			public static int Base_TextAppearance_AppCompat_Body1 = 2131296359;
+			// aapt resource value: 0x7f0b004f
+			public static int Base_TextAppearance_AppCompat_Body1 = 2131427407;
 			
-			// aapt resource value: 0x7f090068
-			public static int Base_TextAppearance_AppCompat_Body2 = 2131296360;
+			// aapt resource value: 0x7f0b0050
+			public static int Base_TextAppearance_AppCompat_Body2 = 2131427408;
 			
-			// aapt resource value: 0x7f090050
-			public static int Base_TextAppearance_AppCompat_Button = 2131296336;
+			// aapt resource value: 0x7f0b0036
+			public static int Base_TextAppearance_AppCompat_Button = 2131427382;
 			
-			// aapt resource value: 0x7f090069
-			public static int Base_TextAppearance_AppCompat_Caption = 2131296361;
+			// aapt resource value: 0x7f0b0051
+			public static int Base_TextAppearance_AppCompat_Caption = 2131427409;
 			
-			// aapt resource value: 0x7f09006a
-			public static int Base_TextAppearance_AppCompat_Display1 = 2131296362;
+			// aapt resource value: 0x7f0b0052
+			public static int Base_TextAppearance_AppCompat_Display1 = 2131427410;
 			
-			// aapt resource value: 0x7f09006b
-			public static int Base_TextAppearance_AppCompat_Display2 = 2131296363;
+			// aapt resource value: 0x7f0b0053
+			public static int Base_TextAppearance_AppCompat_Display2 = 2131427411;
 			
-			// aapt resource value: 0x7f09006c
-			public static int Base_TextAppearance_AppCompat_Display3 = 2131296364;
+			// aapt resource value: 0x7f0b0054
+			public static int Base_TextAppearance_AppCompat_Display3 = 2131427412;
 			
-			// aapt resource value: 0x7f09006d
-			public static int Base_TextAppearance_AppCompat_Display4 = 2131296365;
+			// aapt resource value: 0x7f0b0055
+			public static int Base_TextAppearance_AppCompat_Display4 = 2131427413;
 			
-			// aapt resource value: 0x7f09006e
-			public static int Base_TextAppearance_AppCompat_Headline = 2131296366;
+			// aapt resource value: 0x7f0b0056
+			public static int Base_TextAppearance_AppCompat_Headline = 2131427414;
 			
-			// aapt resource value: 0x7f09003b
-			public static int Base_TextAppearance_AppCompat_Inverse = 2131296315;
+			// aapt resource value: 0x7f0b001a
+			public static int Base_TextAppearance_AppCompat_Inverse = 2131427354;
 			
-			// aapt resource value: 0x7f09006f
-			public static int Base_TextAppearance_AppCompat_Large = 2131296367;
+			// aapt resource value: 0x7f0b0057
+			public static int Base_TextAppearance_AppCompat_Large = 2131427415;
 			
-			// aapt resource value: 0x7f09003c
-			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131296316;
+			// aapt resource value: 0x7f0b001b
+			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131427355;
 			
-			// aapt resource value: 0x7f090070
-			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296368;
+			// aapt resource value: 0x7f0b0058
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427416;
 			
-			// aapt resource value: 0x7f090071
-			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296369;
+			// aapt resource value: 0x7f0b0059
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427417;
 			
-			// aapt resource value: 0x7f090072
-			public static int Base_TextAppearance_AppCompat_Medium = 2131296370;
+			// aapt resource value: 0x7f0b005a
+			public static int Base_TextAppearance_AppCompat_Medium = 2131427418;
 			
-			// aapt resource value: 0x7f09003d
-			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296317;
+			// aapt resource value: 0x7f0b001c
+			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427356;
 			
-			// aapt resource value: 0x7f090073
-			public static int Base_TextAppearance_AppCompat_Menu = 2131296371;
+			// aapt resource value: 0x7f0b005b
+			public static int Base_TextAppearance_AppCompat_Menu = 2131427419;
 			
-			// aapt resource value: 0x7f0900c0
-			public static int Base_TextAppearance_AppCompat_SearchResult = 2131296448;
+			// aapt resource value: 0x7f0b00b8
+			public static int Base_TextAppearance_AppCompat_SearchResult = 2131427512;
 			
-			// aapt resource value: 0x7f090074
-			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296372;
+			// aapt resource value: 0x7f0b005c
+			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427420;
 			
-			// aapt resource value: 0x7f090075
-			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296373;
+			// aapt resource value: 0x7f0b005d
+			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427421;
 			
-			// aapt resource value: 0x7f090076
-			public static int Base_TextAppearance_AppCompat_Small = 2131296374;
+			// aapt resource value: 0x7f0b005e
+			public static int Base_TextAppearance_AppCompat_Small = 2131427422;
 			
-			// aapt resource value: 0x7f09003e
-			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131296318;
+			// aapt resource value: 0x7f0b001d
+			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131427357;
 			
-			// aapt resource value: 0x7f090077
-			public static int Base_TextAppearance_AppCompat_Subhead = 2131296375;
+			// aapt resource value: 0x7f0b005f
+			public static int Base_TextAppearance_AppCompat_Subhead = 2131427423;
 			
-			// aapt resource value: 0x7f09003f
-			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296319;
+			// aapt resource value: 0x7f0b001e
+			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427358;
 			
-			// aapt resource value: 0x7f090078
-			public static int Base_TextAppearance_AppCompat_Title = 2131296376;
+			// aapt resource value: 0x7f0b0060
+			public static int Base_TextAppearance_AppCompat_Title = 2131427424;
 			
-			// aapt resource value: 0x7f090040
-			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131296320;
+			// aapt resource value: 0x7f0b001f
+			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131427359;
 			
-			// aapt resource value: 0x7f0900af
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296431;
+			// aapt resource value: 0x7f0b00a3
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427491;
 			
-			// aapt resource value: 0x7f090079
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296377;
+			// aapt resource value: 0x7f0b0061
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427425;
 			
-			// aapt resource value: 0x7f09007a
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296378;
+			// aapt resource value: 0x7f0b0062
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427426;
 			
-			// aapt resource value: 0x7f09007b
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296379;
+			// aapt resource value: 0x7f0b0063
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427427;
 			
-			// aapt resource value: 0x7f09007c
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296380;
+			// aapt resource value: 0x7f0b0064
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427428;
 			
-			// aapt resource value: 0x7f09007d
-			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296381;
+			// aapt resource value: 0x7f0b0065
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427429;
 			
-			// aapt resource value: 0x7f09007e
-			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296382;
+			// aapt resource value: 0x7f0b0066
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427430;
 			
-			// aapt resource value: 0x7f09007f
-			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131296383;
+			// aapt resource value: 0x7f0b0067
+			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131427431;
 			
-			// aapt resource value: 0x7f0900b0
-			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131296432;
+			// aapt resource value: 0x7f0b00aa
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427498;
 			
-			// aapt resource value: 0x7f0900c1
-			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296449;
+			// aapt resource value: 0x7f0b00ab
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131427499;
 			
-			// aapt resource value: 0x7f090080
-			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296384;
+			// aapt resource value: 0x7f0b00a4
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131427492;
 			
-			// aapt resource value: 0x7f090081
-			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296385;
+			// aapt resource value: 0x7f0b00b9
+			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427513;
 			
-			// aapt resource value: 0x7f090082
-			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131296386;
+			// aapt resource value: 0x7f0b0068
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427432;
 			
-			// aapt resource value: 0x7f090083
-			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296387;
+			// aapt resource value: 0x7f0b0069
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427433;
 			
-			// aapt resource value: 0x7f0900c2
-			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296450;
+			// aapt resource value: 0x7f0b006a
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427434;
 			
-			// aapt resource value: 0x7f090084
-			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296388;
+			// aapt resource value: 0x7f0b006b
+			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131427435;
 			
-			// aapt resource value: 0x7f090085
-			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296389;
+			// aapt resource value: 0x7f0b006c
+			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427436;
 			
-			// aapt resource value: 0x7f090086
-			public static int Base_Theme_AppCompat = 2131296390;
+			// aapt resource value: 0x7f0b00ba
+			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427514;
 			
-			// aapt resource value: 0x7f0900c3
-			public static int Base_Theme_AppCompat_CompactMenu = 2131296451;
+			// aapt resource value: 0x7f0b006d
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427437;
 			
-			// aapt resource value: 0x7f090041
-			public static int Base_Theme_AppCompat_Dialog = 2131296321;
+			// aapt resource value: 0x7f0b006e
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427438;
 			
-			// aapt resource value: 0x7f0900c4
-			public static int Base_Theme_AppCompat_Dialog_Alert = 2131296452;
+			// aapt resource value: 0x7f0b006f
+			public static int Base_Theme_AppCompat = 2131427439;
 			
-			// aapt resource value: 0x7f0900c5
-			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131296453;
+			// aapt resource value: 0x7f0b00bb
+			public static int Base_Theme_AppCompat_CompactMenu = 2131427515;
 			
-			// aapt resource value: 0x7f0900c6
-			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131296454;
+			// aapt resource value: 0x7f0b0020
+			public static int Base_Theme_AppCompat_Dialog = 2131427360;
 			
-			// aapt resource value: 0x7f090031
-			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131296305;
+			// aapt resource value: 0x7f0b0021
+			public static int Base_Theme_AppCompat_Dialog_Alert = 2131427361;
 			
-			// aapt resource value: 0x7f090087
-			public static int Base_Theme_AppCompat_Light = 2131296391;
+			// aapt resource value: 0x7f0b00bc
+			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131427516;
 			
-			// aapt resource value: 0x7f0900c7
-			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131296455;
+			// aapt resource value: 0x7f0b0022
+			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131427362;
 			
-			// aapt resource value: 0x7f090042
-			public static int Base_Theme_AppCompat_Light_Dialog = 2131296322;
+			// aapt resource value: 0x7f0b0010
+			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131427344;
 			
-			// aapt resource value: 0x7f0900c8
-			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296456;
+			// aapt resource value: 0x7f0b0070
+			public static int Base_Theme_AppCompat_Light = 2131427440;
 			
-			// aapt resource value: 0x7f0900c9
-			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296457;
+			// aapt resource value: 0x7f0b00bd
+			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131427517;
 			
-			// aapt resource value: 0x7f0900ca
-			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296458;
+			// aapt resource value: 0x7f0b0023
+			public static int Base_Theme_AppCompat_Light_Dialog = 2131427363;
 			
-			// aapt resource value: 0x7f090032
-			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296306;
+			// aapt resource value: 0x7f0b0024
+			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131427364;
 			
-			// aapt resource value: 0x7f0900cb
-			public static int Base_ThemeOverlay_AppCompat = 2131296459;
+			// aapt resource value: 0x7f0b00be
+			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427518;
 			
-			// aapt resource value: 0x7f0900cc
-			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131296460;
+			// aapt resource value: 0x7f0b0025
+			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131427365;
 			
-			// aapt resource value: 0x7f0900cd
-			public static int Base_ThemeOverlay_AppCompat_Dark = 2131296461;
+			// aapt resource value: 0x7f0b0011
+			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427345;
 			
-			// aapt resource value: 0x7f0900ce
-			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296462;
+			// aapt resource value: 0x7f0b00bf
+			public static int Base_ThemeOverlay_AppCompat = 2131427519;
 			
-			// aapt resource value: 0x7f0900cf
-			public static int Base_ThemeOverlay_AppCompat_Light = 2131296463;
+			// aapt resource value: 0x7f0b00c0
+			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131427520;
 			
-			// aapt resource value: 0x7f090043
-			public static int Base_V11_Theme_AppCompat_Dialog = 2131296323;
+			// aapt resource value: 0x7f0b00c1
+			public static int Base_ThemeOverlay_AppCompat_Dark = 2131427521;
 			
-			// aapt resource value: 0x7f090044
-			public static int Base_V11_Theme_AppCompat_Light_Dialog = 2131296324;
+			// aapt resource value: 0x7f0b00c2
+			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427522;
 			
-			// aapt resource value: 0x7f09004c
-			public static int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296332;
+			// aapt resource value: 0x7f0b0026
+			public static int Base_ThemeOverlay_AppCompat_Dialog = 2131427366;
 			
-			// aapt resource value: 0x7f09004d
-			public static int Base_V12_Widget_AppCompat_EditText = 2131296333;
+			// aapt resource value: 0x7f0b0027
+			public static int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131427367;
 			
-			// aapt resource value: 0x7f090088
-			public static int Base_V21_Theme_AppCompat = 2131296392;
+			// aapt resource value: 0x7f0b00c3
+			public static int Base_ThemeOverlay_AppCompat_Light = 2131427523;
 			
-			// aapt resource value: 0x7f090089
-			public static int Base_V21_Theme_AppCompat_Dialog = 2131296393;
+			// aapt resource value: 0x7f0b0028
+			public static int Base_V11_Theme_AppCompat_Dialog = 2131427368;
 			
-			// aapt resource value: 0x7f09008a
-			public static int Base_V21_Theme_AppCompat_Light = 2131296394;
+			// aapt resource value: 0x7f0b0029
+			public static int Base_V11_Theme_AppCompat_Light_Dialog = 2131427369;
 			
-			// aapt resource value: 0x7f09008b
-			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131296395;
+			// aapt resource value: 0x7f0b002a
+			public static int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131427370;
 			
-			// aapt resource value: 0x7f0900ad
-			public static int Base_V22_Theme_AppCompat = 2131296429;
+			// aapt resource value: 0x7f0b0032
+			public static int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131427378;
 			
-			// aapt resource value: 0x7f0900ae
-			public static int Base_V22_Theme_AppCompat_Light = 2131296430;
+			// aapt resource value: 0x7f0b0033
+			public static int Base_V12_Widget_AppCompat_EditText = 2131427379;
 			
-			// aapt resource value: 0x7f0900b1
-			public static int Base_V23_Theme_AppCompat = 2131296433;
+			// aapt resource value: 0x7f0b0071
+			public static int Base_V21_Theme_AppCompat = 2131427441;
 			
-			// aapt resource value: 0x7f0900b2
-			public static int Base_V23_Theme_AppCompat_Light = 2131296434;
+			// aapt resource value: 0x7f0b0072
+			public static int Base_V21_Theme_AppCompat_Dialog = 2131427442;
 			
-			// aapt resource value: 0x7f0900d0
-			public static int Base_V7_Theme_AppCompat = 2131296464;
+			// aapt resource value: 0x7f0b0073
+			public static int Base_V21_Theme_AppCompat_Light = 2131427443;
 			
-			// aapt resource value: 0x7f0900d1
-			public static int Base_V7_Theme_AppCompat_Dialog = 2131296465;
+			// aapt resource value: 0x7f0b0074
+			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131427444;
 			
-			// aapt resource value: 0x7f0900d2
-			public static int Base_V7_Theme_AppCompat_Light = 2131296466;
+			// aapt resource value: 0x7f0b0075
+			public static int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131427445;
 			
-			// aapt resource value: 0x7f0900d3
-			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131296467;
+			// aapt resource value: 0x7f0b00a1
+			public static int Base_V22_Theme_AppCompat = 2131427489;
 			
-			// aapt resource value: 0x7f0900d4
-			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296468;
+			// aapt resource value: 0x7f0b00a2
+			public static int Base_V22_Theme_AppCompat_Light = 2131427490;
 			
-			// aapt resource value: 0x7f0900d5
-			public static int Base_V7_Widget_AppCompat_EditText = 2131296469;
+			// aapt resource value: 0x7f0b00a5
+			public static int Base_V23_Theme_AppCompat = 2131427493;
 			
-			// aapt resource value: 0x7f0900d6
-			public static int Base_Widget_AppCompat_ActionBar = 2131296470;
+			// aapt resource value: 0x7f0b00a6
+			public static int Base_V23_Theme_AppCompat_Light = 2131427494;
 			
-			// aapt resource value: 0x7f0900d7
-			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131296471;
+			// aapt resource value: 0x7f0b00c4
+			public static int Base_V7_Theme_AppCompat = 2131427524;
 			
-			// aapt resource value: 0x7f0900d8
-			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131296472;
+			// aapt resource value: 0x7f0b00c5
+			public static int Base_V7_Theme_AppCompat_Dialog = 2131427525;
 			
-			// aapt resource value: 0x7f09008c
-			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131296396;
+			// aapt resource value: 0x7f0b00c6
+			public static int Base_V7_Theme_AppCompat_Light = 2131427526;
 			
-			// aapt resource value: 0x7f09008d
-			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131296397;
+			// aapt resource value: 0x7f0b00c7
+			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131427527;
 			
-			// aapt resource value: 0x7f09008e
-			public static int Base_Widget_AppCompat_ActionButton = 2131296398;
+			// aapt resource value: 0x7f0b00c8
+			public static int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131427528;
 			
-			// aapt resource value: 0x7f09008f
-			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296399;
+			// aapt resource value: 0x7f0b00c9
+			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131427529;
 			
-			// aapt resource value: 0x7f090090
-			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131296400;
+			// aapt resource value: 0x7f0b00ca
+			public static int Base_V7_Widget_AppCompat_EditText = 2131427530;
 			
-			// aapt resource value: 0x7f0900d9
-			public static int Base_Widget_AppCompat_ActionMode = 2131296473;
+			// aapt resource value: 0x7f0b00cb
+			public static int Base_Widget_AppCompat_ActionBar = 2131427531;
 			
-			// aapt resource value: 0x7f0900da
-			public static int Base_Widget_AppCompat_ActivityChooserView = 2131296474;
+			// aapt resource value: 0x7f0b00cc
+			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131427532;
 			
-			// aapt resource value: 0x7f09004e
-			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131296334;
+			// aapt resource value: 0x7f0b00cd
+			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131427533;
 			
-			// aapt resource value: 0x7f090091
-			public static int Base_Widget_AppCompat_Button = 2131296401;
+			// aapt resource value: 0x7f0b0076
+			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131427446;
 			
-			// aapt resource value: 0x7f090092
-			public static int Base_Widget_AppCompat_Button_Borderless = 2131296402;
+			// aapt resource value: 0x7f0b0077
+			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131427447;
 			
-			// aapt resource value: 0x7f090093
-			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296403;
+			// aapt resource value: 0x7f0b0078
+			public static int Base_Widget_AppCompat_ActionButton = 2131427448;
 			
-			// aapt resource value: 0x7f0900db
-			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296475;
+			// aapt resource value: 0x7f0b0079
+			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427449;
 			
-			// aapt resource value: 0x7f0900b3
-			public static int Base_Widget_AppCompat_Button_Colored = 2131296435;
+			// aapt resource value: 0x7f0b007a
+			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131427450;
 			
-			// aapt resource value: 0x7f090094
-			public static int Base_Widget_AppCompat_Button_Small = 2131296404;
+			// aapt resource value: 0x7f0b00ce
+			public static int Base_Widget_AppCompat_ActionMode = 2131427534;
 			
-			// aapt resource value: 0x7f090095
-			public static int Base_Widget_AppCompat_ButtonBar = 2131296405;
+			// aapt resource value: 0x7f0b00cf
+			public static int Base_Widget_AppCompat_ActivityChooserView = 2131427535;
 			
-			// aapt resource value: 0x7f0900dc
-			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296476;
+			// aapt resource value: 0x7f0b0034
+			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131427380;
 			
-			// aapt resource value: 0x7f090096
-			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296406;
+			// aapt resource value: 0x7f0b007b
+			public static int Base_Widget_AppCompat_Button = 2131427451;
 			
-			// aapt resource value: 0x7f090097
-			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296407;
+			// aapt resource value: 0x7f0b007c
+			public static int Base_Widget_AppCompat_Button_Borderless = 2131427452;
 			
-			// aapt resource value: 0x7f0900dd
-			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131296477;
+			// aapt resource value: 0x7f0b007d
+			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131427453;
 			
-			// aapt resource value: 0x7f090030
-			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131296304;
+			// aapt resource value: 0x7f0b00d0
+			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427536;
 			
-			// aapt resource value: 0x7f0900de
-			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296478;
+			// aapt resource value: 0x7f0b00a7
+			public static int Base_Widget_AppCompat_Button_Colored = 2131427495;
 			
-			// aapt resource value: 0x7f090098
-			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296408;
+			// aapt resource value: 0x7f0b007e
+			public static int Base_Widget_AppCompat_Button_Small = 2131427454;
 			
-			// aapt resource value: 0x7f09004f
-			public static int Base_Widget_AppCompat_EditText = 2131296335;
+			// aapt resource value: 0x7f0b007f
+			public static int Base_Widget_AppCompat_ButtonBar = 2131427455;
 			
-			// aapt resource value: 0x7f090099
-			public static int Base_Widget_AppCompat_ImageButton = 2131296409;
+			// aapt resource value: 0x7f0b00d1
+			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131427537;
 			
-			// aapt resource value: 0x7f0900df
-			public static int Base_Widget_AppCompat_Light_ActionBar = 2131296479;
+			// aapt resource value: 0x7f0b0080
+			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131427456;
 			
-			// aapt resource value: 0x7f0900e0
-			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296480;
+			// aapt resource value: 0x7f0b0081
+			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131427457;
 			
-			// aapt resource value: 0x7f0900e1
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296481;
+			// aapt resource value: 0x7f0b00d2
+			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131427538;
 			
-			// aapt resource value: 0x7f09009a
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296410;
+			// aapt resource value: 0x7f0b000f
+			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131427343;
 			
-			// aapt resource value: 0x7f09009b
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296411;
+			// aapt resource value: 0x7f0b00d3
+			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131427539;
 			
-			// aapt resource value: 0x7f09009c
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296412;
+			// aapt resource value: 0x7f0b0082
+			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427458;
 			
-			// aapt resource value: 0x7f09009d
-			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131296413;
+			// aapt resource value: 0x7f0b0035
+			public static int Base_Widget_AppCompat_EditText = 2131427381;
 			
-			// aapt resource value: 0x7f09009e
-			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296414;
+			// aapt resource value: 0x7f0b0083
+			public static int Base_Widget_AppCompat_ImageButton = 2131427459;
 			
-			// aapt resource value: 0x7f09009f
-			public static int Base_Widget_AppCompat_ListPopupWindow = 2131296415;
+			// aapt resource value: 0x7f0b00d4
+			public static int Base_Widget_AppCompat_Light_ActionBar = 2131427540;
 			
-			// aapt resource value: 0x7f0900a0
-			public static int Base_Widget_AppCompat_ListView = 2131296416;
+			// aapt resource value: 0x7f0b00d5
+			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427541;
 			
-			// aapt resource value: 0x7f0900a1
-			public static int Base_Widget_AppCompat_ListView_DropDown = 2131296417;
+			// aapt resource value: 0x7f0b00d6
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427542;
 			
-			// aapt resource value: 0x7f0900a2
-			public static int Base_Widget_AppCompat_ListView_Menu = 2131296418;
+			// aapt resource value: 0x7f0b0084
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427460;
 			
-			// aapt resource value: 0x7f0900a3
-			public static int Base_Widget_AppCompat_PopupMenu = 2131296419;
+			// aapt resource value: 0x7f0b0085
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427461;
 			
-			// aapt resource value: 0x7f0900a4
-			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296420;
+			// aapt resource value: 0x7f0b0086
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427462;
 			
-			// aapt resource value: 0x7f0900e2
-			public static int Base_Widget_AppCompat_PopupWindow = 2131296482;
+			// aapt resource value: 0x7f0b0087
+			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131427463;
 			
-			// aapt resource value: 0x7f090045
-			public static int Base_Widget_AppCompat_ProgressBar = 2131296325;
+			// aapt resource value: 0x7f0b0088
+			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427464;
 			
-			// aapt resource value: 0x7f090046
-			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296326;
+			// aapt resource value: 0x7f0b00d7
+			public static int Base_Widget_AppCompat_ListMenuView = 2131427543;
 			
-			// aapt resource value: 0x7f0900a5
-			public static int Base_Widget_AppCompat_RatingBar = 2131296421;
+			// aapt resource value: 0x7f0b0089
+			public static int Base_Widget_AppCompat_ListPopupWindow = 2131427465;
 			
-			// aapt resource value: 0x7f0900b4
-			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131296436;
+			// aapt resource value: 0x7f0b008a
+			public static int Base_Widget_AppCompat_ListView = 2131427466;
 			
-			// aapt resource value: 0x7f0900b5
-			public static int Base_Widget_AppCompat_RatingBar_Small = 2131296437;
+			// aapt resource value: 0x7f0b008b
+			public static int Base_Widget_AppCompat_ListView_DropDown = 2131427467;
 			
-			// aapt resource value: 0x7f0900e3
-			public static int Base_Widget_AppCompat_SearchView = 2131296483;
+			// aapt resource value: 0x7f0b008c
+			public static int Base_Widget_AppCompat_ListView_Menu = 2131427468;
 			
-			// aapt resource value: 0x7f0900e4
-			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131296484;
+			// aapt resource value: 0x7f0b008d
+			public static int Base_Widget_AppCompat_PopupMenu = 2131427469;
 			
-			// aapt resource value: 0x7f0900a6
-			public static int Base_Widget_AppCompat_SeekBar = 2131296422;
+			// aapt resource value: 0x7f0b008e
+			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427470;
 			
-			// aapt resource value: 0x7f0900a7
-			public static int Base_Widget_AppCompat_Spinner = 2131296423;
+			// aapt resource value: 0x7f0b00d8
+			public static int Base_Widget_AppCompat_PopupWindow = 2131427544;
 			
-			// aapt resource value: 0x7f090033
-			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131296307;
+			// aapt resource value: 0x7f0b002b
+			public static int Base_Widget_AppCompat_ProgressBar = 2131427371;
 			
-			// aapt resource value: 0x7f0900a8
-			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296424;
+			// aapt resource value: 0x7f0b002c
+			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427372;
 			
-			// aapt resource value: 0x7f0900e5
-			public static int Base_Widget_AppCompat_Toolbar = 2131296485;
+			// aapt resource value: 0x7f0b008f
+			public static int Base_Widget_AppCompat_RatingBar = 2131427471;
 			
-			// aapt resource value: 0x7f0900a9
-			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296425;
+			// aapt resource value: 0x7f0b00a8
+			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131427496;
 			
-			// aapt resource value: 0x7f090019
-			public static int Base_Widget_Design_TabLayout = 2131296281;
+			// aapt resource value: 0x7f0b00a9
+			public static int Base_Widget_AppCompat_RatingBar_Small = 2131427497;
 			
-			// aapt resource value: 0x7f09016e
-			public static int CardView = 2131296622;
+			// aapt resource value: 0x7f0b00d9
+			public static int Base_Widget_AppCompat_SearchView = 2131427545;
 			
-			// aapt resource value: 0x7f090170
-			public static int CardView_Dark = 2131296624;
+			// aapt resource value: 0x7f0b00da
+			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131427546;
 			
-			// aapt resource value: 0x7f090171
-			public static int CardView_Light = 2131296625;
+			// aapt resource value: 0x7f0b0090
+			public static int Base_Widget_AppCompat_SeekBar = 2131427472;
 			
-			// aapt resource value: 0x7f090047
-			public static int Platform_AppCompat = 2131296327;
+			// aapt resource value: 0x7f0b00db
+			public static int Base_Widget_AppCompat_SeekBar_Discrete = 2131427547;
 			
-			// aapt resource value: 0x7f090048
-			public static int Platform_AppCompat_Light = 2131296328;
+			// aapt resource value: 0x7f0b0091
+			public static int Base_Widget_AppCompat_Spinner = 2131427473;
 			
-			// aapt resource value: 0x7f0900aa
-			public static int Platform_ThemeOverlay_AppCompat = 2131296426;
+			// aapt resource value: 0x7f0b0012
+			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131427346;
 			
-			// aapt resource value: 0x7f0900ab
-			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131296427;
+			// aapt resource value: 0x7f0b0092
+			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131427474;
 			
-			// aapt resource value: 0x7f0900ac
-			public static int Platform_ThemeOverlay_AppCompat_Light = 2131296428;
+			// aapt resource value: 0x7f0b00dc
+			public static int Base_Widget_AppCompat_Toolbar = 2131427548;
 			
-			// aapt resource value: 0x7f090049
-			public static int Platform_V11_AppCompat = 2131296329;
+			// aapt resource value: 0x7f0b0093
+			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427475;
 			
-			// aapt resource value: 0x7f09004a
-			public static int Platform_V11_AppCompat_Light = 2131296330;
+			// aapt resource value: 0x7f0b0171
+			public static int Base_Widget_Design_AppBarLayout = 2131427697;
 			
-			// aapt resource value: 0x7f090051
-			public static int Platform_V14_AppCompat = 2131296337;
+			// aapt resource value: 0x7f0b0172
+			public static int Base_Widget_Design_TabLayout = 2131427698;
 			
-			// aapt resource value: 0x7f090052
-			public static int Platform_V14_AppCompat_Light = 2131296338;
+			// aapt resource value: 0x7f0b000b
+			public static int CardView = 2131427339;
 			
-			// aapt resource value: 0x7f09004b
-			public static int Platform_Widget_AppCompat_Spinner = 2131296331;
+			// aapt resource value: 0x7f0b000d
+			public static int CardView_Dark = 2131427341;
 			
-			// aapt resource value: 0x7f090058
-			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131296344;
+			// aapt resource value: 0x7f0b000e
+			public static int CardView_Light = 2131427342;
 			
-			// aapt resource value: 0x7f090059
-			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296345;
+			// aapt resource value: 0x7f0b002d
+			public static int Platform_AppCompat = 2131427373;
 			
-			// aapt resource value: 0x7f09005a
-			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296346;
+			// aapt resource value: 0x7f0b002e
+			public static int Platform_AppCompat_Light = 2131427374;
 			
-			// aapt resource value: 0x7f09005b
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296347;
+			// aapt resource value: 0x7f0b0094
+			public static int Platform_ThemeOverlay_AppCompat = 2131427476;
 			
-			// aapt resource value: 0x7f09005c
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296348;
+			// aapt resource value: 0x7f0b0095
+			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131427477;
 			
-			// aapt resource value: 0x7f09005d
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296349;
+			// aapt resource value: 0x7f0b0096
+			public static int Platform_ThemeOverlay_AppCompat_Light = 2131427478;
 			
-			// aapt resource value: 0x7f09005e
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296350;
+			// aapt resource value: 0x7f0b002f
+			public static int Platform_V11_AppCompat = 2131427375;
 			
-			// aapt resource value: 0x7f09005f
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296351;
+			// aapt resource value: 0x7f0b0030
+			public static int Platform_V11_AppCompat_Light = 2131427376;
 			
-			// aapt resource value: 0x7f090060
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296352;
+			// aapt resource value: 0x7f0b0037
+			public static int Platform_V14_AppCompat = 2131427383;
 			
-			// aapt resource value: 0x7f090061
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296353;
+			// aapt resource value: 0x7f0b0038
+			public static int Platform_V14_AppCompat_Light = 2131427384;
 			
-			// aapt resource value: 0x7f090062
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296354;
+			// aapt resource value: 0x7f0b0097
+			public static int Platform_V21_AppCompat = 2131427479;
 			
-			// aapt resource value: 0x7f090063
-			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296355;
+			// aapt resource value: 0x7f0b0098
+			public static int Platform_V21_AppCompat_Light = 2131427480;
 			
-			// aapt resource value: 0x7f090064
-			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131296356;
+			// aapt resource value: 0x7f0b00ac
+			public static int Platform_V25_AppCompat = 2131427500;
 			
-			// aapt resource value: 0x7f090065
-			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131296357;
+			// aapt resource value: 0x7f0b00ad
+			public static int Platform_V25_AppCompat_Light = 2131427501;
 			
-			// aapt resource value: 0x7f0900e6
-			public static int TextAppearance_AppCompat = 2131296486;
+			// aapt resource value: 0x7f0b0031
+			public static int Platform_Widget_AppCompat_Spinner = 2131427377;
 			
-			// aapt resource value: 0x7f0900e7
-			public static int TextAppearance_AppCompat_Body1 = 2131296487;
+			// aapt resource value: 0x7f0b0040
+			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131427392;
 			
-			// aapt resource value: 0x7f0900e8
-			public static int TextAppearance_AppCompat_Body2 = 2131296488;
+			// aapt resource value: 0x7f0b0041
+			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427393;
 			
-			// aapt resource value: 0x7f0900e9
-			public static int TextAppearance_AppCompat_Button = 2131296489;
+			// aapt resource value: 0x7f0b0042
+			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131427394;
 			
-			// aapt resource value: 0x7f0900ea
-			public static int TextAppearance_AppCompat_Caption = 2131296490;
+			// aapt resource value: 0x7f0b0043
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427395;
 			
-			// aapt resource value: 0x7f0900eb
-			public static int TextAppearance_AppCompat_Display1 = 2131296491;
+			// aapt resource value: 0x7f0b0044
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427396;
 			
-			// aapt resource value: 0x7f0900ec
-			public static int TextAppearance_AppCompat_Display2 = 2131296492;
+			// aapt resource value: 0x7f0b0045
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427397;
 			
-			// aapt resource value: 0x7f0900ed
-			public static int TextAppearance_AppCompat_Display3 = 2131296493;
+			// aapt resource value: 0x7f0b0046
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427398;
 			
-			// aapt resource value: 0x7f0900ee
-			public static int TextAppearance_AppCompat_Display4 = 2131296494;
+			// aapt resource value: 0x7f0b0047
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427399;
 			
-			// aapt resource value: 0x7f0900ef
-			public static int TextAppearance_AppCompat_Headline = 2131296495;
+			// aapt resource value: 0x7f0b0048
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427400;
 			
-			// aapt resource value: 0x7f0900f0
-			public static int TextAppearance_AppCompat_Inverse = 2131296496;
+			// aapt resource value: 0x7f0b0049
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427401;
 			
-			// aapt resource value: 0x7f0900f1
-			public static int TextAppearance_AppCompat_Large = 2131296497;
+			// aapt resource value: 0x7f0b004a
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427402;
 			
-			// aapt resource value: 0x7f0900f2
-			public static int TextAppearance_AppCompat_Large_Inverse = 2131296498;
+			// aapt resource value: 0x7f0b004b
+			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427403;
 			
-			// aapt resource value: 0x7f0900f3
-			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296499;
+			// aapt resource value: 0x7f0b004c
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131427404;
 			
-			// aapt resource value: 0x7f0900f4
-			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296500;
+			// aapt resource value: 0x7f0b004d
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131427405;
 			
-			// aapt resource value: 0x7f0900f5
-			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296501;
+			// aapt resource value: 0x7f0b00dd
+			public static int TextAppearance_AppCompat = 2131427549;
 			
-			// aapt resource value: 0x7f0900f6
-			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296502;
+			// aapt resource value: 0x7f0b00de
+			public static int TextAppearance_AppCompat_Body1 = 2131427550;
 			
-			// aapt resource value: 0x7f0900f7
-			public static int TextAppearance_AppCompat_Medium = 2131296503;
+			// aapt resource value: 0x7f0b00df
+			public static int TextAppearance_AppCompat_Body2 = 2131427551;
 			
-			// aapt resource value: 0x7f0900f8
-			public static int TextAppearance_AppCompat_Medium_Inverse = 2131296504;
+			// aapt resource value: 0x7f0b00e0
+			public static int TextAppearance_AppCompat_Button = 2131427552;
 			
-			// aapt resource value: 0x7f0900f9
-			public static int TextAppearance_AppCompat_Menu = 2131296505;
+			// aapt resource value: 0x7f0b00e1
+			public static int TextAppearance_AppCompat_Caption = 2131427553;
 			
-			// aapt resource value: 0x7f0900fa
-			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296506;
+			// aapt resource value: 0x7f0b00e2
+			public static int TextAppearance_AppCompat_Display1 = 2131427554;
 			
-			// aapt resource value: 0x7f0900fb
-			public static int TextAppearance_AppCompat_SearchResult_Title = 2131296507;
+			// aapt resource value: 0x7f0b00e3
+			public static int TextAppearance_AppCompat_Display2 = 2131427555;
 			
-			// aapt resource value: 0x7f0900fc
-			public static int TextAppearance_AppCompat_Small = 2131296508;
+			// aapt resource value: 0x7f0b00e4
+			public static int TextAppearance_AppCompat_Display3 = 2131427556;
 			
-			// aapt resource value: 0x7f0900fd
-			public static int TextAppearance_AppCompat_Small_Inverse = 2131296509;
+			// aapt resource value: 0x7f0b00e5
+			public static int TextAppearance_AppCompat_Display4 = 2131427557;
 			
-			// aapt resource value: 0x7f0900fe
-			public static int TextAppearance_AppCompat_Subhead = 2131296510;
+			// aapt resource value: 0x7f0b00e6
+			public static int TextAppearance_AppCompat_Headline = 2131427558;
 			
-			// aapt resource value: 0x7f0900ff
-			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131296511;
+			// aapt resource value: 0x7f0b00e7
+			public static int TextAppearance_AppCompat_Inverse = 2131427559;
 			
-			// aapt resource value: 0x7f090100
-			public static int TextAppearance_AppCompat_Title = 2131296512;
+			// aapt resource value: 0x7f0b00e8
+			public static int TextAppearance_AppCompat_Large = 2131427560;
 			
-			// aapt resource value: 0x7f090101
-			public static int TextAppearance_AppCompat_Title_Inverse = 2131296513;
+			// aapt resource value: 0x7f0b00e9
+			public static int TextAppearance_AppCompat_Large_Inverse = 2131427561;
 			
-			// aapt resource value: 0x7f090102
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296514;
+			// aapt resource value: 0x7f0b00ea
+			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427562;
 			
-			// aapt resource value: 0x7f090103
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296515;
+			// aapt resource value: 0x7f0b00eb
+			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427563;
 			
-			// aapt resource value: 0x7f090104
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296516;
+			// aapt resource value: 0x7f0b00ec
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427564;
 			
-			// aapt resource value: 0x7f090105
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296517;
+			// aapt resource value: 0x7f0b00ed
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427565;
 			
-			// aapt resource value: 0x7f090106
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296518;
+			// aapt resource value: 0x7f0b00ee
+			public static int TextAppearance_AppCompat_Medium = 2131427566;
 			
-			// aapt resource value: 0x7f090107
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296519;
+			// aapt resource value: 0x7f0b00ef
+			public static int TextAppearance_AppCompat_Medium_Inverse = 2131427567;
 			
-			// aapt resource value: 0x7f090108
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296520;
+			// aapt resource value: 0x7f0b00f0
+			public static int TextAppearance_AppCompat_Menu = 2131427568;
 			
-			// aapt resource value: 0x7f090109
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296521;
+			// aapt resource value: 0x7f0b0039
+			public static int TextAppearance_AppCompat_Notification = 2131427385;
 			
-			// aapt resource value: 0x7f09010a
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296522;
+			// aapt resource value: 0x7f0b0099
+			public static int TextAppearance_AppCompat_Notification_Info = 2131427481;
 			
-			// aapt resource value: 0x7f09010b
-			public static int TextAppearance_AppCompat_Widget_Button = 2131296523;
+			// aapt resource value: 0x7f0b009a
+			public static int TextAppearance_AppCompat_Notification_Info_Media = 2131427482;
 			
-			// aapt resource value: 0x7f09010c
-			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131296524;
+			// aapt resource value: 0x7f0b00f1
+			public static int TextAppearance_AppCompat_Notification_Line2 = 2131427569;
 			
-			// aapt resource value: 0x7f09010d
-			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131296525;
+			// aapt resource value: 0x7f0b00f2
+			public static int TextAppearance_AppCompat_Notification_Line2_Media = 2131427570;
 			
-			// aapt resource value: 0x7f09010e
-			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296526;
+			// aapt resource value: 0x7f0b009b
+			public static int TextAppearance_AppCompat_Notification_Media = 2131427483;
 			
-			// aapt resource value: 0x7f09010f
-			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296527;
+			// aapt resource value: 0x7f0b009c
+			public static int TextAppearance_AppCompat_Notification_Time = 2131427484;
 			
-			// aapt resource value: 0x7f090110
-			public static int TextAppearance_AppCompat_Widget_Switch = 2131296528;
+			// aapt resource value: 0x7f0b009d
+			public static int TextAppearance_AppCompat_Notification_Time_Media = 2131427485;
 			
-			// aapt resource value: 0x7f090111
-			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296529;
+			// aapt resource value: 0x7f0b003a
+			public static int TextAppearance_AppCompat_Notification_Title = 2131427386;
 			
-			// aapt resource value: 0x7f09001a
-			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131296282;
+			// aapt resource value: 0x7f0b009e
+			public static int TextAppearance_AppCompat_Notification_Title_Media = 2131427486;
 			
-			// aapt resource value: 0x7f09001b
-			public static int TextAppearance_Design_Counter = 2131296283;
+			// aapt resource value: 0x7f0b00f3
+			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427571;
 			
-			// aapt resource value: 0x7f09001c
-			public static int TextAppearance_Design_Counter_Overflow = 2131296284;
+			// aapt resource value: 0x7f0b00f4
+			public static int TextAppearance_AppCompat_SearchResult_Title = 2131427572;
 			
-			// aapt resource value: 0x7f09001d
-			public static int TextAppearance_Design_Error = 2131296285;
+			// aapt resource value: 0x7f0b00f5
+			public static int TextAppearance_AppCompat_Small = 2131427573;
 			
-			// aapt resource value: 0x7f09001e
-			public static int TextAppearance_Design_Hint = 2131296286;
+			// aapt resource value: 0x7f0b00f6
+			public static int TextAppearance_AppCompat_Small_Inverse = 2131427574;
 			
-			// aapt resource value: 0x7f09001f
-			public static int TextAppearance_Design_Snackbar_Message = 2131296287;
+			// aapt resource value: 0x7f0b00f7
+			public static int TextAppearance_AppCompat_Subhead = 2131427575;
 			
-			// aapt resource value: 0x7f090020
-			public static int TextAppearance_Design_Tab = 2131296288;
+			// aapt resource value: 0x7f0b00f8
+			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131427576;
 			
-			// aapt resource value: 0x7f090053
-			public static int TextAppearance_StatusBar_EventContent = 2131296339;
+			// aapt resource value: 0x7f0b00f9
+			public static int TextAppearance_AppCompat_Title = 2131427577;
 			
-			// aapt resource value: 0x7f090054
-			public static int TextAppearance_StatusBar_EventContent_Info = 2131296340;
+			// aapt resource value: 0x7f0b00fa
+			public static int TextAppearance_AppCompat_Title_Inverse = 2131427578;
 			
-			// aapt resource value: 0x7f090055
-			public static int TextAppearance_StatusBar_EventContent_Line2 = 2131296341;
+			// aapt resource value: 0x7f0b00fb
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427579;
 			
-			// aapt resource value: 0x7f090056
-			public static int TextAppearance_StatusBar_EventContent_Time = 2131296342;
+			// aapt resource value: 0x7f0b00fc
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427580;
 			
-			// aapt resource value: 0x7f090057
-			public static int TextAppearance_StatusBar_EventContent_Title = 2131296343;
+			// aapt resource value: 0x7f0b00fd
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427581;
 			
-			// aapt resource value: 0x7f090112
-			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296530;
+			// aapt resource value: 0x7f0b00fe
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427582;
 			
-			// aapt resource value: 0x7f090113
-			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296531;
+			// aapt resource value: 0x7f0b00ff
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427583;
 			
-			// aapt resource value: 0x7f090114
-			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296532;
+			// aapt resource value: 0x7f0b0100
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427584;
 			
-			// aapt resource value: 0x7f090115
-			public static int Theme_AppCompat = 2131296533;
+			// aapt resource value: 0x7f0b0101
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427585;
 			
-			// aapt resource value: 0x7f090116
-			public static int Theme_AppCompat_CompactMenu = 2131296534;
+			// aapt resource value: 0x7f0b0102
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427586;
 			
-			// aapt resource value: 0x7f090034
-			public static int Theme_AppCompat_DayNight = 2131296308;
+			// aapt resource value: 0x7f0b0103
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427587;
 			
-			// aapt resource value: 0x7f090035
-			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131296309;
+			// aapt resource value: 0x7f0b0104
+			public static int TextAppearance_AppCompat_Widget_Button = 2131427588;
 			
-			// aapt resource value: 0x7f090036
-			public static int Theme_AppCompat_DayNight_Dialog = 2131296310;
+			// aapt resource value: 0x7f0b0105
+			public static int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427589;
 			
-			// aapt resource value: 0x7f090037
-			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131296311;
+			// aapt resource value: 0x7f0b0106
+			public static int TextAppearance_AppCompat_Widget_Button_Colored = 2131427590;
 			
-			// aapt resource value: 0x7f090038
-			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131296312;
+			// aapt resource value: 0x7f0b0107
+			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131427591;
 			
-			// aapt resource value: 0x7f090039
-			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131296313;
+			// aapt resource value: 0x7f0b0108
+			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131427592;
 			
-			// aapt resource value: 0x7f09003a
-			public static int Theme_AppCompat_DayNight_NoActionBar = 2131296314;
+			// aapt resource value: 0x7f0b0109
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427593;
 			
-			// aapt resource value: 0x7f090117
-			public static int Theme_AppCompat_Dialog = 2131296535;
+			// aapt resource value: 0x7f0b010a
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427594;
 			
-			// aapt resource value: 0x7f090118
-			public static int Theme_AppCompat_Dialog_Alert = 2131296536;
+			// aapt resource value: 0x7f0b010b
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427595;
 			
-			// aapt resource value: 0x7f090119
-			public static int Theme_AppCompat_Dialog_MinWidth = 2131296537;
+			// aapt resource value: 0x7f0b010c
+			public static int TextAppearance_AppCompat_Widget_Switch = 2131427596;
 			
-			// aapt resource value: 0x7f09011a
-			public static int Theme_AppCompat_DialogWhenLarge = 2131296538;
+			// aapt resource value: 0x7f0b010d
+			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427597;
 			
-			// aapt resource value: 0x7f09011b
-			public static int Theme_AppCompat_Light = 2131296539;
+			// aapt resource value: 0x7f0b0173
+			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131427699;
 			
-			// aapt resource value: 0x7f09011c
-			public static int Theme_AppCompat_Light_DarkActionBar = 2131296540;
+			// aapt resource value: 0x7f0b0174
+			public static int TextAppearance_Design_Counter = 2131427700;
 			
-			// aapt resource value: 0x7f09011d
-			public static int Theme_AppCompat_Light_Dialog = 2131296541;
+			// aapt resource value: 0x7f0b0175
+			public static int TextAppearance_Design_Counter_Overflow = 2131427701;
 			
-			// aapt resource value: 0x7f09011e
-			public static int Theme_AppCompat_Light_Dialog_Alert = 2131296542;
+			// aapt resource value: 0x7f0b0176
+			public static int TextAppearance_Design_Error = 2131427702;
 			
-			// aapt resource value: 0x7f09011f
-			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131296543;
+			// aapt resource value: 0x7f0b0177
+			public static int TextAppearance_Design_Hint = 2131427703;
 			
-			// aapt resource value: 0x7f090120
-			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131296544;
+			// aapt resource value: 0x7f0b0178
+			public static int TextAppearance_Design_Snackbar_Message = 2131427704;
 			
-			// aapt resource value: 0x7f090121
-			public static int Theme_AppCompat_Light_NoActionBar = 2131296545;
+			// aapt resource value: 0x7f0b0179
+			public static int TextAppearance_Design_Tab = 2131427705;
 			
-			// aapt resource value: 0x7f090122
-			public static int Theme_AppCompat_NoActionBar = 2131296546;
+			// aapt resource value: 0x7f0b0000
+			public static int TextAppearance_MediaRouter_PrimaryText = 2131427328;
 			
-			// aapt resource value: 0x7f090021
-			public static int Theme_Design = 2131296289;
+			// aapt resource value: 0x7f0b0001
+			public static int TextAppearance_MediaRouter_SecondaryText = 2131427329;
 			
-			// aapt resource value: 0x7f090022
-			public static int Theme_Design_BottomSheetDialog = 2131296290;
+			// aapt resource value: 0x7f0b0002
+			public static int TextAppearance_MediaRouter_Title = 2131427330;
 			
-			// aapt resource value: 0x7f090023
-			public static int Theme_Design_Light = 2131296291;
+			// aapt resource value: 0x7f0b003b
+			public static int TextAppearance_StatusBar_EventContent = 2131427387;
 			
-			// aapt resource value: 0x7f090024
-			public static int Theme_Design_Light_BottomSheetDialog = 2131296292;
+			// aapt resource value: 0x7f0b003c
+			public static int TextAppearance_StatusBar_EventContent_Info = 2131427388;
 			
-			// aapt resource value: 0x7f090025
-			public static int Theme_Design_Light_NoActionBar = 2131296293;
+			// aapt resource value: 0x7f0b003d
+			public static int TextAppearance_StatusBar_EventContent_Line2 = 2131427389;
 			
-			// aapt resource value: 0x7f090026
-			public static int Theme_Design_NoActionBar = 2131296294;
+			// aapt resource value: 0x7f0b003e
+			public static int TextAppearance_StatusBar_EventContent_Time = 2131427390;
 			
-			// aapt resource value: 0x7f090000
-			public static int Theme_MediaRouter = 2131296256;
+			// aapt resource value: 0x7f0b003f
+			public static int TextAppearance_StatusBar_EventContent_Title = 2131427391;
 			
-			// aapt resource value: 0x7f090001
-			public static int Theme_MediaRouter_Light = 2131296257;
+			// aapt resource value: 0x7f0b010e
+			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427598;
 			
-			// aapt resource value: 0x7f090002
-			public static int Theme_MediaRouter_Light_DarkControlPanel = 2131296258;
+			// aapt resource value: 0x7f0b010f
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427599;
 			
-			// aapt resource value: 0x7f090003
-			public static int Theme_MediaRouter_LightControlPanel = 2131296259;
+			// aapt resource value: 0x7f0b0110
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427600;
 			
-			// aapt resource value: 0x7f090123
-			public static int ThemeOverlay_AppCompat = 2131296547;
+			// aapt resource value: 0x7f0b0111
+			public static int Theme_AppCompat = 2131427601;
 			
-			// aapt resource value: 0x7f090124
-			public static int ThemeOverlay_AppCompat_ActionBar = 2131296548;
+			// aapt resource value: 0x7f0b0112
+			public static int Theme_AppCompat_CompactMenu = 2131427602;
 			
-			// aapt resource value: 0x7f090125
-			public static int ThemeOverlay_AppCompat_Dark = 2131296549;
+			// aapt resource value: 0x7f0b0013
+			public static int Theme_AppCompat_DayNight = 2131427347;
 			
-			// aapt resource value: 0x7f090126
-			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296550;
+			// aapt resource value: 0x7f0b0014
+			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131427348;
 			
-			// aapt resource value: 0x7f090127
-			public static int ThemeOverlay_AppCompat_Light = 2131296551;
+			// aapt resource value: 0x7f0b0015
+			public static int Theme_AppCompat_DayNight_Dialog = 2131427349;
 			
-			// aapt resource value: 0x7f090128
-			public static int Widget_AppCompat_ActionBar = 2131296552;
+			// aapt resource value: 0x7f0b0016
+			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131427350;
 			
-			// aapt resource value: 0x7f090129
-			public static int Widget_AppCompat_ActionBar_Solid = 2131296553;
+			// aapt resource value: 0x7f0b0017
+			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131427351;
 			
-			// aapt resource value: 0x7f09012a
-			public static int Widget_AppCompat_ActionBar_TabBar = 2131296554;
+			// aapt resource value: 0x7f0b0018
+			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131427352;
 			
-			// aapt resource value: 0x7f09012b
-			public static int Widget_AppCompat_ActionBar_TabText = 2131296555;
+			// aapt resource value: 0x7f0b0019
+			public static int Theme_AppCompat_DayNight_NoActionBar = 2131427353;
 			
-			// aapt resource value: 0x7f09012c
-			public static int Widget_AppCompat_ActionBar_TabView = 2131296556;
+			// aapt resource value: 0x7f0b0113
+			public static int Theme_AppCompat_Dialog = 2131427603;
 			
-			// aapt resource value: 0x7f09012d
-			public static int Widget_AppCompat_ActionButton = 2131296557;
+			// aapt resource value: 0x7f0b0114
+			public static int Theme_AppCompat_Dialog_Alert = 2131427604;
 			
-			// aapt resource value: 0x7f09012e
-			public static int Widget_AppCompat_ActionButton_CloseMode = 2131296558;
+			// aapt resource value: 0x7f0b0115
+			public static int Theme_AppCompat_Dialog_MinWidth = 2131427605;
 			
-			// aapt resource value: 0x7f09012f
-			public static int Widget_AppCompat_ActionButton_Overflow = 2131296559;
+			// aapt resource value: 0x7f0b0116
+			public static int Theme_AppCompat_DialogWhenLarge = 2131427606;
 			
-			// aapt resource value: 0x7f090130
-			public static int Widget_AppCompat_ActionMode = 2131296560;
+			// aapt resource value: 0x7f0b0117
+			public static int Theme_AppCompat_Light = 2131427607;
 			
-			// aapt resource value: 0x7f090131
-			public static int Widget_AppCompat_ActivityChooserView = 2131296561;
+			// aapt resource value: 0x7f0b0118
+			public static int Theme_AppCompat_Light_DarkActionBar = 2131427608;
 			
-			// aapt resource value: 0x7f090132
-			public static int Widget_AppCompat_AutoCompleteTextView = 2131296562;
+			// aapt resource value: 0x7f0b0119
+			public static int Theme_AppCompat_Light_Dialog = 2131427609;
 			
-			// aapt resource value: 0x7f090133
-			public static int Widget_AppCompat_Button = 2131296563;
+			// aapt resource value: 0x7f0b011a
+			public static int Theme_AppCompat_Light_Dialog_Alert = 2131427610;
 			
-			// aapt resource value: 0x7f090134
-			public static int Widget_AppCompat_Button_Borderless = 2131296564;
+			// aapt resource value: 0x7f0b011b
+			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131427611;
 			
-			// aapt resource value: 0x7f090135
-			public static int Widget_AppCompat_Button_Borderless_Colored = 2131296565;
+			// aapt resource value: 0x7f0b011c
+			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131427612;
 			
-			// aapt resource value: 0x7f090136
-			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296566;
+			// aapt resource value: 0x7f0b011d
+			public static int Theme_AppCompat_Light_NoActionBar = 2131427613;
 			
-			// aapt resource value: 0x7f090137
-			public static int Widget_AppCompat_Button_Colored = 2131296567;
+			// aapt resource value: 0x7f0b011e
+			public static int Theme_AppCompat_NoActionBar = 2131427614;
 			
-			// aapt resource value: 0x7f090138
-			public static int Widget_AppCompat_Button_Small = 2131296568;
+			// aapt resource value: 0x7f0b017a
+			public static int Theme_Design = 2131427706;
 			
-			// aapt resource value: 0x7f090139
-			public static int Widget_AppCompat_ButtonBar = 2131296569;
+			// aapt resource value: 0x7f0b017b
+			public static int Theme_Design_BottomSheetDialog = 2131427707;
 			
-			// aapt resource value: 0x7f09013a
-			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131296570;
+			// aapt resource value: 0x7f0b017c
+			public static int Theme_Design_Light = 2131427708;
 			
-			// aapt resource value: 0x7f09013b
-			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131296571;
+			// aapt resource value: 0x7f0b017d
+			public static int Theme_Design_Light_BottomSheetDialog = 2131427709;
 			
-			// aapt resource value: 0x7f09013c
-			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131296572;
+			// aapt resource value: 0x7f0b017e
+			public static int Theme_Design_Light_NoActionBar = 2131427710;
 			
-			// aapt resource value: 0x7f09013d
-			public static int Widget_AppCompat_CompoundButton_Switch = 2131296573;
+			// aapt resource value: 0x7f0b017f
+			public static int Theme_Design_NoActionBar = 2131427711;
 			
-			// aapt resource value: 0x7f09013e
-			public static int Widget_AppCompat_DrawerArrowToggle = 2131296574;
+			// aapt resource value: 0x7f0b0003
+			public static int Theme_MediaRouter = 2131427331;
 			
-			// aapt resource value: 0x7f09013f
-			public static int Widget_AppCompat_DropDownItem_Spinner = 2131296575;
+			// aapt resource value: 0x7f0b0004
+			public static int Theme_MediaRouter_Light = 2131427332;
 			
-			// aapt resource value: 0x7f090140
-			public static int Widget_AppCompat_EditText = 2131296576;
+			// aapt resource value: 0x7f0b0005
+			public static int Theme_MediaRouter_Light_DarkControlPanel = 2131427333;
 			
-			// aapt resource value: 0x7f090141
-			public static int Widget_AppCompat_ImageButton = 2131296577;
+			// aapt resource value: 0x7f0b0006
+			public static int Theme_MediaRouter_LightControlPanel = 2131427334;
 			
-			// aapt resource value: 0x7f090142
-			public static int Widget_AppCompat_Light_ActionBar = 2131296578;
+			// aapt resource value: 0x7f0b011f
+			public static int ThemeOverlay_AppCompat = 2131427615;
 			
-			// aapt resource value: 0x7f090143
-			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131296579;
+			// aapt resource value: 0x7f0b0120
+			public static int ThemeOverlay_AppCompat_ActionBar = 2131427616;
 			
-			// aapt resource value: 0x7f090144
-			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296580;
+			// aapt resource value: 0x7f0b0121
+			public static int ThemeOverlay_AppCompat_Dark = 2131427617;
 			
-			// aapt resource value: 0x7f090145
-			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131296581;
+			// aapt resource value: 0x7f0b0122
+			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427618;
 			
-			// aapt resource value: 0x7f090146
-			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296582;
+			// aapt resource value: 0x7f0b0123
+			public static int ThemeOverlay_AppCompat_Dialog = 2131427619;
 			
-			// aapt resource value: 0x7f090147
-			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131296583;
+			// aapt resource value: 0x7f0b0124
+			public static int ThemeOverlay_AppCompat_Dialog_Alert = 2131427620;
 			
-			// aapt resource value: 0x7f090148
-			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296584;
+			// aapt resource value: 0x7f0b0125
+			public static int ThemeOverlay_AppCompat_Light = 2131427621;
 			
-			// aapt resource value: 0x7f090149
-			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131296585;
+			// aapt resource value: 0x7f0b0007
+			public static int ThemeOverlay_MediaRouter_Dark = 2131427335;
 			
-			// aapt resource value: 0x7f09014a
-			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296586;
+			// aapt resource value: 0x7f0b0008
+			public static int ThemeOverlay_MediaRouter_Light = 2131427336;
 			
-			// aapt resource value: 0x7f09014b
-			public static int Widget_AppCompat_Light_ActionButton = 2131296587;
+			// aapt resource value: 0x7f0b0126
+			public static int Widget_AppCompat_ActionBar = 2131427622;
 			
-			// aapt resource value: 0x7f09014c
-			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296588;
+			// aapt resource value: 0x7f0b0127
+			public static int Widget_AppCompat_ActionBar_Solid = 2131427623;
 			
-			// aapt resource value: 0x7f09014d
-			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131296589;
+			// aapt resource value: 0x7f0b0128
+			public static int Widget_AppCompat_ActionBar_TabBar = 2131427624;
 			
-			// aapt resource value: 0x7f09014e
-			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131296590;
+			// aapt resource value: 0x7f0b0129
+			public static int Widget_AppCompat_ActionBar_TabText = 2131427625;
 			
-			// aapt resource value: 0x7f09014f
-			public static int Widget_AppCompat_Light_ActivityChooserView = 2131296591;
+			// aapt resource value: 0x7f0b012a
+			public static int Widget_AppCompat_ActionBar_TabView = 2131427626;
 			
-			// aapt resource value: 0x7f090150
-			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131296592;
+			// aapt resource value: 0x7f0b012b
+			public static int Widget_AppCompat_ActionButton = 2131427627;
 			
-			// aapt resource value: 0x7f090151
-			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296593;
+			// aapt resource value: 0x7f0b012c
+			public static int Widget_AppCompat_ActionButton_CloseMode = 2131427628;
 			
-			// aapt resource value: 0x7f090152
-			public static int Widget_AppCompat_Light_ListPopupWindow = 2131296594;
+			// aapt resource value: 0x7f0b012d
+			public static int Widget_AppCompat_ActionButton_Overflow = 2131427629;
 			
-			// aapt resource value: 0x7f090153
-			public static int Widget_AppCompat_Light_ListView_DropDown = 2131296595;
+			// aapt resource value: 0x7f0b012e
+			public static int Widget_AppCompat_ActionMode = 2131427630;
 			
-			// aapt resource value: 0x7f090154
-			public static int Widget_AppCompat_Light_PopupMenu = 2131296596;
+			// aapt resource value: 0x7f0b012f
+			public static int Widget_AppCompat_ActivityChooserView = 2131427631;
 			
-			// aapt resource value: 0x7f090155
-			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296597;
+			// aapt resource value: 0x7f0b0130
+			public static int Widget_AppCompat_AutoCompleteTextView = 2131427632;
 			
-			// aapt resource value: 0x7f090156
-			public static int Widget_AppCompat_Light_SearchView = 2131296598;
+			// aapt resource value: 0x7f0b0131
+			public static int Widget_AppCompat_Button = 2131427633;
 			
-			// aapt resource value: 0x7f090157
-			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296599;
+			// aapt resource value: 0x7f0b0132
+			public static int Widget_AppCompat_Button_Borderless = 2131427634;
 			
-			// aapt resource value: 0x7f090158
-			public static int Widget_AppCompat_ListPopupWindow = 2131296600;
+			// aapt resource value: 0x7f0b0133
+			public static int Widget_AppCompat_Button_Borderless_Colored = 2131427635;
 			
-			// aapt resource value: 0x7f090159
-			public static int Widget_AppCompat_ListView = 2131296601;
+			// aapt resource value: 0x7f0b0134
+			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427636;
 			
-			// aapt resource value: 0x7f09015a
-			public static int Widget_AppCompat_ListView_DropDown = 2131296602;
+			// aapt resource value: 0x7f0b0135
+			public static int Widget_AppCompat_Button_Colored = 2131427637;
 			
-			// aapt resource value: 0x7f09015b
-			public static int Widget_AppCompat_ListView_Menu = 2131296603;
+			// aapt resource value: 0x7f0b0136
+			public static int Widget_AppCompat_Button_Small = 2131427638;
 			
-			// aapt resource value: 0x7f09015c
-			public static int Widget_AppCompat_PopupMenu = 2131296604;
+			// aapt resource value: 0x7f0b0137
+			public static int Widget_AppCompat_ButtonBar = 2131427639;
 			
-			// aapt resource value: 0x7f09015d
-			public static int Widget_AppCompat_PopupMenu_Overflow = 2131296605;
+			// aapt resource value: 0x7f0b0138
+			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131427640;
 			
-			// aapt resource value: 0x7f09015e
-			public static int Widget_AppCompat_PopupWindow = 2131296606;
+			// aapt resource value: 0x7f0b0139
+			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131427641;
 			
-			// aapt resource value: 0x7f09015f
-			public static int Widget_AppCompat_ProgressBar = 2131296607;
+			// aapt resource value: 0x7f0b013a
+			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131427642;
 			
-			// aapt resource value: 0x7f090160
-			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131296608;
+			// aapt resource value: 0x7f0b013b
+			public static int Widget_AppCompat_CompoundButton_Switch = 2131427643;
 			
-			// aapt resource value: 0x7f090161
-			public static int Widget_AppCompat_RatingBar = 2131296609;
+			// aapt resource value: 0x7f0b013c
+			public static int Widget_AppCompat_DrawerArrowToggle = 2131427644;
 			
-			// aapt resource value: 0x7f090162
-			public static int Widget_AppCompat_RatingBar_Indicator = 2131296610;
+			// aapt resource value: 0x7f0b013d
+			public static int Widget_AppCompat_DropDownItem_Spinner = 2131427645;
 			
-			// aapt resource value: 0x7f090163
-			public static int Widget_AppCompat_RatingBar_Small = 2131296611;
+			// aapt resource value: 0x7f0b013e
+			public static int Widget_AppCompat_EditText = 2131427646;
 			
-			// aapt resource value: 0x7f090164
-			public static int Widget_AppCompat_SearchView = 2131296612;
+			// aapt resource value: 0x7f0b013f
+			public static int Widget_AppCompat_ImageButton = 2131427647;
 			
-			// aapt resource value: 0x7f090165
-			public static int Widget_AppCompat_SearchView_ActionBar = 2131296613;
+			// aapt resource value: 0x7f0b0140
+			public static int Widget_AppCompat_Light_ActionBar = 2131427648;
 			
-			// aapt resource value: 0x7f090166
-			public static int Widget_AppCompat_SeekBar = 2131296614;
+			// aapt resource value: 0x7f0b0141
+			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131427649;
 			
-			// aapt resource value: 0x7f090167
-			public static int Widget_AppCompat_Spinner = 2131296615;
+			// aapt resource value: 0x7f0b0142
+			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427650;
 			
-			// aapt resource value: 0x7f090168
-			public static int Widget_AppCompat_Spinner_DropDown = 2131296616;
+			// aapt resource value: 0x7f0b0143
+			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131427651;
 			
-			// aapt resource value: 0x7f090169
-			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296617;
+			// aapt resource value: 0x7f0b0144
+			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427652;
 			
-			// aapt resource value: 0x7f09016a
-			public static int Widget_AppCompat_Spinner_Underlined = 2131296618;
+			// aapt resource value: 0x7f0b0145
+			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131427653;
 			
-			// aapt resource value: 0x7f09016b
-			public static int Widget_AppCompat_TextView_SpinnerItem = 2131296619;
+			// aapt resource value: 0x7f0b0146
+			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427654;
 			
-			// aapt resource value: 0x7f09016c
-			public static int Widget_AppCompat_Toolbar = 2131296620;
+			// aapt resource value: 0x7f0b0147
+			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131427655;
 			
-			// aapt resource value: 0x7f09016d
-			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131296621;
+			// aapt resource value: 0x7f0b0148
+			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427656;
 			
-			// aapt resource value: 0x7f090027
-			public static int Widget_Design_AppBarLayout = 2131296295;
+			// aapt resource value: 0x7f0b0149
+			public static int Widget_AppCompat_Light_ActionButton = 2131427657;
 			
-			// aapt resource value: 0x7f090028
-			public static int Widget_Design_BottomSheet_Modal = 2131296296;
+			// aapt resource value: 0x7f0b014a
+			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427658;
 			
-			// aapt resource value: 0x7f090029
-			public static int Widget_Design_CollapsingToolbar = 2131296297;
+			// aapt resource value: 0x7f0b014b
+			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131427659;
 			
-			// aapt resource value: 0x7f09002a
-			public static int Widget_Design_CoordinatorLayout = 2131296298;
+			// aapt resource value: 0x7f0b014c
+			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131427660;
 			
-			// aapt resource value: 0x7f09002b
-			public static int Widget_Design_FloatingActionButton = 2131296299;
+			// aapt resource value: 0x7f0b014d
+			public static int Widget_AppCompat_Light_ActivityChooserView = 2131427661;
 			
-			// aapt resource value: 0x7f09002c
-			public static int Widget_Design_NavigationView = 2131296300;
+			// aapt resource value: 0x7f0b014e
+			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131427662;
 			
-			// aapt resource value: 0x7f09002d
-			public static int Widget_Design_ScrimInsetsFrameLayout = 2131296301;
+			// aapt resource value: 0x7f0b014f
+			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427663;
 			
-			// aapt resource value: 0x7f09002e
-			public static int Widget_Design_Snackbar = 2131296302;
+			// aapt resource value: 0x7f0b0150
+			public static int Widget_AppCompat_Light_ListPopupWindow = 2131427664;
 			
-			// aapt resource value: 0x7f090017
-			public static int Widget_Design_TabLayout = 2131296279;
+			// aapt resource value: 0x7f0b0151
+			public static int Widget_AppCompat_Light_ListView_DropDown = 2131427665;
 			
-			// aapt resource value: 0x7f09002f
-			public static int Widget_Design_TextInputLayout = 2131296303;
+			// aapt resource value: 0x7f0b0152
+			public static int Widget_AppCompat_Light_PopupMenu = 2131427666;
 			
-			// aapt resource value: 0x7f090004
-			public static int Widget_MediaRouter_ChooserText = 2131296260;
+			// aapt resource value: 0x7f0b0153
+			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427667;
 			
-			// aapt resource value: 0x7f090005
-			public static int Widget_MediaRouter_ChooserText_Primary = 2131296261;
+			// aapt resource value: 0x7f0b0154
+			public static int Widget_AppCompat_Light_SearchView = 2131427668;
 			
-			// aapt resource value: 0x7f090006
-			public static int Widget_MediaRouter_ChooserText_Primary_Dark = 2131296262;
+			// aapt resource value: 0x7f0b0155
+			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427669;
 			
-			// aapt resource value: 0x7f090007
-			public static int Widget_MediaRouter_ChooserText_Primary_Light = 2131296263;
+			// aapt resource value: 0x7f0b0156
+			public static int Widget_AppCompat_ListMenuView = 2131427670;
 			
-			// aapt resource value: 0x7f090008
-			public static int Widget_MediaRouter_ChooserText_Secondary = 2131296264;
+			// aapt resource value: 0x7f0b0157
+			public static int Widget_AppCompat_ListPopupWindow = 2131427671;
 			
-			// aapt resource value: 0x7f090009
-			public static int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131296265;
+			// aapt resource value: 0x7f0b0158
+			public static int Widget_AppCompat_ListView = 2131427672;
 			
-			// aapt resource value: 0x7f09000a
-			public static int Widget_MediaRouter_ChooserText_Secondary_Light = 2131296266;
+			// aapt resource value: 0x7f0b0159
+			public static int Widget_AppCompat_ListView_DropDown = 2131427673;
 			
-			// aapt resource value: 0x7f09000b
-			public static int Widget_MediaRouter_ControllerText = 2131296267;
+			// aapt resource value: 0x7f0b015a
+			public static int Widget_AppCompat_ListView_Menu = 2131427674;
 			
-			// aapt resource value: 0x7f09000c
-			public static int Widget_MediaRouter_ControllerText_Primary = 2131296268;
+			// aapt resource value: 0x7f0b009f
+			public static int Widget_AppCompat_NotificationActionContainer = 2131427487;
 			
-			// aapt resource value: 0x7f09000d
-			public static int Widget_MediaRouter_ControllerText_Primary_Dark = 2131296269;
+			// aapt resource value: 0x7f0b00a0
+			public static int Widget_AppCompat_NotificationActionText = 2131427488;
 			
-			// aapt resource value: 0x7f09000e
-			public static int Widget_MediaRouter_ControllerText_Primary_Light = 2131296270;
+			// aapt resource value: 0x7f0b015b
+			public static int Widget_AppCompat_PopupMenu = 2131427675;
 			
-			// aapt resource value: 0x7f09000f
-			public static int Widget_MediaRouter_ControllerText_Secondary = 2131296271;
+			// aapt resource value: 0x7f0b015c
+			public static int Widget_AppCompat_PopupMenu_Overflow = 2131427676;
 			
-			// aapt resource value: 0x7f090010
-			public static int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131296272;
+			// aapt resource value: 0x7f0b015d
+			public static int Widget_AppCompat_PopupWindow = 2131427677;
 			
-			// aapt resource value: 0x7f090011
-			public static int Widget_MediaRouter_ControllerText_Secondary_Light = 2131296273;
+			// aapt resource value: 0x7f0b015e
+			public static int Widget_AppCompat_ProgressBar = 2131427678;
 			
-			// aapt resource value: 0x7f090012
-			public static int Widget_MediaRouter_ControllerText_Title = 2131296274;
+			// aapt resource value: 0x7f0b015f
+			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131427679;
 			
-			// aapt resource value: 0x7f090013
-			public static int Widget_MediaRouter_ControllerText_Title_Dark = 2131296275;
+			// aapt resource value: 0x7f0b0160
+			public static int Widget_AppCompat_RatingBar = 2131427680;
 			
-			// aapt resource value: 0x7f090014
-			public static int Widget_MediaRouter_ControllerText_Title_Light = 2131296276;
+			// aapt resource value: 0x7f0b0161
+			public static int Widget_AppCompat_RatingBar_Indicator = 2131427681;
 			
-			// aapt resource value: 0x7f090015
-			public static int Widget_MediaRouter_Light_MediaRouteButton = 2131296277;
+			// aapt resource value: 0x7f0b0162
+			public static int Widget_AppCompat_RatingBar_Small = 2131427682;
 			
-			// aapt resource value: 0x7f090016
-			public static int Widget_MediaRouter_MediaRouteButton = 2131296278;
+			// aapt resource value: 0x7f0b0163
+			public static int Widget_AppCompat_SearchView = 2131427683;
+			
+			// aapt resource value: 0x7f0b0164
+			public static int Widget_AppCompat_SearchView_ActionBar = 2131427684;
+			
+			// aapt resource value: 0x7f0b0165
+			public static int Widget_AppCompat_SeekBar = 2131427685;
+			
+			// aapt resource value: 0x7f0b0166
+			public static int Widget_AppCompat_SeekBar_Discrete = 2131427686;
+			
+			// aapt resource value: 0x7f0b0167
+			public static int Widget_AppCompat_Spinner = 2131427687;
+			
+			// aapt resource value: 0x7f0b0168
+			public static int Widget_AppCompat_Spinner_DropDown = 2131427688;
+			
+			// aapt resource value: 0x7f0b0169
+			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427689;
+			
+			// aapt resource value: 0x7f0b016a
+			public static int Widget_AppCompat_Spinner_Underlined = 2131427690;
+			
+			// aapt resource value: 0x7f0b016b
+			public static int Widget_AppCompat_TextView_SpinnerItem = 2131427691;
+			
+			// aapt resource value: 0x7f0b016c
+			public static int Widget_AppCompat_Toolbar = 2131427692;
+			
+			// aapt resource value: 0x7f0b016d
+			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131427693;
+			
+			// aapt resource value: 0x7f0b016f
+			public static int Widget_Design_AppBarLayout = 2131427695;
+			
+			// aapt resource value: 0x7f0b0180
+			public static int Widget_Design_BottomNavigationView = 2131427712;
+			
+			// aapt resource value: 0x7f0b0181
+			public static int Widget_Design_BottomSheet_Modal = 2131427713;
+			
+			// aapt resource value: 0x7f0b0182
+			public static int Widget_Design_CollapsingToolbar = 2131427714;
+			
+			// aapt resource value: 0x7f0b0183
+			public static int Widget_Design_CoordinatorLayout = 2131427715;
+			
+			// aapt resource value: 0x7f0b0184
+			public static int Widget_Design_FloatingActionButton = 2131427716;
+			
+			// aapt resource value: 0x7f0b0185
+			public static int Widget_Design_NavigationView = 2131427717;
+			
+			// aapt resource value: 0x7f0b0186
+			public static int Widget_Design_ScrimInsetsFrameLayout = 2131427718;
+			
+			// aapt resource value: 0x7f0b0187
+			public static int Widget_Design_Snackbar = 2131427719;
+			
+			// aapt resource value: 0x7f0b016e
+			public static int Widget_Design_TabLayout = 2131427694;
+			
+			// aapt resource value: 0x7f0b0188
+			public static int Widget_Design_TextInputLayout = 2131427720;
+			
+			// aapt resource value: 0x7f0b0009
+			public static int Widget_MediaRouter_Light_MediaRouteButton = 2131427337;
+			
+			// aapt resource value: 0x7f0b000a
+			public static int Widget_MediaRouter_MediaRouteButton = 2131427338;
 			
 			static Style()
 			{
@@ -4250,33 +5064,35 @@ namespace FAB.Droid
 			
 			public static int[] ActionBar = new int[]
 			{
-					2130772061,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074,
-					2130772075,
-					2130772076,
-					2130772077,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772144};
+					2130771997,
+					2130771999,
+					2130772000,
+					2130772001,
+					2130772002,
+					2130772003,
+					2130772004,
+					2130772005,
+					2130772006,
+					2130772007,
+					2130772008,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012,
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772087};
 			
 			// aapt resource value: 10
 			public static int ActionBar_background = 10;
@@ -4290,6 +5106,9 @@ namespace FAB.Droid
 			// aapt resource value: 21
 			public static int ActionBar_contentInsetEnd = 21;
 			
+			// aapt resource value: 25
+			public static int ActionBar_contentInsetEndWithActions = 25;
+			
 			// aapt resource value: 22
 			public static int ActionBar_contentInsetLeft = 22;
 			
@@ -4298,6 +5117,9 @@ namespace FAB.Droid
 			
 			// aapt resource value: 20
 			public static int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public static int ActionBar_contentInsetStartWithNavigation = 24;
 			
 			// aapt resource value: 13
 			public static int ActionBar_customNavigationLayout = 13;
@@ -4308,8 +5130,8 @@ namespace FAB.Droid
 			// aapt resource value: 9
 			public static int ActionBar_divider = 9;
 			
-			// aapt resource value: 24
-			public static int ActionBar_elevation = 24;
+			// aapt resource value: 26
+			public static int ActionBar_elevation = 26;
 			
 			// aapt resource value: 0
 			public static int ActionBar_height = 0;
@@ -4317,8 +5139,8 @@ namespace FAB.Droid
 			// aapt resource value: 19
 			public static int ActionBar_hideOnContentScroll = 19;
 			
-			// aapt resource value: 26
-			public static int ActionBar_homeAsUpIndicator = 26;
+			// aapt resource value: 28
+			public static int ActionBar_homeAsUpIndicator = 28;
 			
 			// aapt resource value: 14
 			public static int ActionBar_homeLayout = 14;
@@ -4338,8 +5160,8 @@ namespace FAB.Droid
 			// aapt resource value: 2
 			public static int ActionBar_navigationMode = 2;
 			
-			// aapt resource value: 25
-			public static int ActionBar_popupTheme = 25;
+			// aapt resource value: 27
+			public static int ActionBar_popupTheme = 27;
 			
 			// aapt resource value: 17
 			public static int ActionBar_progressBarPadding = 17;
@@ -4377,12 +5199,12 @@ namespace FAB.Droid
 			
 			public static int[] ActionMode = new int[]
 			{
-					2130772061,
-					2130772067,
-					2130772068,
-					2130772072,
-					2130772074,
-					2130772088};
+					2130771997,
+					2130772003,
+					2130772004,
+					2130772008,
+					2130772010,
+					2130772026};
 			
 			// aapt resource value: 3
 			public static int ActionMode_background = 3;
@@ -4404,8 +5226,8 @@ namespace FAB.Droid
 			
 			public static int[] ActivityChooserView = new int[]
 			{
-					2130772089,
-					2130772090};
+					2130772027,
+					2130772028};
 			
 			// aapt resource value: 1
 			public static int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -4416,11 +5238,12 @@ namespace FAB.Droid
 			public static int[] AlertDialog = new int[]
 			{
 					16842994,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095};
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 0
 			public static int AlertDialog_android_layout = 0;
@@ -4437,39 +5260,53 @@ namespace FAB.Droid
 			// aapt resource value: 3
 			public static int AlertDialog_multiChoiceItemLayout = 3;
 			
+			// aapt resource value: 6
+			public static int AlertDialog_showTitle = 6;
+			
 			// aapt resource value: 4
 			public static int AlertDialog_singleChoiceItemLayout = 4;
 			
 			public static int[] AppBarLayout = new int[]
 			{
 					16842964,
-					2130771991,
-					2130772086};
+					2130772024,
+					2130772224};
 			
 			// aapt resource value: 0
 			public static int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 2
-			public static int AppBarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public static int AppBarLayout_expanded = 1;
+			public static int AppBarLayout_elevation = 1;
 			
-			public static int[] AppBarLayout_LayoutParams = new int[]
+			// aapt resource value: 2
+			public static int AppBarLayout_expanded = 2;
+			
+			public static int[] AppBarLayoutStates = new int[]
 			{
-					2130771992,
-					2130771993};
+					2130772225,
+					2130772226};
 			
 			// aapt resource value: 0
-			public static int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
+			public static int AppBarLayoutStates_state_collapsed = 0;
 			
 			// aapt resource value: 1
-			public static int AppBarLayout_LayoutParams_layout_scrollInterpolator = 1;
+			public static int AppBarLayoutStates_state_collapsible = 1;
+			
+			public static int[] AppBarLayout_Layout = new int[]
+			{
+					2130772227,
+					2130772228};
+			
+			// aapt resource value: 0
+			public static int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public static int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
 			public static int[] AppCompatImageView = new int[]
 			{
 					16843033,
-					2130772096};
+					2130772035};
 			
 			// aapt resource value: 0
 			public static int AppCompatImageView_android_src = 0;
@@ -4477,10 +5314,60 @@ namespace FAB.Droid
 			// aapt resource value: 1
 			public static int AppCompatImageView_srcCompat = 1;
 			
+			public static int[] AppCompatSeekBar = new int[]
+			{
+					16843074,
+					2130772036,
+					2130772037,
+					2130772038};
+			
+			// aapt resource value: 0
+			public static int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public static int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public static int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[]
+			{
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public static int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public static int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public static int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public static int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public static int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public static int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public static int AppCompatTextHelper_android_textAppearance = 0;
+			
 			public static int[] AppCompatTextView = new int[]
 			{
 					16842804,
-					2130772097};
+					2130772039};
 			
 			// aapt resource value: 0
 			public static int AppCompatTextView_android_textAppearance = 0;
@@ -4492,6 +5379,64 @@ namespace FAB.Droid
 			{
 					16842839,
 					16842926,
+					2130772040,
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065,
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074,
+					2130772075,
+					2130772076,
+					2130772077,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
 					2130772098,
 					2130772099,
 					2130772100,
@@ -4546,62 +5491,7 @@ namespace FAB.Droid
 					2130772149,
 					2130772150,
 					2130772151,
-					2130772152,
-					2130772153,
-					2130772154,
-					2130772155,
-					2130772156,
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164,
-					2130772165,
-					2130772166,
-					2130772167,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171,
-					2130772172,
-					2130772173,
-					2130772174,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207};
+					2130772152};
 			
 			// aapt resource value: 23
 			public static int AppCompatTheme_actionBarDivider = 23;
@@ -4636,11 +5526,11 @@ namespace FAB.Droid
 			// aapt resource value: 21
 			public static int AppCompatTheme_actionBarWidgetTheme = 21;
 			
-			// aapt resource value: 49
-			public static int AppCompatTheme_actionButtonStyle = 49;
+			// aapt resource value: 50
+			public static int AppCompatTheme_actionButtonStyle = 50;
 			
-			// aapt resource value: 45
-			public static int AppCompatTheme_actionDropDownStyle = 45;
+			// aapt resource value: 46
+			public static int AppCompatTheme_actionDropDownStyle = 46;
 			
 			// aapt resource value: 25
 			public static int AppCompatTheme_actionMenuTextAppearance = 25;
@@ -4693,20 +5583,20 @@ namespace FAB.Droid
 			// aapt resource value: 16
 			public static int AppCompatTheme_actionOverflowMenuStyle = 16;
 			
-			// aapt resource value: 57
-			public static int AppCompatTheme_activityChooserViewStyle = 57;
-			
-			// aapt resource value: 92
-			public static int AppCompatTheme_alertDialogButtonGroupStyle = 92;
-			
-			// aapt resource value: 93
-			public static int AppCompatTheme_alertDialogCenterButtons = 93;
-			
-			// aapt resource value: 91
-			public static int AppCompatTheme_alertDialogStyle = 91;
+			// aapt resource value: 58
+			public static int AppCompatTheme_activityChooserViewStyle = 58;
 			
 			// aapt resource value: 94
-			public static int AppCompatTheme_alertDialogTheme = 94;
+			public static int AppCompatTheme_alertDialogButtonGroupStyle = 94;
+			
+			// aapt resource value: 95
+			public static int AppCompatTheme_alertDialogCenterButtons = 95;
+			
+			// aapt resource value: 93
+			public static int AppCompatTheme_alertDialogStyle = 93;
+			
+			// aapt resource value: 96
+			public static int AppCompatTheme_alertDialogTheme = 96;
 			
 			// aapt resource value: 1
 			public static int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -4714,200 +5604,209 @@ namespace FAB.Droid
 			// aapt resource value: 0
 			public static int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 99
-			public static int AppCompatTheme_autoCompleteTextViewStyle = 99;
-			
-			// aapt resource value: 54
-			public static int AppCompatTheme_borderlessButtonStyle = 54;
-			
-			// aapt resource value: 51
-			public static int AppCompatTheme_buttonBarButtonStyle = 51;
-			
-			// aapt resource value: 97
-			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 97;
-			
-			// aapt resource value: 98
-			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 98;
-			
-			// aapt resource value: 96
-			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 96;
-			
-			// aapt resource value: 50
-			public static int AppCompatTheme_buttonBarStyle = 50;
-			
-			// aapt resource value: 100
-			public static int AppCompatTheme_buttonStyle = 100;
-			
 			// aapt resource value: 101
-			public static int AppCompatTheme_buttonStyleSmall = 101;
-			
-			// aapt resource value: 102
-			public static int AppCompatTheme_checkboxStyle = 102;
-			
-			// aapt resource value: 103
-			public static int AppCompatTheme_checkedTextViewStyle = 103;
-			
-			// aapt resource value: 84
-			public static int AppCompatTheme_colorAccent = 84;
-			
-			// aapt resource value: 88
-			public static int AppCompatTheme_colorButtonNormal = 88;
-			
-			// aapt resource value: 86
-			public static int AppCompatTheme_colorControlActivated = 86;
-			
-			// aapt resource value: 87
-			public static int AppCompatTheme_colorControlHighlight = 87;
-			
-			// aapt resource value: 85
-			public static int AppCompatTheme_colorControlNormal = 85;
-			
-			// aapt resource value: 82
-			public static int AppCompatTheme_colorPrimary = 82;
-			
-			// aapt resource value: 83
-			public static int AppCompatTheme_colorPrimaryDark = 83;
-			
-			// aapt resource value: 89
-			public static int AppCompatTheme_colorSwitchThumbNormal = 89;
-			
-			// aapt resource value: 90
-			public static int AppCompatTheme_controlBackground = 90;
-			
-			// aapt resource value: 43
-			public static int AppCompatTheme_dialogPreferredPadding = 43;
-			
-			// aapt resource value: 42
-			public static int AppCompatTheme_dialogTheme = 42;
-			
-			// aapt resource value: 56
-			public static int AppCompatTheme_dividerHorizontal = 56;
+			public static int AppCompatTheme_autoCompleteTextViewStyle = 101;
 			
 			// aapt resource value: 55
-			public static int AppCompatTheme_dividerVertical = 55;
-			
-			// aapt resource value: 74
-			public static int AppCompatTheme_dropDownListViewStyle = 74;
-			
-			// aapt resource value: 46
-			public static int AppCompatTheme_dropdownListPreferredItemHeight = 46;
-			
-			// aapt resource value: 63
-			public static int AppCompatTheme_editTextBackground = 63;
-			
-			// aapt resource value: 62
-			public static int AppCompatTheme_editTextColor = 62;
-			
-			// aapt resource value: 104
-			public static int AppCompatTheme_editTextStyle = 104;
-			
-			// aapt resource value: 48
-			public static int AppCompatTheme_homeAsUpIndicator = 48;
-			
-			// aapt resource value: 64
-			public static int AppCompatTheme_imageButtonStyle = 64;
-			
-			// aapt resource value: 81
-			public static int AppCompatTheme_listChoiceBackgroundIndicator = 81;
-			
-			// aapt resource value: 44
-			public static int AppCompatTheme_listDividerAlertDialog = 44;
-			
-			// aapt resource value: 75
-			public static int AppCompatTheme_listPopupWindowStyle = 75;
-			
-			// aapt resource value: 69
-			public static int AppCompatTheme_listPreferredItemHeight = 69;
-			
-			// aapt resource value: 71
-			public static int AppCompatTheme_listPreferredItemHeightLarge = 71;
-			
-			// aapt resource value: 70
-			public static int AppCompatTheme_listPreferredItemHeightSmall = 70;
-			
-			// aapt resource value: 72
-			public static int AppCompatTheme_listPreferredItemPaddingLeft = 72;
-			
-			// aapt resource value: 73
-			public static int AppCompatTheme_listPreferredItemPaddingRight = 73;
-			
-			// aapt resource value: 78
-			public static int AppCompatTheme_panelBackground = 78;
-			
-			// aapt resource value: 80
-			public static int AppCompatTheme_panelMenuListTheme = 80;
-			
-			// aapt resource value: 79
-			public static int AppCompatTheme_panelMenuListWidth = 79;
-			
-			// aapt resource value: 60
-			public static int AppCompatTheme_popupMenuStyle = 60;
-			
-			// aapt resource value: 61
-			public static int AppCompatTheme_popupWindowStyle = 61;
-			
-			// aapt resource value: 105
-			public static int AppCompatTheme_radioButtonStyle = 105;
-			
-			// aapt resource value: 106
-			public static int AppCompatTheme_ratingBarStyle = 106;
-			
-			// aapt resource value: 107
-			public static int AppCompatTheme_ratingBarStyleIndicator = 107;
-			
-			// aapt resource value: 108
-			public static int AppCompatTheme_ratingBarStyleSmall = 108;
-			
-			// aapt resource value: 68
-			public static int AppCompatTheme_searchViewStyle = 68;
-			
-			// aapt resource value: 109
-			public static int AppCompatTheme_seekBarStyle = 109;
+			public static int AppCompatTheme_borderlessButtonStyle = 55;
 			
 			// aapt resource value: 52
-			public static int AppCompatTheme_selectableItemBackground = 52;
+			public static int AppCompatTheme_buttonBarButtonStyle = 52;
 			
-			// aapt resource value: 53
-			public static int AppCompatTheme_selectableItemBackgroundBorderless = 53;
+			// aapt resource value: 99
+			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 99;
+			
+			// aapt resource value: 100
+			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 100;
+			
+			// aapt resource value: 98
+			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 98;
+			
+			// aapt resource value: 51
+			public static int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 102
+			public static int AppCompatTheme_buttonStyle = 102;
+			
+			// aapt resource value: 103
+			public static int AppCompatTheme_buttonStyleSmall = 103;
+			
+			// aapt resource value: 104
+			public static int AppCompatTheme_checkboxStyle = 104;
+			
+			// aapt resource value: 105
+			public static int AppCompatTheme_checkedTextViewStyle = 105;
+			
+			// aapt resource value: 85
+			public static int AppCompatTheme_colorAccent = 85;
+			
+			// aapt resource value: 92
+			public static int AppCompatTheme_colorBackgroundFloating = 92;
+			
+			// aapt resource value: 89
+			public static int AppCompatTheme_colorButtonNormal = 89;
+			
+			// aapt resource value: 87
+			public static int AppCompatTheme_colorControlActivated = 87;
+			
+			// aapt resource value: 88
+			public static int AppCompatTheme_colorControlHighlight = 88;
+			
+			// aapt resource value: 86
+			public static int AppCompatTheme_colorControlNormal = 86;
+			
+			// aapt resource value: 83
+			public static int AppCompatTheme_colorPrimary = 83;
+			
+			// aapt resource value: 84
+			public static int AppCompatTheme_colorPrimaryDark = 84;
+			
+			// aapt resource value: 90
+			public static int AppCompatTheme_colorSwitchThumbNormal = 90;
+			
+			// aapt resource value: 91
+			public static int AppCompatTheme_controlBackground = 91;
+			
+			// aapt resource value: 44
+			public static int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public static int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public static int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public static int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public static int AppCompatTheme_dropDownListViewStyle = 75;
 			
 			// aapt resource value: 47
-			public static int AppCompatTheme_spinnerDropDownItemStyle = 47;
+			public static int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public static int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public static int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 106
+			public static int AppCompatTheme_editTextStyle = 106;
+			
+			// aapt resource value: 49
+			public static int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public static int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 82
+			public static int AppCompatTheme_listChoiceBackgroundIndicator = 82;
+			
+			// aapt resource value: 45
+			public static int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 114
+			public static int AppCompatTheme_listMenuViewStyle = 114;
+			
+			// aapt resource value: 76
+			public static int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public static int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public static int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public static int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public static int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public static int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 79
+			public static int AppCompatTheme_panelBackground = 79;
+			
+			// aapt resource value: 81
+			public static int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 80
+			public static int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 61
+			public static int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public static int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 107
+			public static int AppCompatTheme_radioButtonStyle = 107;
+			
+			// aapt resource value: 108
+			public static int AppCompatTheme_ratingBarStyle = 108;
+			
+			// aapt resource value: 109
+			public static int AppCompatTheme_ratingBarStyleIndicator = 109;
 			
 			// aapt resource value: 110
-			public static int AppCompatTheme_spinnerStyle = 110;
+			public static int AppCompatTheme_ratingBarStyleSmall = 110;
+			
+			// aapt resource value: 69
+			public static int AppCompatTheme_searchViewStyle = 69;
 			
 			// aapt resource value: 111
-			public static int AppCompatTheme_switchStyle = 111;
+			public static int AppCompatTheme_seekBarStyle = 111;
+			
+			// aapt resource value: 53
+			public static int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public static int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public static int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 112
+			public static int AppCompatTheme_spinnerStyle = 112;
+			
+			// aapt resource value: 113
+			public static int AppCompatTheme_switchStyle = 113;
 			
 			// aapt resource value: 40
 			public static int AppCompatTheme_textAppearanceLargePopupMenu = 40;
 			
-			// aapt resource value: 76
-			public static int AppCompatTheme_textAppearanceListItem = 76;
-			
 			// aapt resource value: 77
-			public static int AppCompatTheme_textAppearanceListItemSmall = 77;
+			public static int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public static int AppCompatTheme_textAppearanceListItemSmall = 78;
+			
+			// aapt resource value: 42
+			public static int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
 			
 			// aapt resource value: 66
-			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 66;
-			
-			// aapt resource value: 65
-			public static int AppCompatTheme_textAppearanceSearchResultTitle = 65;
+			public static int AppCompatTheme_textAppearanceSearchResultTitle = 66;
 			
 			// aapt resource value: 41
 			public static int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
 			
-			// aapt resource value: 95
-			public static int AppCompatTheme_textColorAlertDialogListItem = 95;
+			// aapt resource value: 97
+			public static int AppCompatTheme_textColorAlertDialogListItem = 97;
 			
-			// aapt resource value: 67
-			public static int AppCompatTheme_textColorSearchUrl = 67;
+			// aapt resource value: 68
+			public static int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public static int AppCompatTheme_toolbarNavigationButtonStyle = 60;
 			
 			// aapt resource value: 59
-			public static int AppCompatTheme_toolbarNavigationButtonStyle = 59;
-			
-			// aapt resource value: 58
-			public static int AppCompatTheme_toolbarStyle = 58;
+			public static int AppCompatTheme_toolbarStyle = 59;
 			
 			// aapt resource value: 2
 			public static int AppCompatTheme_windowActionBar = 2;
@@ -4939,20 +5838,47 @@ namespace FAB.Droid
 			// aapt resource value: 3
 			public static int AppCompatTheme_windowNoTitle = 3;
 			
-			public static int[] BottomSheetBehavior_Params = new int[]
+			public static int[] BottomNavigationView = new int[]
 			{
-					2130771994,
-					2130771995};
-			
-			// aapt resource value: 1
-			public static int BottomSheetBehavior_Params_behavior_hideable = 1;
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270};
 			
 			// aapt resource value: 0
-			public static int BottomSheetBehavior_Params_behavior_peekHeight = 0;
+			public static int BottomNavigationView_elevation = 0;
+			
+			// aapt resource value: 4
+			public static int BottomNavigationView_itemBackground = 4;
+			
+			// aapt resource value: 2
+			public static int BottomNavigationView_itemIconTint = 2;
+			
+			// aapt resource value: 3
+			public static int BottomNavigationView_itemTextColor = 3;
+			
+			// aapt resource value: 1
+			public static int BottomNavigationView_menu = 1;
+			
+			public static int[] BottomSheetBehavior_Layout = new int[]
+			{
+					2130772229,
+					2130772230,
+					2130772231};
+			
+			// aapt resource value: 1
+			public static int BottomSheetBehavior_Layout_behavior_hideable = 1;
+			
+			// aapt resource value: 0
+			public static int BottomSheetBehavior_Layout_behavior_peekHeight = 0;
+			
+			// aapt resource value: 2
+			public static int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
 			
 			public static int[] ButtonBarLayout = new int[]
 			{
-					2130772208};
+					2130772153};
 			
 			// aapt resource value: 0
 			public static int ButtonBarLayout_allowStacking = 0;
@@ -4961,17 +5887,17 @@ namespace FAB.Droid
 			{
 					16843071,
 					16843072,
-					2130772273,
-					2130772274,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278,
-					2130772279,
-					2130772280,
-					2130772281,
-					2130772282,
-					2130772283};
+					2130771985,
+					2130771986,
+					2130771987,
+					2130771988,
+					2130771989,
+					2130771990,
+					2130771991,
+					2130771992,
+					2130771993,
+					2130771994,
+					2130771995};
 			
 			// aapt resource value: 1
 			public static int CardView_android_minHeight = 1;
@@ -5012,81 +5938,104 @@ namespace FAB.Droid
 			// aapt resource value: 11
 			public static int CardView_contentPaddingTop = 11;
 			
-			public static int[] CollapsingAppBarLayout_LayoutParams = new int[]
-			{
-					2130771996,
-					2130771997};
-			
-			// aapt resource value: 0
-			public static int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
-			
-			// aapt resource value: 1
-			public static int CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = 1;
-			
 			public static int[] CollapsingToolbarLayout = new int[]
 			{
-					2130771998,
 					2130771999,
-					2130772000,
-					2130772001,
-					2130772002,
-					2130772003,
-					2130772004,
-					2130772005,
-					2130772006,
-					2130772007,
-					2130772008,
-					2130772009,
-					2130772010,
-					2130772063};
-			
-			// aapt resource value: 10
-			public static int CollapsingToolbarLayout_collapsedTitleGravity = 10;
-			
-			// aapt resource value: 6
-			public static int CollapsingToolbarLayout_collapsedTitleTextAppearance = 6;
-			
-			// aapt resource value: 7
-			public static int CollapsingToolbarLayout_contentScrim = 7;
-			
-			// aapt resource value: 11
-			public static int CollapsingToolbarLayout_expandedTitleGravity = 11;
-			
-			// aapt resource value: 0
-			public static int CollapsingToolbarLayout_expandedTitleMargin = 0;
-			
-			// aapt resource value: 4
-			public static int CollapsingToolbarLayout_expandedTitleMarginBottom = 4;
-			
-			// aapt resource value: 3
-			public static int CollapsingToolbarLayout_expandedTitleMarginEnd = 3;
-			
-			// aapt resource value: 1
-			public static int CollapsingToolbarLayout_expandedTitleMarginStart = 1;
-			
-			// aapt resource value: 2
-			public static int CollapsingToolbarLayout_expandedTitleMarginTop = 2;
-			
-			// aapt resource value: 5
-			public static int CollapsingToolbarLayout_expandedTitleTextAppearance = 5;
-			
-			// aapt resource value: 8
-			public static int CollapsingToolbarLayout_statusBarScrim = 8;
+					2130772232,
+					2130772233,
+					2130772234,
+					2130772235,
+					2130772236,
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240,
+					2130772241,
+					2130772242,
+					2130772243,
+					2130772244,
+					2130772245,
+					2130772246};
 			
 			// aapt resource value: 13
-			public static int CollapsingToolbarLayout_title = 13;
+			public static int CollapsingToolbarLayout_collapsedTitleGravity = 13;
+			
+			// aapt resource value: 7
+			public static int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public static int CollapsingToolbarLayout_contentScrim = 8;
+			
+			// aapt resource value: 14
+			public static int CollapsingToolbarLayout_expandedTitleGravity = 14;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_expandedTitleMargin = 1;
+			
+			// aapt resource value: 5
+			public static int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 4
+			public static int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
+			
+			// aapt resource value: 2
+			public static int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
+			
+			// aapt resource value: 3
+			public static int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
+			
+			// aapt resource value: 6
+			public static int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
 			
 			// aapt resource value: 12
-			public static int CollapsingToolbarLayout_titleEnabled = 12;
+			public static int CollapsingToolbarLayout_scrimAnimationDuration = 12;
+			
+			// aapt resource value: 11
+			public static int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
 			
 			// aapt resource value: 9
-			public static int CollapsingToolbarLayout_toolbarId = 9;
+			public static int CollapsingToolbarLayout_statusBarScrim = 9;
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_title = 0;
+			
+			// aapt resource value: 15
+			public static int CollapsingToolbarLayout_titleEnabled = 15;
+			
+			// aapt resource value: 10
+			public static int CollapsingToolbarLayout_toolbarId = 10;
+			
+			public static int[] CollapsingToolbarLayout_Layout = new int[]
+			{
+					2130772247,
+					2130772248};
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			public static int[] ColorStateListItem = new int[]
+			{
+					16843173,
+					16843551,
+					2130772154};
+			
+			// aapt resource value: 2
+			public static int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public static int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public static int ColorStateListItem_android_color = 0;
 			
 			public static int[] CompoundButton = new int[]
 			{
 					16843015,
-					2130772209,
-					2130772210};
+					2130772155,
+					2130772156};
 			
 			// aapt resource value: 0
 			public static int CompoundButton_android_button = 0;
@@ -5099,8 +6048,8 @@ namespace FAB.Droid
 			
 			public static int[] CoordinatorLayout = new int[]
 			{
-					2130772011,
-					2130772012};
+					2130772249,
+					2130772250};
 			
 			// aapt resource value: 0
 			public static int CoordinatorLayout_keylines = 0;
@@ -5108,34 +6057,42 @@ namespace FAB.Droid
 			// aapt resource value: 1
 			public static int CoordinatorLayout_statusBarBackground = 1;
 			
-			public static int[] CoordinatorLayout_LayoutParams = new int[]
+			public static int[] CoordinatorLayout_Layout = new int[]
 			{
 					16842931,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016};
+					2130772251,
+					2130772252,
+					2130772253,
+					2130772254,
+					2130772255,
+					2130772256};
 			
 			// aapt resource value: 0
-			public static int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
+			public static int CoordinatorLayout_Layout_android_layout_gravity = 0;
 			
 			// aapt resource value: 2
-			public static int CoordinatorLayout_LayoutParams_layout_anchor = 2;
+			public static int CoordinatorLayout_Layout_layout_anchor = 2;
 			
 			// aapt resource value: 4
-			public static int CoordinatorLayout_LayoutParams_layout_anchorGravity = 4;
+			public static int CoordinatorLayout_Layout_layout_anchorGravity = 4;
 			
 			// aapt resource value: 1
-			public static int CoordinatorLayout_LayoutParams_layout_behavior = 1;
+			public static int CoordinatorLayout_Layout_layout_behavior = 1;
+			
+			// aapt resource value: 6
+			public static int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 6;
+			
+			// aapt resource value: 5
+			public static int CoordinatorLayout_Layout_layout_insetEdge = 5;
 			
 			// aapt resource value: 3
-			public static int CoordinatorLayout_LayoutParams_layout_keyline = 3;
+			public static int CoordinatorLayout_Layout_layout_keyline = 3;
 			
 			public static int[] DesignTheme = new int[]
 			{
-					2130772017,
-					2130772018,
-					2130772019};
+					2130772257,
+					2130772258,
+					2130772259};
 			
 			// aapt resource value: 0
 			public static int DesignTheme_bottomSheetDialogTheme = 0;
@@ -5148,14 +6105,14 @@ namespace FAB.Droid
 			
 			public static int[] DrawerArrowToggle = new int[]
 			{
-					2130772211,
-					2130772212,
-					2130772213,
-					2130772214,
-					2130772215,
-					2130772216,
-					2130772217,
-					2130772218};
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164};
 			
 			// aapt resource value: 4
 			public static int DrawerArrowToggle_arrowHeadLength = 4;
@@ -5183,35 +6140,35 @@ namespace FAB.Droid
 			
 			public static int[] FloatingActionButton = new int[]
 			{
-					2130772020,
-					2130772021,
-					2130772022,
-					2130772023,
 					2130772024,
-					2130772086,
-					2130772267,
-					2130772268,
-					2130772284,
-					2130772285,
-					2130772286,
-					2130772287,
-					2130772288,
-					2130772289};
-			
-			// aapt resource value: 6
-			public static int FloatingActionButton_backgroundTint = 6;
-			
-			// aapt resource value: 7
-			public static int FloatingActionButton_backgroundTintMode = 7;
-			
-			// aapt resource value: 3
-			public static int FloatingActionButton_borderWidth = 3;
-			
-			// aapt resource value: 5
-			public static int FloatingActionButton_elevation = 5;
+					2130772222,
+					2130772223,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264,
+					2130772306,
+					2130772307,
+					2130772308,
+					2130772309,
+					2130772310,
+					2130772311};
 			
 			// aapt resource value: 1
-			public static int FloatingActionButton_fabSize = 1;
+			public static int FloatingActionButton_backgroundTint = 1;
+			
+			// aapt resource value: 2
+			public static int FloatingActionButton_backgroundTintMode = 2;
+			
+			// aapt resource value: 6
+			public static int FloatingActionButton_borderWidth = 6;
+			
+			// aapt resource value: 0
+			public static int FloatingActionButton_elevation = 0;
+			
+			// aapt resource value: 4
+			public static int FloatingActionButton_fabSize = 4;
 			
 			// aapt resource value: 10
 			public static int FloatingActionButton_fab_colorDisabled = 10;
@@ -5231,20 +6188,27 @@ namespace FAB.Droid
 			// aapt resource value: 13
 			public static int FloatingActionButton_fab_size = 13;
 			
-			// aapt resource value: 2
-			public static int FloatingActionButton_pressedTranslationZ = 2;
+			// aapt resource value: 5
+			public static int FloatingActionButton_pressedTranslationZ = 5;
+			
+			// aapt resource value: 3
+			public static int FloatingActionButton_rippleColor = 3;
+			
+			// aapt resource value: 7
+			public static int FloatingActionButton_useCompatPadding = 7;
+			
+			public static int[] FloatingActionButton_Behavior_Layout = new int[]
+			{
+					2130772265};
 			
 			// aapt resource value: 0
-			public static int FloatingActionButton_rippleColor = 0;
-			
-			// aapt resource value: 4
-			public static int FloatingActionButton_useCompatPadding = 4;
+			public static int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
 			
 			public static int[] ForegroundLinearLayout = new int[]
 			{
 					16843017,
 					16843264,
-					2130772025};
+					2130772266};
 			
 			// aapt resource value: 0
 			public static int ForegroundLinearLayout_android_foreground = 0;
@@ -5262,10 +6226,10 @@ namespace FAB.Droid
 					16843046,
 					16843047,
 					16843048,
-					2130772071,
-					2130772219,
-					2130772220,
-					2130772221};
+					2130772007,
+					2130772165,
+					2130772166,
+					2130772167};
 			
 			// aapt resource value: 2
 			public static int LinearLayoutCompat_android_baselineAligned = 2;
@@ -5328,13 +6292,17 @@ namespace FAB.Droid
 			{
 					16843071,
 					16843072,
-					2130771990};
+					2130771984,
+					2130772155};
 			
 			// aapt resource value: 1
 			public static int MediaRouteButton_android_minHeight = 1;
 			
 			// aapt resource value: 0
 			public static int MediaRouteButton_android_minWidth = 0;
+			
+			// aapt resource value: 3
+			public static int MediaRouteButton_buttonTint = 3;
 			
 			// aapt resource value: 2
 			public static int MediaRouteButton_externalRouteEnabledDrawable = 2;
@@ -5381,10 +6349,10 @@ namespace FAB.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772222,
-					2130772223,
-					2130772224,
-					2130772225};
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171};
 			
 			// aapt resource value: 14
 			public static int MenuItem_actionLayout = 14;
@@ -5446,7 +6414,8 @@ namespace FAB.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772226};
+					2130772172,
+					2130772173};
 			
 			// aapt resource value: 4
 			public static int MenuView_android_headerBackground = 4;
@@ -5472,18 +6441,21 @@ namespace FAB.Droid
 			// aapt resource value: 7
 			public static int MenuView_preserveIconSpacing = 7;
 			
+			// aapt resource value: 8
+			public static int MenuView_subMenuArrow = 8;
+			
 			public static int[] NavigationView = new int[]
 			{
 					16842964,
 					16842973,
 					16843039,
-					2130772026,
-					2130772027,
-					2130772028,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772086};
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270,
+					2130772271,
+					2130772272};
 			
 			// aapt resource value: 0
 			public static int NavigationView_android_background = 0;
@@ -5494,81 +6466,100 @@ namespace FAB.Droid
 			// aapt resource value: 2
 			public static int NavigationView_android_maxWidth = 2;
 			
+			// aapt resource value: 3
+			public static int NavigationView_elevation = 3;
+			
 			// aapt resource value: 9
-			public static int NavigationView_elevation = 9;
-			
-			// aapt resource value: 8
-			public static int NavigationView_headerLayout = 8;
-			
-			// aapt resource value: 6
-			public static int NavigationView_itemBackground = 6;
-			
-			// aapt resource value: 4
-			public static int NavigationView_itemIconTint = 4;
+			public static int NavigationView_headerLayout = 9;
 			
 			// aapt resource value: 7
-			public static int NavigationView_itemTextAppearance = 7;
+			public static int NavigationView_itemBackground = 7;
 			
 			// aapt resource value: 5
-			public static int NavigationView_itemTextColor = 5;
+			public static int NavigationView_itemIconTint = 5;
 			
-			// aapt resource value: 3
-			public static int NavigationView_menu = 3;
+			// aapt resource value: 8
+			public static int NavigationView_itemTextAppearance = 8;
+			
+			// aapt resource value: 6
+			public static int NavigationView_itemTextColor = 6;
+			
+			// aapt resource value: 4
+			public static int NavigationView_menu = 4;
 			
 			public static int[] PopupWindow = new int[]
 			{
 					16843126,
-					2130772227};
+					16843465,
+					2130772174};
+			
+			// aapt resource value: 1
+			public static int PopupWindow_android_popupAnimationStyle = 1;
 			
 			// aapt resource value: 0
 			public static int PopupWindow_android_popupBackground = 0;
 			
-			// aapt resource value: 1
-			public static int PopupWindow_overlapAnchor = 1;
+			// aapt resource value: 2
+			public static int PopupWindow_overlapAnchor = 2;
 			
 			public static int[] PopupWindowBackgroundState = new int[]
 			{
-					2130772228};
+					2130772175};
 			
 			// aapt resource value: 0
 			public static int PopupWindowBackgroundState_state_above_anchor = 0;
 			
+			public static int[] RecycleListView = new int[]
+			{
+					2130772176,
+					2130772177};
+			
+			// aapt resource value: 0
+			public static int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public static int RecycleListView_paddingTopNoTitle = 1;
+			
 			public static int[] RecyclerView = new int[]
 			{
 					16842948,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272};
+					16842993,
+					2130771968,
+					2130771969,
+					2130771970,
+					2130771971};
+			
+			// aapt resource value: 1
+			public static int RecyclerView_android_descendantFocusability = 1;
 			
 			// aapt resource value: 0
 			public static int RecyclerView_android_orientation = 0;
 			
-			// aapt resource value: 1
-			public static int RecyclerView_layoutManager = 1;
-			
-			// aapt resource value: 3
-			public static int RecyclerView_reverseLayout = 3;
-			
 			// aapt resource value: 2
-			public static int RecyclerView_spanCount = 2;
+			public static int RecyclerView_layoutManager = 2;
 			
 			// aapt resource value: 4
-			public static int RecyclerView_stackFromEnd = 4;
+			public static int RecyclerView_reverseLayout = 4;
+			
+			// aapt resource value: 3
+			public static int RecyclerView_spanCount = 3;
+			
+			// aapt resource value: 5
+			public static int RecyclerView_stackFromEnd = 5;
 			
 			public static int[] ScrimInsetsFrameLayout = new int[]
 			{
-					2130772032};
+					2130772273};
 			
 			// aapt resource value: 0
 			public static int ScrimInsetsFrameLayout_insetForeground = 0;
 			
-			public static int[] ScrollingViewBehavior_Params = new int[]
+			public static int[] ScrollingViewBehavior_Layout = new int[]
 			{
-					2130772033};
+					2130772274};
 			
 			// aapt resource value: 0
-			public static int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
+			public static int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
 			public static int[] SearchView = new int[]
 			{
@@ -5576,19 +6567,19 @@ namespace FAB.Droid
 					16843039,
 					16843296,
 					16843364,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233,
-					2130772234,
-					2130772235,
-					2130772236,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240,
-					2130772241};
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187,
+					2130772188,
+					2130772189,
+					2130772190};
 			
 			// aapt resource value: 0
 			public static int SearchView_android_focusable = 0;
@@ -5644,17 +6635,17 @@ namespace FAB.Droid
 			public static int[] SnackbarLayout = new int[]
 			{
 					16843039,
-					2130772034,
-					2130772086};
+					2130772024,
+					2130772275};
 			
 			// aapt resource value: 0
 			public static int SnackbarLayout_android_maxWidth = 0;
 			
-			// aapt resource value: 2
-			public static int SnackbarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public static int SnackbarLayout_maxActionInlineWidth = 1;
+			public static int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public static int SnackbarLayout_maxActionInlineWidth = 2;
 			
 			public static int[] Spinner = new int[]
 			{
@@ -5662,7 +6653,7 @@ namespace FAB.Droid
 					16843126,
 					16843131,
 					16843362,
-					2130772087};
+					2130772025};
 			
 			// aapt resource value: 3
 			public static int Spinner_android_dropDownWidth = 3;
@@ -5684,13 +6675,17 @@ namespace FAB.Droid
 					16843044,
 					16843045,
 					16843074,
-					2130772242,
-					2130772243,
-					2130772244,
-					2130772245,
-					2130772246,
-					2130772247,
-					2130772248};
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199,
+					2130772200,
+					2130772201};
 			
 			// aapt resource value: 1
 			public static int SwitchCompat_android_textOff = 1;
@@ -5701,26 +6696,38 @@ namespace FAB.Droid
 			// aapt resource value: 2
 			public static int SwitchCompat_android_thumb = 2;
 			
+			// aapt resource value: 13
+			public static int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public static int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public static int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public static int SwitchCompat_switchPadding = 11;
+			
 			// aapt resource value: 9
-			public static int SwitchCompat_showText = 9;
+			public static int SwitchCompat_switchTextAppearance = 9;
 			
 			// aapt resource value: 8
-			public static int SwitchCompat_splitTrack = 8;
-			
-			// aapt resource value: 6
-			public static int SwitchCompat_switchMinWidth = 6;
-			
-			// aapt resource value: 7
-			public static int SwitchCompat_switchPadding = 7;
-			
-			// aapt resource value: 5
-			public static int SwitchCompat_switchTextAppearance = 5;
-			
-			// aapt resource value: 4
-			public static int SwitchCompat_thumbTextPadding = 4;
+			public static int SwitchCompat_thumbTextPadding = 8;
 			
 			// aapt resource value: 3
-			public static int SwitchCompat_track = 3;
+			public static int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public static int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public static int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public static int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public static int SwitchCompat_trackTintMode = 7;
 			
 			public static int[] TabItem = new int[]
 			{
@@ -5739,22 +6746,22 @@ namespace FAB.Droid
 			
 			public static int[] TabLayout = new int[]
 			{
-					2130772035,
-					2130772036,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040,
-					2130772041,
-					2130772042,
-					2130772043,
-					2130772044,
-					2130772045,
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050};
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280,
+					2130772281,
+					2130772282,
+					2130772283,
+					2130772284,
+					2130772285,
+					2130772286,
+					2130772287,
+					2130772288,
+					2130772289,
+					2130772290,
+					2130772291};
 			
 			// aapt resource value: 3
 			public static int TabLayout_tabBackground = 3;
@@ -5810,26 +6817,30 @@ namespace FAB.Droid
 					16842902,
 					16842903,
 					16842904,
+					16842906,
 					16843105,
 					16843106,
 					16843107,
 					16843108,
-					2130772097};
-			
-			// aapt resource value: 4
-			public static int TextAppearance_android_shadowColor = 4;
+					2130772039};
 			
 			// aapt resource value: 5
-			public static int TextAppearance_android_shadowDx = 5;
+			public static int TextAppearance_android_shadowColor = 5;
 			
 			// aapt resource value: 6
-			public static int TextAppearance_android_shadowDy = 6;
+			public static int TextAppearance_android_shadowDx = 6;
 			
 			// aapt resource value: 7
-			public static int TextAppearance_android_shadowRadius = 7;
+			public static int TextAppearance_android_shadowDy = 7;
+			
+			// aapt resource value: 8
+			public static int TextAppearance_android_shadowRadius = 8;
 			
 			// aapt resource value: 3
 			public static int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public static int TextAppearance_android_textColorHint = 4;
 			
 			// aapt resource value: 0
 			public static int TextAppearance_android_textSize = 0;
@@ -5840,22 +6851,27 @@ namespace FAB.Droid
 			// aapt resource value: 1
 			public static int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 8
-			public static int TextAppearance_textAllCaps = 8;
+			// aapt resource value: 9
+			public static int TextAppearance_textAllCaps = 9;
 			
 			public static int[] TextInputLayout = new int[]
 			{
 					16842906,
 					16843088,
-					2130772051,
-					2130772052,
-					2130772053,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059};
+					2130772292,
+					2130772293,
+					2130772294,
+					2130772295,
+					2130772296,
+					2130772297,
+					2130772298,
+					2130772299,
+					2130772300,
+					2130772301,
+					2130772302,
+					2130772303,
+					2130772304,
+					2130772305};
 			
 			// aapt resource value: 1
 			public static int TextInputLayout_android_hint = 1;
@@ -5890,33 +6906,52 @@ namespace FAB.Droid
 			// aapt resource value: 2
 			public static int TextInputLayout_hintTextAppearance = 2;
 			
+			// aapt resource value: 13
+			public static int TextInputLayout_passwordToggleContentDescription = 13;
+			
+			// aapt resource value: 12
+			public static int TextInputLayout_passwordToggleDrawable = 12;
+			
+			// aapt resource value: 11
+			public static int TextInputLayout_passwordToggleEnabled = 11;
+			
+			// aapt resource value: 14
+			public static int TextInputLayout_passwordToggleTint = 14;
+			
+			// aapt resource value: 15
+			public static int TextInputLayout_passwordToggleTintMode = 15;
+			
 			public static int[] Toolbar = new int[]
 			{
 					16842927,
 					16843072,
-					2130772063,
-					2130772066,
-					2130772070,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772087,
-					2130772249,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255,
-					2130772256,
-					2130772257,
-					2130772258,
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263};
+					2130771999,
+					2130772002,
+					2130772006,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772025,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214,
+					2130772215,
+					2130772216,
+					2130772217,
+					2130772218};
 			
 			// aapt resource value: 0
 			public static int Toolbar_android_gravity = 0;
@@ -5924,14 +6959,20 @@ namespace FAB.Droid
 			// aapt resource value: 1
 			public static int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public static int Toolbar_collapseContentDescription = 19;
+			// aapt resource value: 21
+			public static int Toolbar_buttonGravity = 21;
 			
-			// aapt resource value: 18
-			public static int Toolbar_collapseIcon = 18;
+			// aapt resource value: 23
+			public static int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public static int Toolbar_collapseIcon = 22;
 			
 			// aapt resource value: 6
 			public static int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public static int Toolbar_contentInsetEndWithActions = 10;
 			
 			// aapt resource value: 7
 			public static int Toolbar_contentInsetLeft = 7;
@@ -5942,64 +6983,70 @@ namespace FAB.Droid
 			// aapt resource value: 5
 			public static int Toolbar_contentInsetStart = 5;
 			
+			// aapt resource value: 9
+			public static int Toolbar_contentInsetStartWithNavigation = 9;
+			
 			// aapt resource value: 4
 			public static int Toolbar_logo = 4;
 			
-			// aapt resource value: 22
-			public static int Toolbar_logoDescription = 22;
-			
-			// aapt resource value: 17
-			public static int Toolbar_maxButtonHeight = 17;
-			
-			// aapt resource value: 21
-			public static int Toolbar_navigationContentDescription = 21;
+			// aapt resource value: 26
+			public static int Toolbar_logoDescription = 26;
 			
 			// aapt resource value: 20
-			public static int Toolbar_navigationIcon = 20;
+			public static int Toolbar_maxButtonHeight = 20;
 			
-			// aapt resource value: 9
-			public static int Toolbar_popupTheme = 9;
+			// aapt resource value: 25
+			public static int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public static int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public static int Toolbar_popupTheme = 11;
 			
 			// aapt resource value: 3
 			public static int Toolbar_subtitle = 3;
 			
-			// aapt resource value: 11
-			public static int Toolbar_subtitleTextAppearance = 11;
+			// aapt resource value: 13
+			public static int Toolbar_subtitleTextAppearance = 13;
 			
-			// aapt resource value: 24
-			public static int Toolbar_subtitleTextColor = 24;
+			// aapt resource value: 28
+			public static int Toolbar_subtitleTextColor = 28;
 			
 			// aapt resource value: 2
 			public static int Toolbar_title = 2;
 			
-			// aapt resource value: 16
-			public static int Toolbar_titleMarginBottom = 16;
-			
 			// aapt resource value: 14
-			public static int Toolbar_titleMarginEnd = 14;
+			public static int Toolbar_titleMargin = 14;
 			
-			// aapt resource value: 13
-			public static int Toolbar_titleMarginStart = 13;
+			// aapt resource value: 18
+			public static int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public static int Toolbar_titleMarginEnd = 16;
 			
 			// aapt resource value: 15
-			public static int Toolbar_titleMarginTop = 15;
+			public static int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public static int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public static int Toolbar_titleMargins = 19;
 			
 			// aapt resource value: 12
-			public static int Toolbar_titleMargins = 12;
+			public static int Toolbar_titleTextAppearance = 12;
 			
-			// aapt resource value: 10
-			public static int Toolbar_titleTextAppearance = 10;
-			
-			// aapt resource value: 23
-			public static int Toolbar_titleTextColor = 23;
+			// aapt resource value: 27
+			public static int Toolbar_titleTextColor = 27;
 			
 			public static int[] View = new int[]
 			{
 					16842752,
 					16842970,
-					2130772264,
-					2130772265,
-					2130772266};
+					2130772219,
+					2130772220,
+					2130772221};
 			
 			// aapt resource value: 1
 			public static int View_android_focusable = 1;
@@ -6019,8 +7066,8 @@ namespace FAB.Droid
 			public static int[] ViewBackgroundHelper = new int[]
 			{
 					16842964,
-					2130772267,
-					2130772268};
+					2130772222,
+					2130772223};
 			
 			// aapt resource value: 0
 			public static int ViewBackgroundHelper_android_background = 0;

--- a/Library/FloatingActionButton.Droid/packages.config
+++ b/Library/FloatingActionButton.Droid/packages.config
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Annotations" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.UI" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Design" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Fragment" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Transition" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v4" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.Palette" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid71" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="monoandroid71" />
 </packages>

--- a/Library/FloatingActionButton.Forms/Profile111/FAB.Forms.Profile111.csproj
+++ b/Library/FloatingActionButton.Forms/Profile111/FAB.Forms.Profile111.csproj
@@ -42,18 +42,18 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Library/FloatingActionButton.Forms/Profile111/packages.config
+++ b/Library/FloatingActionButton.Forms/Profile111/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/Library/FloatingActionButton.Forms/Profile78/FAB.Forms.Profile78.csproj
+++ b/Library/FloatingActionButton.Forms/Profile78/FAB.Forms.Profile78.csproj
@@ -40,18 +40,18 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-<Import Project="..\..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Library/FloatingActionButton.Forms/Profile78/packages.config
+++ b/Library/FloatingActionButton.Forms/Profile78/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/Library/FloatingActionButton.iOS/FAB.iOS.csproj
+++ b/Library/FloatingActionButton.iOS/FAB.iOS.csproj
@@ -35,16 +35,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -67,5 +67,5 @@
   </ItemGroup>
   <Import Project="..\FloatingActionButton.Shared\FloatingActionButton.Shared.projitems" Label="Shared" Condition="Exists('..\FloatingActionButton.Shared\FloatingActionButton.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Library/FloatingActionButton.iOS/packages.config
+++ b/Library/FloatingActionButton.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="xamarinios10" />
 </packages>

--- a/Sample/Droid/FABSample.Droid.csproj
+++ b/Sample/Droid/FABSample.Droid.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -43,44 +44,68 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
+    <Reference Include="Xamarin.Android.Support.Annotations">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Transition">
+      <HintPath>..\..\packages\Xamarin.Android.Support.Transition.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Transition.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v4.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.CardView">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.Palette">
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.Palette.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Vector.Drawable">
-      <HintPath>..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <HintPath>..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Design">
-      <HintPath>..\..\packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.Design.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <HintPath>..\..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -136,6 +161,22 @@
     <Folder Include="Resources\drawable\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets')" />
+  <Import Project="..\..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Sample/Droid/Resources/Resource.designer.cs
+++ b/Sample/Droid/Resources/Resource.designer.cs
@@ -26,7 +26,6 @@ namespace FABSample.Droid
 		
 		public static void UpdateIdValues()
 		{
-			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarSize = global::FABSample.Droid.Resource.Attribute.actionBarSize;
 			global::FAB.Droid.Resource.Animation.abc_fade_in = global::FABSample.Droid.Resource.Animation.abc_fade_in;
 			global::FAB.Droid.Resource.Animation.abc_fade_out = global::FABSample.Droid.Resource.Animation.abc_fade_out;
 			global::FAB.Droid.Resource.Animation.abc_grow_fade_in_from_bottom = global::FABSample.Droid.Resource.Animation.abc_grow_fade_in_from_bottom;
@@ -43,7 +42,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Animation.design_fab_out = global::FABSample.Droid.Resource.Animation.design_fab_out;
 			global::FAB.Droid.Resource.Animation.design_snackbar_in = global::FABSample.Droid.Resource.Animation.design_snackbar_in;
 			global::FAB.Droid.Resource.Animation.design_snackbar_out = global::FABSample.Droid.Resource.Animation.design_snackbar_out;
-			global::FAB.Droid.Resource.Attribute.MediaRouteControllerWindowBackground = global::FABSample.Droid.Resource.Attribute.MediaRouteControllerWindowBackground;
+			global::FAB.Droid.Resource.Animator.design_appbar_state_list_animator = global::FABSample.Droid.Resource.Animator.design_appbar_state_list_animator;
 			global::FAB.Droid.Resource.Attribute.actionBarDivider = global::FABSample.Droid.Resource.Attribute.actionBarDivider;
 			global::FAB.Droid.Resource.Attribute.actionBarItemBackground = global::FABSample.Droid.Resource.Attribute.actionBarItemBackground;
 			global::FAB.Droid.Resource.Attribute.actionBarPopupTheme = global::FABSample.Droid.Resource.Attribute.actionBarPopupTheme;
@@ -83,6 +82,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.alertDialogStyle = global::FABSample.Droid.Resource.Attribute.alertDialogStyle;
 			global::FAB.Droid.Resource.Attribute.alertDialogTheme = global::FABSample.Droid.Resource.Attribute.alertDialogTheme;
 			global::FAB.Droid.Resource.Attribute.allowStacking = global::FABSample.Droid.Resource.Attribute.allowStacking;
+			global::FAB.Droid.Resource.Attribute.alpha = global::FABSample.Droid.Resource.Attribute.alpha;
 			global::FAB.Droid.Resource.Attribute.arrowHeadLength = global::FABSample.Droid.Resource.Attribute.arrowHeadLength;
 			global::FAB.Droid.Resource.Attribute.arrowShaftLength = global::FABSample.Droid.Resource.Attribute.arrowShaftLength;
 			global::FAB.Droid.Resource.Attribute.autoCompleteTextViewStyle = global::FABSample.Droid.Resource.Attribute.autoCompleteTextViewStyle;
@@ -92,9 +92,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.backgroundTint = global::FABSample.Droid.Resource.Attribute.backgroundTint;
 			global::FAB.Droid.Resource.Attribute.backgroundTintMode = global::FABSample.Droid.Resource.Attribute.backgroundTintMode;
 			global::FAB.Droid.Resource.Attribute.barLength = global::FABSample.Droid.Resource.Attribute.barLength;
+			global::FAB.Droid.Resource.Attribute.behavior_autoHide = global::FABSample.Droid.Resource.Attribute.behavior_autoHide;
 			global::FAB.Droid.Resource.Attribute.behavior_hideable = global::FABSample.Droid.Resource.Attribute.behavior_hideable;
 			global::FAB.Droid.Resource.Attribute.behavior_overlapTop = global::FABSample.Droid.Resource.Attribute.behavior_overlapTop;
 			global::FAB.Droid.Resource.Attribute.behavior_peekHeight = global::FABSample.Droid.Resource.Attribute.behavior_peekHeight;
+			global::FAB.Droid.Resource.Attribute.behavior_skipCollapsed = global::FABSample.Droid.Resource.Attribute.behavior_skipCollapsed;
 			global::FAB.Droid.Resource.Attribute.borderWidth = global::FABSample.Droid.Resource.Attribute.borderWidth;
 			global::FAB.Droid.Resource.Attribute.borderlessButtonStyle = global::FABSample.Droid.Resource.Attribute.borderlessButtonStyle;
 			global::FAB.Droid.Resource.Attribute.bottomSheetDialogTheme = global::FABSample.Droid.Resource.Attribute.bottomSheetDialogTheme;
@@ -104,6 +106,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.buttonBarNeutralButtonStyle = global::FABSample.Droid.Resource.Attribute.buttonBarNeutralButtonStyle;
 			global::FAB.Droid.Resource.Attribute.buttonBarPositiveButtonStyle = global::FABSample.Droid.Resource.Attribute.buttonBarPositiveButtonStyle;
 			global::FAB.Droid.Resource.Attribute.buttonBarStyle = global::FABSample.Droid.Resource.Attribute.buttonBarStyle;
+			global::FAB.Droid.Resource.Attribute.buttonGravity = global::FABSample.Droid.Resource.Attribute.buttonGravity;
 			global::FAB.Droid.Resource.Attribute.buttonPanelSideLayout = global::FABSample.Droid.Resource.Attribute.buttonPanelSideLayout;
 			global::FAB.Droid.Resource.Attribute.buttonStyle = global::FABSample.Droid.Resource.Attribute.buttonStyle;
 			global::FAB.Droid.Resource.Attribute.buttonStyleSmall = global::FABSample.Droid.Resource.Attribute.buttonStyleSmall;
@@ -125,6 +128,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.collapsedTitleTextAppearance = global::FABSample.Droid.Resource.Attribute.collapsedTitleTextAppearance;
 			global::FAB.Droid.Resource.Attribute.color = global::FABSample.Droid.Resource.Attribute.color;
 			global::FAB.Droid.Resource.Attribute.colorAccent = global::FABSample.Droid.Resource.Attribute.colorAccent;
+			global::FAB.Droid.Resource.Attribute.colorBackgroundFloating = global::FABSample.Droid.Resource.Attribute.colorBackgroundFloating;
 			global::FAB.Droid.Resource.Attribute.colorButtonNormal = global::FABSample.Droid.Resource.Attribute.colorButtonNormal;
 			global::FAB.Droid.Resource.Attribute.colorControlActivated = global::FABSample.Droid.Resource.Attribute.colorControlActivated;
 			global::FAB.Droid.Resource.Attribute.colorControlHighlight = global::FABSample.Droid.Resource.Attribute.colorControlHighlight;
@@ -134,9 +138,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.colorSwitchThumbNormal = global::FABSample.Droid.Resource.Attribute.colorSwitchThumbNormal;
 			global::FAB.Droid.Resource.Attribute.commitIcon = global::FABSample.Droid.Resource.Attribute.commitIcon;
 			global::FAB.Droid.Resource.Attribute.contentInsetEnd = global::FABSample.Droid.Resource.Attribute.contentInsetEnd;
+			global::FAB.Droid.Resource.Attribute.contentInsetEndWithActions = global::FABSample.Droid.Resource.Attribute.contentInsetEndWithActions;
 			global::FAB.Droid.Resource.Attribute.contentInsetLeft = global::FABSample.Droid.Resource.Attribute.contentInsetLeft;
 			global::FAB.Droid.Resource.Attribute.contentInsetRight = global::FABSample.Droid.Resource.Attribute.contentInsetRight;
 			global::FAB.Droid.Resource.Attribute.contentInsetStart = global::FABSample.Droid.Resource.Attribute.contentInsetStart;
+			global::FAB.Droid.Resource.Attribute.contentInsetStartWithNavigation = global::FABSample.Droid.Resource.Attribute.contentInsetStartWithNavigation;
 			global::FAB.Droid.Resource.Attribute.contentPadding = global::FABSample.Droid.Resource.Attribute.contentPadding;
 			global::FAB.Droid.Resource.Attribute.contentPaddingBottom = global::FABSample.Droid.Resource.Attribute.contentPaddingBottom;
 			global::FAB.Droid.Resource.Attribute.contentPaddingLeft = global::FABSample.Droid.Resource.Attribute.contentPaddingLeft;
@@ -215,6 +221,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.layout_behavior = global::FABSample.Droid.Resource.Attribute.layout_behavior;
 			global::FAB.Droid.Resource.Attribute.layout_collapseMode = global::FABSample.Droid.Resource.Attribute.layout_collapseMode;
 			global::FAB.Droid.Resource.Attribute.layout_collapseParallaxMultiplier = global::FABSample.Droid.Resource.Attribute.layout_collapseParallaxMultiplier;
+			global::FAB.Droid.Resource.Attribute.layout_dodgeInsetEdges = global::FABSample.Droid.Resource.Attribute.layout_dodgeInsetEdges;
+			global::FAB.Droid.Resource.Attribute.layout_insetEdge = global::FABSample.Droid.Resource.Attribute.layout_insetEdge;
 			global::FAB.Droid.Resource.Attribute.layout_keyline = global::FABSample.Droid.Resource.Attribute.layout_keyline;
 			global::FAB.Droid.Resource.Attribute.layout_scrollFlags = global::FABSample.Droid.Resource.Attribute.layout_scrollFlags;
 			global::FAB.Droid.Resource.Attribute.layout_scrollInterpolator = global::FABSample.Droid.Resource.Attribute.layout_scrollInterpolator;
@@ -222,6 +230,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.listDividerAlertDialog = global::FABSample.Droid.Resource.Attribute.listDividerAlertDialog;
 			global::FAB.Droid.Resource.Attribute.listItemLayout = global::FABSample.Droid.Resource.Attribute.listItemLayout;
 			global::FAB.Droid.Resource.Attribute.listLayout = global::FABSample.Droid.Resource.Attribute.listLayout;
+			global::FAB.Droid.Resource.Attribute.listMenuViewStyle = global::FABSample.Droid.Resource.Attribute.listMenuViewStyle;
 			global::FAB.Droid.Resource.Attribute.listPopupWindowStyle = global::FABSample.Droid.Resource.Attribute.listPopupWindowStyle;
 			global::FAB.Droid.Resource.Attribute.listPreferredItemHeight = global::FABSample.Droid.Resource.Attribute.listPreferredItemHeight;
 			global::FAB.Droid.Resource.Attribute.listPreferredItemHeightLarge = global::FABSample.Droid.Resource.Attribute.listPreferredItemHeightLarge;
@@ -234,25 +243,16 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.maxButtonHeight = global::FABSample.Droid.Resource.Attribute.maxButtonHeight;
 			global::FAB.Droid.Resource.Attribute.measureWithLargestChild = global::FABSample.Droid.Resource.Attribute.measureWithLargestChild;
 			global::FAB.Droid.Resource.Attribute.mediaRouteAudioTrackDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteAudioTrackDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteBluetoothIconDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteBluetoothIconDrawable;
 			global::FAB.Droid.Resource.Attribute.mediaRouteButtonStyle = global::FABSample.Droid.Resource.Attribute.mediaRouteButtonStyle;
-			global::FAB.Droid.Resource.Attribute.mediaRouteCastDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteCastDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteChooserPrimaryTextStyle = global::FABSample.Droid.Resource.Attribute.mediaRouteChooserPrimaryTextStyle;
-			global::FAB.Droid.Resource.Attribute.mediaRouteChooserSecondaryTextStyle = global::FABSample.Droid.Resource.Attribute.mediaRouteChooserSecondaryTextStyle;
 			global::FAB.Droid.Resource.Attribute.mediaRouteCloseDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteCloseDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteCollapseGroupDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteCollapseGroupDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteConnectingDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteConnectingDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteControllerPrimaryTextStyle = global::FABSample.Droid.Resource.Attribute.mediaRouteControllerPrimaryTextStyle;
-			global::FAB.Droid.Resource.Attribute.mediaRouteControllerSecondaryTextStyle = global::FABSample.Droid.Resource.Attribute.mediaRouteControllerSecondaryTextStyle;
-			global::FAB.Droid.Resource.Attribute.mediaRouteControllerTitleTextStyle = global::FABSample.Droid.Resource.Attribute.mediaRouteControllerTitleTextStyle;
+			global::FAB.Droid.Resource.Attribute.mediaRouteControlPanelThemeOverlay = global::FABSample.Droid.Resource.Attribute.mediaRouteControlPanelThemeOverlay;
 			global::FAB.Droid.Resource.Attribute.mediaRouteDefaultIconDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteDefaultIconDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteExpandGroupDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteExpandGroupDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteOffDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteOffDrawable;
-			global::FAB.Droid.Resource.Attribute.mediaRouteOnDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteOnDrawable;
 			global::FAB.Droid.Resource.Attribute.mediaRoutePauseDrawable = global::FABSample.Droid.Resource.Attribute.mediaRoutePauseDrawable;
 			global::FAB.Droid.Resource.Attribute.mediaRoutePlayDrawable = global::FABSample.Droid.Resource.Attribute.mediaRoutePlayDrawable;
 			global::FAB.Droid.Resource.Attribute.mediaRouteSpeakerGroupIconDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteSpeakerGroupIconDrawable;
 			global::FAB.Droid.Resource.Attribute.mediaRouteSpeakerIconDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteSpeakerIconDrawable;
+			global::FAB.Droid.Resource.Attribute.mediaRouteStopDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteStopDrawable;
+			global::FAB.Droid.Resource.Attribute.mediaRouteTheme = global::FABSample.Droid.Resource.Attribute.mediaRouteTheme;
 			global::FAB.Droid.Resource.Attribute.mediaRouteTvIconDrawable = global::FABSample.Droid.Resource.Attribute.mediaRouteTvIconDrawable;
 			global::FAB.Droid.Resource.Attribute.menu = global::FABSample.Droid.Resource.Attribute.menu;
 			global::FAB.Droid.Resource.Attribute.multiChoiceItemLayout = global::FABSample.Droid.Resource.Attribute.multiChoiceItemLayout;
@@ -260,11 +260,18 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.navigationIcon = global::FABSample.Droid.Resource.Attribute.navigationIcon;
 			global::FAB.Droid.Resource.Attribute.navigationMode = global::FABSample.Droid.Resource.Attribute.navigationMode;
 			global::FAB.Droid.Resource.Attribute.overlapAnchor = global::FABSample.Droid.Resource.Attribute.overlapAnchor;
+			global::FAB.Droid.Resource.Attribute.paddingBottomNoButtons = global::FABSample.Droid.Resource.Attribute.paddingBottomNoButtons;
 			global::FAB.Droid.Resource.Attribute.paddingEnd = global::FABSample.Droid.Resource.Attribute.paddingEnd;
 			global::FAB.Droid.Resource.Attribute.paddingStart = global::FABSample.Droid.Resource.Attribute.paddingStart;
+			global::FAB.Droid.Resource.Attribute.paddingTopNoTitle = global::FABSample.Droid.Resource.Attribute.paddingTopNoTitle;
 			global::FAB.Droid.Resource.Attribute.panelBackground = global::FABSample.Droid.Resource.Attribute.panelBackground;
 			global::FAB.Droid.Resource.Attribute.panelMenuListTheme = global::FABSample.Droid.Resource.Attribute.panelMenuListTheme;
 			global::FAB.Droid.Resource.Attribute.panelMenuListWidth = global::FABSample.Droid.Resource.Attribute.panelMenuListWidth;
+			global::FAB.Droid.Resource.Attribute.passwordToggleContentDescription = global::FABSample.Droid.Resource.Attribute.passwordToggleContentDescription;
+			global::FAB.Droid.Resource.Attribute.passwordToggleDrawable = global::FABSample.Droid.Resource.Attribute.passwordToggleDrawable;
+			global::FAB.Droid.Resource.Attribute.passwordToggleEnabled = global::FABSample.Droid.Resource.Attribute.passwordToggleEnabled;
+			global::FAB.Droid.Resource.Attribute.passwordToggleTint = global::FABSample.Droid.Resource.Attribute.passwordToggleTint;
+			global::FAB.Droid.Resource.Attribute.passwordToggleTintMode = global::FABSample.Droid.Resource.Attribute.passwordToggleTintMode;
 			global::FAB.Droid.Resource.Attribute.popupMenuStyle = global::FABSample.Droid.Resource.Attribute.popupMenuStyle;
 			global::FAB.Droid.Resource.Attribute.popupTheme = global::FABSample.Droid.Resource.Attribute.popupTheme;
 			global::FAB.Droid.Resource.Attribute.popupWindowStyle = global::FABSample.Droid.Resource.Attribute.popupWindowStyle;
@@ -280,6 +287,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.ratingBarStyleSmall = global::FABSample.Droid.Resource.Attribute.ratingBarStyleSmall;
 			global::FAB.Droid.Resource.Attribute.reverseLayout = global::FABSample.Droid.Resource.Attribute.reverseLayout;
 			global::FAB.Droid.Resource.Attribute.rippleColor = global::FABSample.Droid.Resource.Attribute.rippleColor;
+			global::FAB.Droid.Resource.Attribute.scrimAnimationDuration = global::FABSample.Droid.Resource.Attribute.scrimAnimationDuration;
+			global::FAB.Droid.Resource.Attribute.scrimVisibleHeightTrigger = global::FABSample.Droid.Resource.Attribute.scrimVisibleHeightTrigger;
 			global::FAB.Droid.Resource.Attribute.searchHintIcon = global::FABSample.Droid.Resource.Attribute.searchHintIcon;
 			global::FAB.Droid.Resource.Attribute.searchIcon = global::FABSample.Droid.Resource.Attribute.searchIcon;
 			global::FAB.Droid.Resource.Attribute.searchViewStyle = global::FABSample.Droid.Resource.Attribute.searchViewStyle;
@@ -289,6 +298,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.showAsAction = global::FABSample.Droid.Resource.Attribute.showAsAction;
 			global::FAB.Droid.Resource.Attribute.showDividers = global::FABSample.Droid.Resource.Attribute.showDividers;
 			global::FAB.Droid.Resource.Attribute.showText = global::FABSample.Droid.Resource.Attribute.showText;
+			global::FAB.Droid.Resource.Attribute.showTitle = global::FABSample.Droid.Resource.Attribute.showTitle;
 			global::FAB.Droid.Resource.Attribute.singleChoiceItemLayout = global::FABSample.Droid.Resource.Attribute.singleChoiceItemLayout;
 			global::FAB.Droid.Resource.Attribute.spanCount = global::FABSample.Droid.Resource.Attribute.spanCount;
 			global::FAB.Droid.Resource.Attribute.spinBars = global::FABSample.Droid.Resource.Attribute.spinBars;
@@ -298,8 +308,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.srcCompat = global::FABSample.Droid.Resource.Attribute.srcCompat;
 			global::FAB.Droid.Resource.Attribute.stackFromEnd = global::FABSample.Droid.Resource.Attribute.stackFromEnd;
 			global::FAB.Droid.Resource.Attribute.state_above_anchor = global::FABSample.Droid.Resource.Attribute.state_above_anchor;
+			global::FAB.Droid.Resource.Attribute.state_collapsed = global::FABSample.Droid.Resource.Attribute.state_collapsed;
+			global::FAB.Droid.Resource.Attribute.state_collapsible = global::FABSample.Droid.Resource.Attribute.state_collapsible;
 			global::FAB.Droid.Resource.Attribute.statusBarBackground = global::FABSample.Droid.Resource.Attribute.statusBarBackground;
 			global::FAB.Droid.Resource.Attribute.statusBarScrim = global::FABSample.Droid.Resource.Attribute.statusBarScrim;
+			global::FAB.Droid.Resource.Attribute.subMenuArrow = global::FABSample.Droid.Resource.Attribute.subMenuArrow;
 			global::FAB.Droid.Resource.Attribute.submitBackground = global::FABSample.Droid.Resource.Attribute.submitBackground;
 			global::FAB.Droid.Resource.Attribute.subtitle = global::FABSample.Droid.Resource.Attribute.subtitle;
 			global::FAB.Droid.Resource.Attribute.subtitleTextAppearance = global::FABSample.Droid.Resource.Attribute.subtitleTextAppearance;
@@ -330,6 +343,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.textAppearanceLargePopupMenu = global::FABSample.Droid.Resource.Attribute.textAppearanceLargePopupMenu;
 			global::FAB.Droid.Resource.Attribute.textAppearanceListItem = global::FABSample.Droid.Resource.Attribute.textAppearanceListItem;
 			global::FAB.Droid.Resource.Attribute.textAppearanceListItemSmall = global::FABSample.Droid.Resource.Attribute.textAppearanceListItemSmall;
+			global::FAB.Droid.Resource.Attribute.textAppearancePopupMenuHeader = global::FABSample.Droid.Resource.Attribute.textAppearancePopupMenuHeader;
 			global::FAB.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle = global::FABSample.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle;
 			global::FAB.Droid.Resource.Attribute.textAppearanceSearchResultTitle = global::FABSample.Droid.Resource.Attribute.textAppearanceSearchResultTitle;
 			global::FAB.Droid.Resource.Attribute.textAppearanceSmallPopupMenu = global::FABSample.Droid.Resource.Attribute.textAppearanceSmallPopupMenu;
@@ -339,8 +353,14 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.theme = global::FABSample.Droid.Resource.Attribute.theme;
 			global::FAB.Droid.Resource.Attribute.thickness = global::FABSample.Droid.Resource.Attribute.thickness;
 			global::FAB.Droid.Resource.Attribute.thumbTextPadding = global::FABSample.Droid.Resource.Attribute.thumbTextPadding;
+			global::FAB.Droid.Resource.Attribute.thumbTint = global::FABSample.Droid.Resource.Attribute.thumbTint;
+			global::FAB.Droid.Resource.Attribute.thumbTintMode = global::FABSample.Droid.Resource.Attribute.thumbTintMode;
+			global::FAB.Droid.Resource.Attribute.tickMark = global::FABSample.Droid.Resource.Attribute.tickMark;
+			global::FAB.Droid.Resource.Attribute.tickMarkTint = global::FABSample.Droid.Resource.Attribute.tickMarkTint;
+			global::FAB.Droid.Resource.Attribute.tickMarkTintMode = global::FABSample.Droid.Resource.Attribute.tickMarkTintMode;
 			global::FAB.Droid.Resource.Attribute.title = global::FABSample.Droid.Resource.Attribute.title;
 			global::FAB.Droid.Resource.Attribute.titleEnabled = global::FABSample.Droid.Resource.Attribute.titleEnabled;
+			global::FAB.Droid.Resource.Attribute.titleMargin = global::FABSample.Droid.Resource.Attribute.titleMargin;
 			global::FAB.Droid.Resource.Attribute.titleMarginBottom = global::FABSample.Droid.Resource.Attribute.titleMarginBottom;
 			global::FAB.Droid.Resource.Attribute.titleMarginEnd = global::FABSample.Droid.Resource.Attribute.titleMarginEnd;
 			global::FAB.Droid.Resource.Attribute.titleMarginStart = global::FABSample.Droid.Resource.Attribute.titleMarginStart;
@@ -353,6 +373,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.toolbarNavigationButtonStyle = global::FABSample.Droid.Resource.Attribute.toolbarNavigationButtonStyle;
 			global::FAB.Droid.Resource.Attribute.toolbarStyle = global::FABSample.Droid.Resource.Attribute.toolbarStyle;
 			global::FAB.Droid.Resource.Attribute.track = global::FABSample.Droid.Resource.Attribute.track;
+			global::FAB.Droid.Resource.Attribute.trackTint = global::FABSample.Droid.Resource.Attribute.trackTint;
+			global::FAB.Droid.Resource.Attribute.trackTintMode = global::FABSample.Droid.Resource.Attribute.trackTintMode;
 			global::FAB.Droid.Resource.Attribute.useCompatPadding = global::FABSample.Droid.Resource.Attribute.useCompatPadding;
 			global::FAB.Droid.Resource.Attribute.voiceIcon = global::FABSample.Droid.Resource.Attribute.voiceIcon;
 			global::FAB.Droid.Resource.Attribute.windowActionBar = global::FABSample.Droid.Resource.Attribute.windowActionBar;
@@ -366,16 +388,17 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Attribute.windowMinWidthMinor = global::FABSample.Droid.Resource.Attribute.windowMinWidthMinor;
 			global::FAB.Droid.Resource.Attribute.windowNoTitle = global::FABSample.Droid.Resource.Attribute.windowNoTitle;
 			global::FAB.Droid.Resource.Boolean.abc_action_bar_embed_tabs = global::FABSample.Droid.Resource.Boolean.abc_action_bar_embed_tabs;
-			global::FAB.Droid.Resource.Boolean.abc_action_bar_embed_tabs_pre_jb = global::FABSample.Droid.Resource.Boolean.abc_action_bar_embed_tabs_pre_jb;
-			global::FAB.Droid.Resource.Boolean.abc_action_bar_expanded_action_views_exclusive = global::FABSample.Droid.Resource.Boolean.abc_action_bar_expanded_action_views_exclusive;
 			global::FAB.Droid.Resource.Boolean.abc_allow_stacked_button_bar = global::FABSample.Droid.Resource.Boolean.abc_allow_stacked_button_bar;
 			global::FAB.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps = global::FABSample.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps;
-			global::FAB.Droid.Resource.Boolean.abc_config_allowActionMenuItemTextWithIcon = global::FABSample.Droid.Resource.Boolean.abc_config_allowActionMenuItemTextWithIcon;
 			global::FAB.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside = global::FABSample.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside;
 			global::FAB.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent = global::FABSample.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent;
 			global::FAB.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark = global::FABSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark;
 			global::FAB.Droid.Resource.Color.abc_background_cache_hint_selector_material_light = global::FABSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_light;
+			global::FAB.Droid.Resource.Color.abc_btn_colored_borderless_text_material = global::FABSample.Droid.Resource.Color.abc_btn_colored_borderless_text_material;
+			global::FAB.Droid.Resource.Color.abc_btn_colored_text_material = global::FABSample.Droid.Resource.Color.abc_btn_colored_text_material;
 			global::FAB.Droid.Resource.Color.abc_color_highlight_material = global::FABSample.Droid.Resource.Color.abc_color_highlight_material;
+			global::FAB.Droid.Resource.Color.abc_hint_foreground_material_dark = global::FABSample.Droid.Resource.Color.abc_hint_foreground_material_dark;
+			global::FAB.Droid.Resource.Color.abc_hint_foreground_material_light = global::FABSample.Droid.Resource.Color.abc_hint_foreground_material_light;
 			global::FAB.Droid.Resource.Color.abc_input_method_navigation_guard = global::FABSample.Droid.Resource.Color.abc_input_method_navigation_guard;
 			global::FAB.Droid.Resource.Color.abc_primary_text_disable_only_material_dark = global::FABSample.Droid.Resource.Color.abc_primary_text_disable_only_material_dark;
 			global::FAB.Droid.Resource.Color.abc_primary_text_disable_only_material_light = global::FABSample.Droid.Resource.Color.abc_primary_text_disable_only_material_light;
@@ -387,6 +410,13 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Color.abc_search_url_text_selected = global::FABSample.Droid.Resource.Color.abc_search_url_text_selected;
 			global::FAB.Droid.Resource.Color.abc_secondary_text_material_dark = global::FABSample.Droid.Resource.Color.abc_secondary_text_material_dark;
 			global::FAB.Droid.Resource.Color.abc_secondary_text_material_light = global::FABSample.Droid.Resource.Color.abc_secondary_text_material_light;
+			global::FAB.Droid.Resource.Color.abc_tint_btn_checkable = global::FABSample.Droid.Resource.Color.abc_tint_btn_checkable;
+			global::FAB.Droid.Resource.Color.abc_tint_default = global::FABSample.Droid.Resource.Color.abc_tint_default;
+			global::FAB.Droid.Resource.Color.abc_tint_edittext = global::FABSample.Droid.Resource.Color.abc_tint_edittext;
+			global::FAB.Droid.Resource.Color.abc_tint_seek_thumb = global::FABSample.Droid.Resource.Color.abc_tint_seek_thumb;
+			global::FAB.Droid.Resource.Color.abc_tint_spinner = global::FABSample.Droid.Resource.Color.abc_tint_spinner;
+			global::FAB.Droid.Resource.Color.abc_tint_switch_thumb = global::FABSample.Droid.Resource.Color.abc_tint_switch_thumb;
+			global::FAB.Droid.Resource.Color.abc_tint_switch_track = global::FABSample.Droid.Resource.Color.abc_tint_switch_track;
 			global::FAB.Droid.Resource.Color.accent_material_dark = global::FABSample.Droid.Resource.Color.accent_material_dark;
 			global::FAB.Droid.Resource.Color.accent_material_light = global::FABSample.Droid.Resource.Color.accent_material_light;
 			global::FAB.Droid.Resource.Color.background_floating_material_dark = global::FABSample.Droid.Resource.Color.background_floating_material_dark;
@@ -405,6 +435,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Color.cardview_light_background = global::FABSample.Droid.Resource.Color.cardview_light_background;
 			global::FAB.Droid.Resource.Color.cardview_shadow_end_color = global::FABSample.Droid.Resource.Color.cardview_shadow_end_color;
 			global::FAB.Droid.Resource.Color.cardview_shadow_start_color = global::FABSample.Droid.Resource.Color.cardview_shadow_start_color;
+			global::FAB.Droid.Resource.Color.design_bottom_navigation_shadow_color = global::FABSample.Droid.Resource.Color.design_bottom_navigation_shadow_color;
+			global::FAB.Droid.Resource.Color.design_error = global::FABSample.Droid.Resource.Color.design_error;
 			global::FAB.Droid.Resource.Color.design_fab_shadow_end_color = global::FABSample.Droid.Resource.Color.design_fab_shadow_end_color;
 			global::FAB.Droid.Resource.Color.design_fab_shadow_mid_color = global::FABSample.Droid.Resource.Color.design_fab_shadow_mid_color;
 			global::FAB.Droid.Resource.Color.design_fab_shadow_start_color = global::FABSample.Droid.Resource.Color.design_fab_shadow_start_color;
@@ -415,6 +447,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Color.design_snackbar_background_color = global::FABSample.Droid.Resource.Color.design_snackbar_background_color;
 			global::FAB.Droid.Resource.Color.design_textinput_error_color_dark = global::FABSample.Droid.Resource.Color.design_textinput_error_color_dark;
 			global::FAB.Droid.Resource.Color.design_textinput_error_color_light = global::FABSample.Droid.Resource.Color.design_textinput_error_color_light;
+			global::FAB.Droid.Resource.Color.design_tint_password_toggle = global::FABSample.Droid.Resource.Color.design_tint_password_toggle;
 			global::FAB.Droid.Resource.Color.dim_foreground_disabled_material_dark = global::FABSample.Droid.Resource.Color.dim_foreground_disabled_material_dark;
 			global::FAB.Droid.Resource.Color.dim_foreground_disabled_material_light = global::FABSample.Droid.Resource.Color.dim_foreground_disabled_material_light;
 			global::FAB.Droid.Resource.Color.dim_foreground_material_dark = global::FABSample.Droid.Resource.Color.dim_foreground_material_dark;
@@ -424,8 +457,6 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Color.foreground_material_light = global::FABSample.Droid.Resource.Color.foreground_material_light;
 			global::FAB.Droid.Resource.Color.highlighted_text_material_dark = global::FABSample.Droid.Resource.Color.highlighted_text_material_dark;
 			global::FAB.Droid.Resource.Color.highlighted_text_material_light = global::FABSample.Droid.Resource.Color.highlighted_text_material_light;
-			global::FAB.Droid.Resource.Color.hint_foreground_material_dark = global::FABSample.Droid.Resource.Color.hint_foreground_material_dark;
-			global::FAB.Droid.Resource.Color.hint_foreground_material_light = global::FABSample.Droid.Resource.Color.hint_foreground_material_light;
 			global::FAB.Droid.Resource.Color.material_blue_grey_800 = global::FABSample.Droid.Resource.Color.material_blue_grey_800;
 			global::FAB.Droid.Resource.Color.material_blue_grey_900 = global::FABSample.Droid.Resource.Color.material_blue_grey_900;
 			global::FAB.Droid.Resource.Color.material_blue_grey_950 = global::FABSample.Droid.Resource.Color.material_blue_grey_950;
@@ -438,6 +469,9 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Color.material_grey_800 = global::FABSample.Droid.Resource.Color.material_grey_800;
 			global::FAB.Droid.Resource.Color.material_grey_850 = global::FABSample.Droid.Resource.Color.material_grey_850;
 			global::FAB.Droid.Resource.Color.material_grey_900 = global::FABSample.Droid.Resource.Color.material_grey_900;
+			global::FAB.Droid.Resource.Color.notification_action_color_filter = global::FABSample.Droid.Resource.Color.notification_action_color_filter;
+			global::FAB.Droid.Resource.Color.notification_icon_bg_color = global::FABSample.Droid.Resource.Color.notification_icon_bg_color;
+			global::FAB.Droid.Resource.Color.notification_material_background_media_default_color = global::FABSample.Droid.Resource.Color.notification_material_background_media_default_color;
 			global::FAB.Droid.Resource.Color.primary_dark_material_dark = global::FABSample.Droid.Resource.Color.primary_dark_material_dark;
 			global::FAB.Droid.Resource.Color.primary_dark_material_light = global::FABSample.Droid.Resource.Color.primary_dark_material_light;
 			global::FAB.Droid.Resource.Color.primary_material_dark = global::FABSample.Droid.Resource.Color.primary_material_dark;
@@ -459,9 +493,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Color.switch_thumb_normal_material_dark = global::FABSample.Droid.Resource.Color.switch_thumb_normal_material_dark;
 			global::FAB.Droid.Resource.Color.switch_thumb_normal_material_light = global::FABSample.Droid.Resource.Color.switch_thumb_normal_material_light;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_content_inset_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_content_inset_material;
+			global::FAB.Droid.Resource.Dimension.abc_action_bar_content_inset_with_nav = global::FABSample.Droid.Resource.Dimension.abc_action_bar_content_inset_with_nav;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_default_height_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_default_height_material;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_default_padding_end_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_default_padding_end_material;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_default_padding_start_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_default_padding_start_material;
+			global::FAB.Droid.Resource.Dimension.abc_action_bar_elevation_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_elevation_material;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material;
 			global::FAB.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material = global::FABSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material;
@@ -478,6 +514,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.abc_button_inset_vertical_material = global::FABSample.Droid.Resource.Dimension.abc_button_inset_vertical_material;
 			global::FAB.Droid.Resource.Dimension.abc_button_padding_horizontal_material = global::FABSample.Droid.Resource.Dimension.abc_button_padding_horizontal_material;
 			global::FAB.Droid.Resource.Dimension.abc_button_padding_vertical_material = global::FABSample.Droid.Resource.Dimension.abc_button_padding_vertical_material;
+			global::FAB.Droid.Resource.Dimension.abc_cascading_menus_min_smallest_width = global::FABSample.Droid.Resource.Dimension.abc_cascading_menus_min_smallest_width;
 			global::FAB.Droid.Resource.Dimension.abc_config_prefDialogWidth = global::FABSample.Droid.Resource.Dimension.abc_config_prefDialogWidth;
 			global::FAB.Droid.Resource.Dimension.abc_control_corner_material = global::FABSample.Droid.Resource.Dimension.abc_control_corner_material;
 			global::FAB.Droid.Resource.Dimension.abc_control_inset_material = global::FABSample.Droid.Resource.Dimension.abc_control_inset_material;
@@ -486,11 +523,13 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.abc_dialog_fixed_height_minor = global::FABSample.Droid.Resource.Dimension.abc_dialog_fixed_height_minor;
 			global::FAB.Droid.Resource.Dimension.abc_dialog_fixed_width_major = global::FABSample.Droid.Resource.Dimension.abc_dialog_fixed_width_major;
 			global::FAB.Droid.Resource.Dimension.abc_dialog_fixed_width_minor = global::FABSample.Droid.Resource.Dimension.abc_dialog_fixed_width_minor;
-			global::FAB.Droid.Resource.Dimension.abc_dialog_list_padding_vertical_material = global::FABSample.Droid.Resource.Dimension.abc_dialog_list_padding_vertical_material;
+			global::FAB.Droid.Resource.Dimension.abc_dialog_list_padding_bottom_no_buttons = global::FABSample.Droid.Resource.Dimension.abc_dialog_list_padding_bottom_no_buttons;
+			global::FAB.Droid.Resource.Dimension.abc_dialog_list_padding_top_no_title = global::FABSample.Droid.Resource.Dimension.abc_dialog_list_padding_top_no_title;
 			global::FAB.Droid.Resource.Dimension.abc_dialog_min_width_major = global::FABSample.Droid.Resource.Dimension.abc_dialog_min_width_major;
 			global::FAB.Droid.Resource.Dimension.abc_dialog_min_width_minor = global::FABSample.Droid.Resource.Dimension.abc_dialog_min_width_minor;
 			global::FAB.Droid.Resource.Dimension.abc_dialog_padding_material = global::FABSample.Droid.Resource.Dimension.abc_dialog_padding_material;
 			global::FAB.Droid.Resource.Dimension.abc_dialog_padding_top_material = global::FABSample.Droid.Resource.Dimension.abc_dialog_padding_top_material;
+			global::FAB.Droid.Resource.Dimension.abc_dialog_title_divider_material = global::FABSample.Droid.Resource.Dimension.abc_dialog_title_divider_material;
 			global::FAB.Droid.Resource.Dimension.abc_disabled_alpha_material_dark = global::FABSample.Droid.Resource.Dimension.abc_disabled_alpha_material_dark;
 			global::FAB.Droid.Resource.Dimension.abc_disabled_alpha_material_light = global::FABSample.Droid.Resource.Dimension.abc_disabled_alpha_material_light;
 			global::FAB.Droid.Resource.Dimension.abc_dropdownitem_icon_width = global::FABSample.Droid.Resource.Dimension.abc_dropdownitem_icon_width;
@@ -502,8 +541,9 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.abc_floating_window_z = global::FABSample.Droid.Resource.Dimension.abc_floating_window_z;
 			global::FAB.Droid.Resource.Dimension.abc_list_item_padding_horizontal_material = global::FABSample.Droid.Resource.Dimension.abc_list_item_padding_horizontal_material;
 			global::FAB.Droid.Resource.Dimension.abc_panel_menu_list_width = global::FABSample.Droid.Resource.Dimension.abc_panel_menu_list_width;
+			global::FAB.Droid.Resource.Dimension.abc_progress_bar_height_material = global::FABSample.Droid.Resource.Dimension.abc_progress_bar_height_material;
+			global::FAB.Droid.Resource.Dimension.abc_search_view_preferred_height = global::FABSample.Droid.Resource.Dimension.abc_search_view_preferred_height;
 			global::FAB.Droid.Resource.Dimension.abc_search_view_preferred_width = global::FABSample.Droid.Resource.Dimension.abc_search_view_preferred_width;
-			global::FAB.Droid.Resource.Dimension.abc_search_view_text_min_width = global::FABSample.Droid.Resource.Dimension.abc_search_view_text_min_width;
 			global::FAB.Droid.Resource.Dimension.abc_seekbar_track_background_height_material = global::FABSample.Droid.Resource.Dimension.abc_seekbar_track_background_height_material;
 			global::FAB.Droid.Resource.Dimension.abc_seekbar_track_progress_height_material = global::FABSample.Droid.Resource.Dimension.abc_seekbar_track_progress_height_material;
 			global::FAB.Droid.Resource.Dimension.abc_select_dialog_padding_start_material = global::FABSample.Droid.Resource.Dimension.abc_select_dialog_padding_start_material;
@@ -519,6 +559,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.abc_text_size_headline_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_headline_material;
 			global::FAB.Droid.Resource.Dimension.abc_text_size_large_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_large_material;
 			global::FAB.Droid.Resource.Dimension.abc_text_size_medium_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_medium_material;
+			global::FAB.Droid.Resource.Dimension.abc_text_size_menu_header_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_menu_header_material;
 			global::FAB.Droid.Resource.Dimension.abc_text_size_menu_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_menu_material;
 			global::FAB.Droid.Resource.Dimension.abc_text_size_small_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_small_material;
 			global::FAB.Droid.Resource.Dimension.abc_text_size_subhead_material = global::FABSample.Droid.Resource.Dimension.abc_text_size_subhead_material;
@@ -529,8 +570,17 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.cardview_default_elevation = global::FABSample.Droid.Resource.Dimension.cardview_default_elevation;
 			global::FAB.Droid.Resource.Dimension.cardview_default_radius = global::FABSample.Droid.Resource.Dimension.cardview_default_radius;
 			global::FAB.Droid.Resource.Dimension.design_appbar_elevation = global::FABSample.Droid.Resource.Dimension.design_appbar_elevation;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_active_item_max_width = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_active_item_max_width;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_active_text_size = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_active_text_size;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_elevation = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_elevation;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_height = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_height;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_item_max_width = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_item_max_width;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_item_min_width = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_item_min_width;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_margin = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_margin;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_shadow_height = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_shadow_height;
+			global::FAB.Droid.Resource.Dimension.design_bottom_navigation_text_size = global::FABSample.Droid.Resource.Dimension.design_bottom_navigation_text_size;
 			global::FAB.Droid.Resource.Dimension.design_bottom_sheet_modal_elevation = global::FABSample.Droid.Resource.Dimension.design_bottom_sheet_modal_elevation;
-			global::FAB.Droid.Resource.Dimension.design_bottom_sheet_modal_peek_height = global::FABSample.Droid.Resource.Dimension.design_bottom_sheet_modal_peek_height;
+			global::FAB.Droid.Resource.Dimension.design_bottom_sheet_peek_height_min = global::FABSample.Droid.Resource.Dimension.design_bottom_sheet_peek_height_min;
 			global::FAB.Droid.Resource.Dimension.design_fab_border_width = global::FABSample.Droid.Resource.Dimension.design_fab_border_width;
 			global::FAB.Droid.Resource.Dimension.design_fab_elevation = global::FABSample.Droid.Resource.Dimension.design_fab_elevation;
 			global::FAB.Droid.Resource.Dimension.design_fab_image_size = global::FABSample.Droid.Resource.Dimension.design_fab_image_size;
@@ -567,6 +617,10 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.highlight_alpha_material_colored = global::FABSample.Droid.Resource.Dimension.highlight_alpha_material_colored;
 			global::FAB.Droid.Resource.Dimension.highlight_alpha_material_dark = global::FABSample.Droid.Resource.Dimension.highlight_alpha_material_dark;
 			global::FAB.Droid.Resource.Dimension.highlight_alpha_material_light = global::FABSample.Droid.Resource.Dimension.highlight_alpha_material_light;
+			global::FAB.Droid.Resource.Dimension.hint_alpha_material_dark = global::FABSample.Droid.Resource.Dimension.hint_alpha_material_dark;
+			global::FAB.Droid.Resource.Dimension.hint_alpha_material_light = global::FABSample.Droid.Resource.Dimension.hint_alpha_material_light;
+			global::FAB.Droid.Resource.Dimension.hint_pressed_alpha_material_dark = global::FABSample.Droid.Resource.Dimension.hint_pressed_alpha_material_dark;
+			global::FAB.Droid.Resource.Dimension.hint_pressed_alpha_material_light = global::FABSample.Droid.Resource.Dimension.hint_pressed_alpha_material_light;
 			global::FAB.Droid.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame = global::FABSample.Droid.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame;
 			global::FAB.Droid.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity = global::FABSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity;
 			global::FAB.Droid.Resource.Dimension.item_touch_helper_swipe_escape_velocity = global::FABSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_velocity;
@@ -576,9 +630,21 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Dimension.mr_controller_volume_group_list_padding_top = global::FABSample.Droid.Resource.Dimension.mr_controller_volume_group_list_padding_top;
 			global::FAB.Droid.Resource.Dimension.mr_dialog_fixed_width_major = global::FABSample.Droid.Resource.Dimension.mr_dialog_fixed_width_major;
 			global::FAB.Droid.Resource.Dimension.mr_dialog_fixed_width_minor = global::FABSample.Droid.Resource.Dimension.mr_dialog_fixed_width_minor;
+			global::FAB.Droid.Resource.Dimension.notification_action_icon_size = global::FABSample.Droid.Resource.Dimension.notification_action_icon_size;
+			global::FAB.Droid.Resource.Dimension.notification_action_text_size = global::FABSample.Droid.Resource.Dimension.notification_action_text_size;
+			global::FAB.Droid.Resource.Dimension.notification_big_circle_margin = global::FABSample.Droid.Resource.Dimension.notification_big_circle_margin;
+			global::FAB.Droid.Resource.Dimension.notification_content_margin_start = global::FABSample.Droid.Resource.Dimension.notification_content_margin_start;
 			global::FAB.Droid.Resource.Dimension.notification_large_icon_height = global::FABSample.Droid.Resource.Dimension.notification_large_icon_height;
 			global::FAB.Droid.Resource.Dimension.notification_large_icon_width = global::FABSample.Droid.Resource.Dimension.notification_large_icon_width;
+			global::FAB.Droid.Resource.Dimension.notification_main_column_padding_top = global::FABSample.Droid.Resource.Dimension.notification_main_column_padding_top;
+			global::FAB.Droid.Resource.Dimension.notification_media_narrow_margin = global::FABSample.Droid.Resource.Dimension.notification_media_narrow_margin;
+			global::FAB.Droid.Resource.Dimension.notification_right_icon_size = global::FABSample.Droid.Resource.Dimension.notification_right_icon_size;
+			global::FAB.Droid.Resource.Dimension.notification_right_side_padding_top = global::FABSample.Droid.Resource.Dimension.notification_right_side_padding_top;
+			global::FAB.Droid.Resource.Dimension.notification_small_icon_background_padding = global::FABSample.Droid.Resource.Dimension.notification_small_icon_background_padding;
+			global::FAB.Droid.Resource.Dimension.notification_small_icon_size_as_large = global::FABSample.Droid.Resource.Dimension.notification_small_icon_size_as_large;
 			global::FAB.Droid.Resource.Dimension.notification_subtext_size = global::FABSample.Droid.Resource.Dimension.notification_subtext_size;
+			global::FAB.Droid.Resource.Dimension.notification_top_pad = global::FABSample.Droid.Resource.Dimension.notification_top_pad;
+			global::FAB.Droid.Resource.Dimension.notification_top_pad_large_text = global::FABSample.Droid.Resource.Dimension.notification_top_pad_large_text;
 			global::FAB.Droid.Resource.Drawable.abc_ab_share_pack_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ab_share_pack_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_action_bar_item_background_material = global::FABSample.Droid.Resource.Drawable.abc_action_bar_item_background_material;
 			global::FAB.Droid.Resource.Drawable.abc_btn_borderless_material = global::FABSample.Droid.Resource.Drawable.abc_btn_borderless_material;
@@ -590,33 +656,33 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Drawable.abc_btn_radio_material = global::FABSample.Droid.Resource.Drawable.abc_btn_radio_material;
 			global::FAB.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_000 = global::FABSample.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_000;
 			global::FAB.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_015 = global::FABSample.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_015;
-			global::FAB.Droid.Resource.Drawable.abc_btn_rating_star_off_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_btn_rating_star_off_mtrl_alpha;
-			global::FAB.Droid.Resource.Drawable.abc_btn_rating_star_on_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_btn_rating_star_on_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00001 = global::FABSample.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00001;
 			global::FAB.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00012 = global::FABSample.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00012;
 			global::FAB.Droid.Resource.Drawable.abc_cab_background_internal_bg = global::FABSample.Droid.Resource.Drawable.abc_cab_background_internal_bg;
 			global::FAB.Droid.Resource.Drawable.abc_cab_background_top_material = global::FABSample.Droid.Resource.Drawable.abc_cab_background_top_material;
 			global::FAB.Droid.Resource.Drawable.abc_cab_background_top_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_cab_background_top_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_control_background_material = global::FABSample.Droid.Resource.Drawable.abc_control_background_material;
-			global::FAB.Droid.Resource.Drawable.abc_dialog_material_background_dark = global::FABSample.Droid.Resource.Drawable.abc_dialog_material_background_dark;
-			global::FAB.Droid.Resource.Drawable.abc_dialog_material_background_light = global::FABSample.Droid.Resource.Drawable.abc_dialog_material_background_light;
+			global::FAB.Droid.Resource.Drawable.abc_dialog_material_background = global::FABSample.Droid.Resource.Drawable.abc_dialog_material_background;
 			global::FAB.Droid.Resource.Drawable.abc_edit_text_material = global::FABSample.Droid.Resource.Drawable.abc_edit_text_material;
-			global::FAB.Droid.Resource.Drawable.abc_ic_ab_back_mtrl_am_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_ab_back_mtrl_am_alpha;
-			global::FAB.Droid.Resource.Drawable.abc_ic_clear_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_clear_mtrl_alpha;
+			global::FAB.Droid.Resource.Drawable.abc_ic_ab_back_material = global::FABSample.Droid.Resource.Drawable.abc_ic_ab_back_material;
+			global::FAB.Droid.Resource.Drawable.abc_ic_arrow_drop_right_black_24dp = global::FABSample.Droid.Resource.Drawable.abc_ic_arrow_drop_right_black_24dp;
+			global::FAB.Droid.Resource.Drawable.abc_ic_clear_material = global::FABSample.Droid.Resource.Drawable.abc_ic_clear_material;
 			global::FAB.Droid.Resource.Drawable.abc_ic_commit_search_api_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_commit_search_api_mtrl_alpha;
-			global::FAB.Droid.Resource.Drawable.abc_ic_go_search_api_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_go_search_api_mtrl_alpha;
+			global::FAB.Droid.Resource.Drawable.abc_ic_go_search_api_material = global::FABSample.Droid.Resource.Drawable.abc_ic_go_search_api_material;
 			global::FAB.Droid.Resource.Drawable.abc_ic_menu_copy_mtrl_am_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_copy_mtrl_am_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_ic_menu_cut_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_cut_mtrl_alpha;
-			global::FAB.Droid.Resource.Drawable.abc_ic_menu_moreoverflow_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_moreoverflow_mtrl_alpha;
+			global::FAB.Droid.Resource.Drawable.abc_ic_menu_overflow_material = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_overflow_material;
 			global::FAB.Droid.Resource.Drawable.abc_ic_menu_paste_mtrl_am_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_paste_mtrl_am_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_ic_menu_selectall_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_selectall_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_ic_menu_share_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_menu_share_mtrl_alpha;
-			global::FAB.Droid.Resource.Drawable.abc_ic_search_api_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_search_api_mtrl_alpha;
+			global::FAB.Droid.Resource.Drawable.abc_ic_search_api_material = global::FABSample.Droid.Resource.Drawable.abc_ic_search_api_material;
 			global::FAB.Droid.Resource.Drawable.abc_ic_star_black_16dp = global::FABSample.Droid.Resource.Drawable.abc_ic_star_black_16dp;
 			global::FAB.Droid.Resource.Drawable.abc_ic_star_black_36dp = global::FABSample.Droid.Resource.Drawable.abc_ic_star_black_36dp;
+			global::FAB.Droid.Resource.Drawable.abc_ic_star_black_48dp = global::FABSample.Droid.Resource.Drawable.abc_ic_star_black_48dp;
 			global::FAB.Droid.Resource.Drawable.abc_ic_star_half_black_16dp = global::FABSample.Droid.Resource.Drawable.abc_ic_star_half_black_16dp;
 			global::FAB.Droid.Resource.Drawable.abc_ic_star_half_black_36dp = global::FABSample.Droid.Resource.Drawable.abc_ic_star_half_black_36dp;
-			global::FAB.Droid.Resource.Drawable.abc_ic_voice_search_api_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_ic_voice_search_api_mtrl_alpha;
+			global::FAB.Droid.Resource.Drawable.abc_ic_star_half_black_48dp = global::FABSample.Droid.Resource.Drawable.abc_ic_star_half_black_48dp;
+			global::FAB.Droid.Resource.Drawable.abc_ic_voice_search_api_material = global::FABSample.Droid.Resource.Drawable.abc_ic_voice_search_api_material;
 			global::FAB.Droid.Resource.Drawable.abc_item_background_holo_dark = global::FABSample.Droid.Resource.Drawable.abc_item_background_holo_dark;
 			global::FAB.Droid.Resource.Drawable.abc_item_background_holo_light = global::FABSample.Droid.Resource.Drawable.abc_item_background_holo_light;
 			global::FAB.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha;
@@ -632,8 +698,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Drawable.abc_list_selector_holo_light = global::FABSample.Droid.Resource.Drawable.abc_list_selector_holo_light;
 			global::FAB.Droid.Resource.Drawable.abc_menu_hardkey_panel_mtrl_mult = global::FABSample.Droid.Resource.Drawable.abc_menu_hardkey_panel_mtrl_mult;
 			global::FAB.Droid.Resource.Drawable.abc_popup_background_mtrl_mult = global::FABSample.Droid.Resource.Drawable.abc_popup_background_mtrl_mult;
-			global::FAB.Droid.Resource.Drawable.abc_ratingbar_full_material = global::FABSample.Droid.Resource.Drawable.abc_ratingbar_full_material;
 			global::FAB.Droid.Resource.Drawable.abc_ratingbar_indicator_material = global::FABSample.Droid.Resource.Drawable.abc_ratingbar_indicator_material;
+			global::FAB.Droid.Resource.Drawable.abc_ratingbar_material = global::FABSample.Droid.Resource.Drawable.abc_ratingbar_material;
 			global::FAB.Droid.Resource.Drawable.abc_ratingbar_small_material = global::FABSample.Droid.Resource.Drawable.abc_ratingbar_small_material;
 			global::FAB.Droid.Resource.Drawable.abc_scrubber_control_off_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_scrubber_control_off_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_scrubber_control_to_pressed_mtrl_000 = global::FABSample.Droid.Resource.Drawable.abc_scrubber_control_to_pressed_mtrl_000;
@@ -641,6 +707,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Drawable.abc_scrubber_primary_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_scrubber_primary_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_scrubber_track_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_scrubber_track_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_seekbar_thumb_material = global::FABSample.Droid.Resource.Drawable.abc_seekbar_thumb_material;
+			global::FAB.Droid.Resource.Drawable.abc_seekbar_tick_mark_material = global::FABSample.Droid.Resource.Drawable.abc_seekbar_tick_mark_material;
 			global::FAB.Droid.Resource.Drawable.abc_seekbar_track_material = global::FABSample.Droid.Resource.Drawable.abc_seekbar_track_material;
 			global::FAB.Droid.Resource.Drawable.abc_spinner_mtrl_am_alpha = global::FABSample.Droid.Resource.Drawable.abc_spinner_mtrl_am_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_spinner_textfield_background_material = global::FABSample.Droid.Resource.Drawable.abc_spinner_textfield_background_material;
@@ -649,99 +716,212 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Drawable.abc_tab_indicator_material = global::FABSample.Droid.Resource.Drawable.abc_tab_indicator_material;
 			global::FAB.Droid.Resource.Drawable.abc_tab_indicator_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_tab_indicator_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_text_cursor_material = global::FABSample.Droid.Resource.Drawable.abc_text_cursor_material;
+			global::FAB.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_dark = global::FABSample.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_dark;
+			global::FAB.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_light = global::FABSample.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_light;
+			global::FAB.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_dark = global::FABSample.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_dark;
+			global::FAB.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_light = global::FABSample.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_light;
+			global::FAB.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_dark = global::FABSample.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_dark;
+			global::FAB.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_light = global::FABSample.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_light;
 			global::FAB.Droid.Resource.Drawable.abc_textfield_activated_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_textfield_activated_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_textfield_default_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_textfield_default_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_textfield_search_activated_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_textfield_search_activated_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_textfield_search_default_mtrl_alpha = global::FABSample.Droid.Resource.Drawable.abc_textfield_search_default_mtrl_alpha;
 			global::FAB.Droid.Resource.Drawable.abc_textfield_search_material = global::FABSample.Droid.Resource.Drawable.abc_textfield_search_material;
+			global::FAB.Droid.Resource.Drawable.abc_vector_test = global::FABSample.Droid.Resource.Drawable.abc_vector_test;
+			global::FAB.Droid.Resource.Drawable.avd_hide_password = global::FABSample.Droid.Resource.Drawable.avd_hide_password;
+			global::FAB.Droid.Resource.Drawable.avd_hide_password_1 = global::FABSample.Droid.Resource.Drawable.avd_hide_password_1;
+			global::FAB.Droid.Resource.Drawable.avd_hide_password_2 = global::FABSample.Droid.Resource.Drawable.avd_hide_password_2;
+			global::FAB.Droid.Resource.Drawable.avd_hide_password_3 = global::FABSample.Droid.Resource.Drawable.avd_hide_password_3;
+			global::FAB.Droid.Resource.Drawable.avd_show_password = global::FABSample.Droid.Resource.Drawable.avd_show_password;
+			global::FAB.Droid.Resource.Drawable.avd_show_password_1 = global::FABSample.Droid.Resource.Drawable.avd_show_password_1;
+			global::FAB.Droid.Resource.Drawable.avd_show_password_2 = global::FABSample.Droid.Resource.Drawable.avd_show_password_2;
+			global::FAB.Droid.Resource.Drawable.avd_show_password_3 = global::FABSample.Droid.Resource.Drawable.avd_show_password_3;
+			global::FAB.Droid.Resource.Drawable.design_bottom_navigation_item_background = global::FABSample.Droid.Resource.Drawable.design_bottom_navigation_item_background;
 			global::FAB.Droid.Resource.Drawable.design_fab_background = global::FABSample.Droid.Resource.Drawable.design_fab_background;
+			global::FAB.Droid.Resource.Drawable.design_ic_visibility = global::FABSample.Droid.Resource.Drawable.design_ic_visibility;
+			global::FAB.Droid.Resource.Drawable.design_ic_visibility_off = global::FABSample.Droid.Resource.Drawable.design_ic_visibility_off;
+			global::FAB.Droid.Resource.Drawable.design_password_eye = global::FABSample.Droid.Resource.Drawable.design_password_eye;
 			global::FAB.Droid.Resource.Drawable.design_snackbar_background = global::FABSample.Droid.Resource.Drawable.design_snackbar_background;
 			global::FAB.Droid.Resource.Drawable.fab_shadow = global::FABSample.Droid.Resource.Drawable.fab_shadow;
 			global::FAB.Droid.Resource.Drawable.fab_shadow_mini = global::FABSample.Droid.Resource.Drawable.fab_shadow_mini;
-			global::FAB.Droid.Resource.Drawable.ic_audiotrack = global::FABSample.Droid.Resource.Drawable.ic_audiotrack;
+			global::FAB.Droid.Resource.Drawable.ic_audiotrack_dark = global::FABSample.Droid.Resource.Drawable.ic_audiotrack_dark;
 			global::FAB.Droid.Resource.Drawable.ic_audiotrack_light = global::FABSample.Droid.Resource.Drawable.ic_audiotrack_light;
-			global::FAB.Droid.Resource.Drawable.ic_bluetooth_grey = global::FABSample.Droid.Resource.Drawable.ic_bluetooth_grey;
-			global::FAB.Droid.Resource.Drawable.ic_bluetooth_white = global::FABSample.Droid.Resource.Drawable.ic_bluetooth_white;
-			global::FAB.Droid.Resource.Drawable.ic_cast_dark = global::FABSample.Droid.Resource.Drawable.ic_cast_dark;
-			global::FAB.Droid.Resource.Drawable.ic_cast_disabled_light = global::FABSample.Droid.Resource.Drawable.ic_cast_disabled_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_grey = global::FABSample.Droid.Resource.Drawable.ic_cast_grey;
-			global::FAB.Droid.Resource.Drawable.ic_cast_light = global::FABSample.Droid.Resource.Drawable.ic_cast_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_off_light = global::FABSample.Droid.Resource.Drawable.ic_cast_off_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_on_0_light = global::FABSample.Droid.Resource.Drawable.ic_cast_on_0_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_on_1_light = global::FABSample.Droid.Resource.Drawable.ic_cast_on_1_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_on_2_light = global::FABSample.Droid.Resource.Drawable.ic_cast_on_2_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_on_light = global::FABSample.Droid.Resource.Drawable.ic_cast_on_light;
-			global::FAB.Droid.Resource.Drawable.ic_cast_white = global::FABSample.Droid.Resource.Drawable.ic_cast_white;
-			global::FAB.Droid.Resource.Drawable.ic_close_dark = global::FABSample.Droid.Resource.Drawable.ic_close_dark;
-			global::FAB.Droid.Resource.Drawable.ic_close_light = global::FABSample.Droid.Resource.Drawable.ic_close_light;
-			global::FAB.Droid.Resource.Drawable.ic_collapse = global::FABSample.Droid.Resource.Drawable.ic_collapse;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00000 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00000;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00001 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00001;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00002 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00002;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00003 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00003;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00004 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00004;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00005 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00005;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00006 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00006;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00007 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00007;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00008 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00008;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00009 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00009;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00010 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00010;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00011 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00011;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00012 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00012;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00013 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00013;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00014 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00014;
-			global::FAB.Droid.Resource.Drawable.ic_collapse_00015 = global::FABSample.Droid.Resource.Drawable.ic_collapse_00015;
-			global::FAB.Droid.Resource.Drawable.ic_expand = global::FABSample.Droid.Resource.Drawable.ic_expand;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00000 = global::FABSample.Droid.Resource.Drawable.ic_expand_00000;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00001 = global::FABSample.Droid.Resource.Drawable.ic_expand_00001;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00002 = global::FABSample.Droid.Resource.Drawable.ic_expand_00002;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00003 = global::FABSample.Droid.Resource.Drawable.ic_expand_00003;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00004 = global::FABSample.Droid.Resource.Drawable.ic_expand_00004;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00005 = global::FABSample.Droid.Resource.Drawable.ic_expand_00005;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00006 = global::FABSample.Droid.Resource.Drawable.ic_expand_00006;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00007 = global::FABSample.Droid.Resource.Drawable.ic_expand_00007;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00008 = global::FABSample.Droid.Resource.Drawable.ic_expand_00008;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00009 = global::FABSample.Droid.Resource.Drawable.ic_expand_00009;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00010 = global::FABSample.Droid.Resource.Drawable.ic_expand_00010;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00011 = global::FABSample.Droid.Resource.Drawable.ic_expand_00011;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00012 = global::FABSample.Droid.Resource.Drawable.ic_expand_00012;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00013 = global::FABSample.Droid.Resource.Drawable.ic_expand_00013;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00014 = global::FABSample.Droid.Resource.Drawable.ic_expand_00014;
-			global::FAB.Droid.Resource.Drawable.ic_expand_00015 = global::FABSample.Droid.Resource.Drawable.ic_expand_00015;
-			global::FAB.Droid.Resource.Drawable.ic_media_pause = global::FABSample.Droid.Resource.Drawable.ic_media_pause;
-			global::FAB.Droid.Resource.Drawable.ic_media_play = global::FABSample.Droid.Resource.Drawable.ic_media_play;
-			global::FAB.Droid.Resource.Drawable.ic_media_route_disabled_mono_dark = global::FABSample.Droid.Resource.Drawable.ic_media_route_disabled_mono_dark;
-			global::FAB.Droid.Resource.Drawable.ic_media_route_off_mono_dark = global::FABSample.Droid.Resource.Drawable.ic_media_route_off_mono_dark;
-			global::FAB.Droid.Resource.Drawable.ic_media_route_on_0_mono_dark = global::FABSample.Droid.Resource.Drawable.ic_media_route_on_0_mono_dark;
-			global::FAB.Droid.Resource.Drawable.ic_media_route_on_1_mono_dark = global::FABSample.Droid.Resource.Drawable.ic_media_route_on_1_mono_dark;
-			global::FAB.Droid.Resource.Drawable.ic_media_route_on_2_mono_dark = global::FABSample.Droid.Resource.Drawable.ic_media_route_on_2_mono_dark;
-			global::FAB.Droid.Resource.Drawable.ic_media_route_on_mono_dark = global::FABSample.Droid.Resource.Drawable.ic_media_route_on_mono_dark;
-			global::FAB.Droid.Resource.Drawable.ic_pause_dark = global::FABSample.Droid.Resource.Drawable.ic_pause_dark;
-			global::FAB.Droid.Resource.Drawable.ic_pause_light = global::FABSample.Droid.Resource.Drawable.ic_pause_light;
-			global::FAB.Droid.Resource.Drawable.ic_play_dark = global::FABSample.Droid.Resource.Drawable.ic_play_dark;
-			global::FAB.Droid.Resource.Drawable.ic_play_light = global::FABSample.Droid.Resource.Drawable.ic_play_light;
-			global::FAB.Droid.Resource.Drawable.ic_speaker_dark = global::FABSample.Droid.Resource.Drawable.ic_speaker_dark;
-			global::FAB.Droid.Resource.Drawable.ic_speaker_group_dark = global::FABSample.Droid.Resource.Drawable.ic_speaker_group_dark;
-			global::FAB.Droid.Resource.Drawable.ic_speaker_group_light = global::FABSample.Droid.Resource.Drawable.ic_speaker_group_light;
-			global::FAB.Droid.Resource.Drawable.ic_speaker_light = global::FABSample.Droid.Resource.Drawable.ic_speaker_light;
-			global::FAB.Droid.Resource.Drawable.ic_tv_dark = global::FABSample.Droid.Resource.Drawable.ic_tv_dark;
-			global::FAB.Droid.Resource.Drawable.ic_tv_light = global::FABSample.Droid.Resource.Drawable.ic_tv_light;
+			global::FAB.Droid.Resource.Drawable.ic_dialog_close_dark = global::FABSample.Droid.Resource.Drawable.ic_dialog_close_dark;
+			global::FAB.Droid.Resource.Drawable.ic_dialog_close_light = global::FABSample.Droid.Resource.Drawable.ic_dialog_close_light;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_00 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_00;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_01 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_01;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_02 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_02;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_03 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_03;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_04 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_04;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_05 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_05;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_06 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_06;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_07 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_07;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_08 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_08;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_09 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_09;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_10 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_10;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_11 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_11;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_12 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_12;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_13 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_13;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_14 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_14;
+			global::FAB.Droid.Resource.Drawable.ic_group_collapse_15 = global::FABSample.Droid.Resource.Drawable.ic_group_collapse_15;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_00 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_00;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_01 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_01;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_02 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_02;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_03 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_03;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_04 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_04;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_05 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_05;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_06 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_06;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_07 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_07;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_08 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_08;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_09 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_09;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_10 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_10;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_11 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_11;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_12 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_12;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_13 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_13;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_14 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_14;
+			global::FAB.Droid.Resource.Drawable.ic_group_expand_15 = global::FABSample.Droid.Resource.Drawable.ic_group_expand_15;
+			global::FAB.Droid.Resource.Drawable.ic_media_pause_dark = global::FABSample.Droid.Resource.Drawable.ic_media_pause_dark;
+			global::FAB.Droid.Resource.Drawable.ic_media_pause_light = global::FABSample.Droid.Resource.Drawable.ic_media_pause_light;
+			global::FAB.Droid.Resource.Drawable.ic_media_play_dark = global::FABSample.Droid.Resource.Drawable.ic_media_play_dark;
+			global::FAB.Droid.Resource.Drawable.ic_media_play_light = global::FABSample.Droid.Resource.Drawable.ic_media_play_light;
+			global::FAB.Droid.Resource.Drawable.ic_media_stop_dark = global::FABSample.Droid.Resource.Drawable.ic_media_stop_dark;
+			global::FAB.Droid.Resource.Drawable.ic_media_stop_light = global::FABSample.Droid.Resource.Drawable.ic_media_stop_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_00_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_00_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_00_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_00_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_01_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_01_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_01_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_01_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_02_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_02_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_02_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_02_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_03_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_03_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_03_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_03_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_04_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_04_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_04_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_04_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_05_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_05_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_05_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_05_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_06_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_06_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_06_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_06_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_07_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_07_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_07_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_07_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_08_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_08_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_08_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_08_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_09_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_09_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_09_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_09_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_10_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_10_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_10_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_10_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_11_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_11_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_11_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_11_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_12_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_12_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_12_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_12_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_13_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_13_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_13_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_13_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_14_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_14_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_14_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_14_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_15_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_15_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_15_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_15_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_16_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_16_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_16_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_16_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_17_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_17_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_17_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_17_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_18_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_18_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_18_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_18_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_19_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_19_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_19_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_19_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_20_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_20_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_20_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_20_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_21_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_21_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_21_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_21_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_22_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_22_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connected_22_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connected_22_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_00_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_00_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_00_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_00_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_01_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_01_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_01_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_01_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_02_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_02_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_02_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_02_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_03_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_03_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_03_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_03_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_04_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_04_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_04_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_04_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_05_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_05_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_05_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_05_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_06_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_06_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_06_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_06_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_07_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_07_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_07_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_07_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_08_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_08_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_08_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_08_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_09_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_09_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_09_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_09_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_10_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_10_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_10_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_10_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_11_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_11_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_11_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_11_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_12_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_12_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_12_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_12_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_13_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_13_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_13_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_13_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_14_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_14_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_14_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_14_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_15_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_15_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_15_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_15_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_16_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_16_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_16_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_16_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_17_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_17_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_17_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_17_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_18_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_18_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_18_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_18_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_19_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_19_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_19_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_19_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_20_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_20_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_20_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_20_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_21_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_21_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_21_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_21_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_22_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_22_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_connecting_22_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_connecting_22_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_disabled_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_disabled_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_disabled_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_disabled_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_disconnected_dark = global::FABSample.Droid.Resource.Drawable.ic_mr_button_disconnected_dark;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_disconnected_light = global::FABSample.Droid.Resource.Drawable.ic_mr_button_disconnected_light;
+			global::FAB.Droid.Resource.Drawable.ic_mr_button_grey = global::FABSample.Droid.Resource.Drawable.ic_mr_button_grey;
+			global::FAB.Droid.Resource.Drawable.ic_vol_type_speaker_dark = global::FABSample.Droid.Resource.Drawable.ic_vol_type_speaker_dark;
+			global::FAB.Droid.Resource.Drawable.ic_vol_type_speaker_group_dark = global::FABSample.Droid.Resource.Drawable.ic_vol_type_speaker_group_dark;
+			global::FAB.Droid.Resource.Drawable.ic_vol_type_speaker_group_light = global::FABSample.Droid.Resource.Drawable.ic_vol_type_speaker_group_light;
+			global::FAB.Droid.Resource.Drawable.ic_vol_type_speaker_light = global::FABSample.Droid.Resource.Drawable.ic_vol_type_speaker_light;
+			global::FAB.Droid.Resource.Drawable.ic_vol_type_tv_dark = global::FABSample.Droid.Resource.Drawable.ic_vol_type_tv_dark;
+			global::FAB.Droid.Resource.Drawable.ic_vol_type_tv_light = global::FABSample.Droid.Resource.Drawable.ic_vol_type_tv_light;
+			global::FAB.Droid.Resource.Drawable.mr_button_connected_dark = global::FABSample.Droid.Resource.Drawable.mr_button_connected_dark;
+			global::FAB.Droid.Resource.Drawable.mr_button_connected_light = global::FABSample.Droid.Resource.Drawable.mr_button_connected_light;
+			global::FAB.Droid.Resource.Drawable.mr_button_connecting_dark = global::FABSample.Droid.Resource.Drawable.mr_button_connecting_dark;
+			global::FAB.Droid.Resource.Drawable.mr_button_connecting_light = global::FABSample.Droid.Resource.Drawable.mr_button_connecting_light;
+			global::FAB.Droid.Resource.Drawable.mr_button_dark = global::FABSample.Droid.Resource.Drawable.mr_button_dark;
+			global::FAB.Droid.Resource.Drawable.mr_button_light = global::FABSample.Droid.Resource.Drawable.mr_button_light;
+			global::FAB.Droid.Resource.Drawable.mr_dialog_close_dark = global::FABSample.Droid.Resource.Drawable.mr_dialog_close_dark;
+			global::FAB.Droid.Resource.Drawable.mr_dialog_close_light = global::FABSample.Droid.Resource.Drawable.mr_dialog_close_light;
 			global::FAB.Droid.Resource.Drawable.mr_dialog_material_background_dark = global::FABSample.Droid.Resource.Drawable.mr_dialog_material_background_dark;
 			global::FAB.Droid.Resource.Drawable.mr_dialog_material_background_light = global::FABSample.Droid.Resource.Drawable.mr_dialog_material_background_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_audiotrack_light = global::FABSample.Droid.Resource.Drawable.mr_ic_audiotrack_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_cast_dark = global::FABSample.Droid.Resource.Drawable.mr_ic_cast_dark;
-			global::FAB.Droid.Resource.Drawable.mr_ic_cast_light = global::FABSample.Droid.Resource.Drawable.mr_ic_cast_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_close_dark = global::FABSample.Droid.Resource.Drawable.mr_ic_close_dark;
-			global::FAB.Droid.Resource.Drawable.mr_ic_close_light = global::FABSample.Droid.Resource.Drawable.mr_ic_close_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_dark = global::FABSample.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_dark;
-			global::FAB.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_light = global::FABSample.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_media_route_mono_dark = global::FABSample.Droid.Resource.Drawable.mr_ic_media_route_mono_dark;
-			global::FAB.Droid.Resource.Drawable.mr_ic_media_route_mono_light = global::FABSample.Droid.Resource.Drawable.mr_ic_media_route_mono_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_pause_dark = global::FABSample.Droid.Resource.Drawable.mr_ic_pause_dark;
-			global::FAB.Droid.Resource.Drawable.mr_ic_pause_light = global::FABSample.Droid.Resource.Drawable.mr_ic_pause_light;
-			global::FAB.Droid.Resource.Drawable.mr_ic_play_dark = global::FABSample.Droid.Resource.Drawable.mr_ic_play_dark;
-			global::FAB.Droid.Resource.Drawable.mr_ic_play_light = global::FABSample.Droid.Resource.Drawable.mr_ic_play_light;
+			global::FAB.Droid.Resource.Drawable.mr_group_collapse = global::FABSample.Droid.Resource.Drawable.mr_group_collapse;
+			global::FAB.Droid.Resource.Drawable.mr_group_expand = global::FABSample.Droid.Resource.Drawable.mr_group_expand;
+			global::FAB.Droid.Resource.Drawable.mr_media_pause_dark = global::FABSample.Droid.Resource.Drawable.mr_media_pause_dark;
+			global::FAB.Droid.Resource.Drawable.mr_media_pause_light = global::FABSample.Droid.Resource.Drawable.mr_media_pause_light;
+			global::FAB.Droid.Resource.Drawable.mr_media_play_dark = global::FABSample.Droid.Resource.Drawable.mr_media_play_dark;
+			global::FAB.Droid.Resource.Drawable.mr_media_play_light = global::FABSample.Droid.Resource.Drawable.mr_media_play_light;
+			global::FAB.Droid.Resource.Drawable.mr_media_stop_dark = global::FABSample.Droid.Resource.Drawable.mr_media_stop_dark;
+			global::FAB.Droid.Resource.Drawable.mr_media_stop_light = global::FABSample.Droid.Resource.Drawable.mr_media_stop_light;
+			global::FAB.Droid.Resource.Drawable.mr_vol_type_audiotrack_dark = global::FABSample.Droid.Resource.Drawable.mr_vol_type_audiotrack_dark;
+			global::FAB.Droid.Resource.Drawable.mr_vol_type_audiotrack_light = global::FABSample.Droid.Resource.Drawable.mr_vol_type_audiotrack_light;
+			global::FAB.Droid.Resource.Drawable.navigation_empty_icon = global::FABSample.Droid.Resource.Drawable.navigation_empty_icon;
+			global::FAB.Droid.Resource.Drawable.notification_action_background = global::FABSample.Droid.Resource.Drawable.notification_action_background;
+			global::FAB.Droid.Resource.Drawable.notification_bg = global::FABSample.Droid.Resource.Drawable.notification_bg;
+			global::FAB.Droid.Resource.Drawable.notification_bg_low = global::FABSample.Droid.Resource.Drawable.notification_bg_low;
+			global::FAB.Droid.Resource.Drawable.notification_bg_low_normal = global::FABSample.Droid.Resource.Drawable.notification_bg_low_normal;
+			global::FAB.Droid.Resource.Drawable.notification_bg_low_pressed = global::FABSample.Droid.Resource.Drawable.notification_bg_low_pressed;
+			global::FAB.Droid.Resource.Drawable.notification_bg_normal = global::FABSample.Droid.Resource.Drawable.notification_bg_normal;
+			global::FAB.Droid.Resource.Drawable.notification_bg_normal_pressed = global::FABSample.Droid.Resource.Drawable.notification_bg_normal_pressed;
+			global::FAB.Droid.Resource.Drawable.notification_icon_background = global::FABSample.Droid.Resource.Drawable.notification_icon_background;
 			global::FAB.Droid.Resource.Drawable.notification_template_icon_bg = global::FABSample.Droid.Resource.Drawable.notification_template_icon_bg;
+			global::FAB.Droid.Resource.Drawable.notification_template_icon_low_bg = global::FABSample.Droid.Resource.Drawable.notification_template_icon_low_bg;
+			global::FAB.Droid.Resource.Drawable.notification_tile_bg = global::FABSample.Droid.Resource.Drawable.notification_tile_bg;
+			global::FAB.Droid.Resource.Drawable.notify_panel_notification_icon_bg = global::FABSample.Droid.Resource.Drawable.notify_panel_notification_icon_bg;
 			global::FAB.Droid.Resource.Id.action0 = global::FABSample.Droid.Resource.Id.action0;
 			global::FAB.Droid.Resource.Id.action_bar = global::FABSample.Droid.Resource.Id.action_bar;
 			global::FAB.Droid.Resource.Id.action_bar_activity_content = global::FABSample.Droid.Resource.Id.action_bar_activity_content;
@@ -750,16 +930,23 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.action_bar_spinner = global::FABSample.Droid.Resource.Id.action_bar_spinner;
 			global::FAB.Droid.Resource.Id.action_bar_subtitle = global::FABSample.Droid.Resource.Id.action_bar_subtitle;
 			global::FAB.Droid.Resource.Id.action_bar_title = global::FABSample.Droid.Resource.Id.action_bar_title;
+			global::FAB.Droid.Resource.Id.action_container = global::FABSample.Droid.Resource.Id.action_container;
 			global::FAB.Droid.Resource.Id.action_context_bar = global::FABSample.Droid.Resource.Id.action_context_bar;
 			global::FAB.Droid.Resource.Id.action_divider = global::FABSample.Droid.Resource.Id.action_divider;
+			global::FAB.Droid.Resource.Id.action_image = global::FABSample.Droid.Resource.Id.action_image;
 			global::FAB.Droid.Resource.Id.action_menu_divider = global::FABSample.Droid.Resource.Id.action_menu_divider;
 			global::FAB.Droid.Resource.Id.action_menu_presenter = global::FABSample.Droid.Resource.Id.action_menu_presenter;
 			global::FAB.Droid.Resource.Id.action_mode_bar = global::FABSample.Droid.Resource.Id.action_mode_bar;
 			global::FAB.Droid.Resource.Id.action_mode_bar_stub = global::FABSample.Droid.Resource.Id.action_mode_bar_stub;
 			global::FAB.Droid.Resource.Id.action_mode_close_button = global::FABSample.Droid.Resource.Id.action_mode_close_button;
+			global::FAB.Droid.Resource.Id.action_text = global::FABSample.Droid.Resource.Id.action_text;
+			global::FAB.Droid.Resource.Id.actions = global::FABSample.Droid.Resource.Id.actions;
 			global::FAB.Droid.Resource.Id.activity_chooser_view_content = global::FABSample.Droid.Resource.Id.activity_chooser_view_content;
+			global::FAB.Droid.Resource.Id.add = global::FABSample.Droid.Resource.Id.add;
 			global::FAB.Droid.Resource.Id.alertTitle = global::FABSample.Droid.Resource.Id.alertTitle;
+			global::FAB.Droid.Resource.Id.all = global::FABSample.Droid.Resource.Id.all;
 			global::FAB.Droid.Resource.Id.always = global::FABSample.Droid.Resource.Id.always;
+			global::FAB.Droid.Resource.Id.auto = global::FABSample.Droid.Resource.Id.auto;
 			global::FAB.Droid.Resource.Id.beginning = global::FABSample.Droid.Resource.Id.beginning;
 			global::FAB.Droid.Resource.Id.bottom = global::FABSample.Droid.Resource.Id.bottom;
 			global::FAB.Droid.Resource.Id.buttonPanel = global::FABSample.Droid.Resource.Id.buttonPanel;
@@ -798,15 +985,18 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.home = global::FABSample.Droid.Resource.Id.home;
 			global::FAB.Droid.Resource.Id.homeAsUp = global::FABSample.Droid.Resource.Id.homeAsUp;
 			global::FAB.Droid.Resource.Id.icon = global::FABSample.Droid.Resource.Id.icon;
+			global::FAB.Droid.Resource.Id.icon_group = global::FABSample.Droid.Resource.Id.icon_group;
 			global::FAB.Droid.Resource.Id.ifRoom = global::FABSample.Droid.Resource.Id.ifRoom;
 			global::FAB.Droid.Resource.Id.image = global::FABSample.Droid.Resource.Id.image;
 			global::FAB.Droid.Resource.Id.info = global::FABSample.Droid.Resource.Id.info;
 			global::FAB.Droid.Resource.Id.item_touch_helper_previous_elevation = global::FABSample.Droid.Resource.Id.item_touch_helper_previous_elevation;
+			global::FAB.Droid.Resource.Id.largeLabel = global::FABSample.Droid.Resource.Id.largeLabel;
 			global::FAB.Droid.Resource.Id.left = global::FABSample.Droid.Resource.Id.left;
 			global::FAB.Droid.Resource.Id.line1 = global::FABSample.Droid.Resource.Id.line1;
 			global::FAB.Droid.Resource.Id.line3 = global::FABSample.Droid.Resource.Id.line3;
 			global::FAB.Droid.Resource.Id.listMode = global::FABSample.Droid.Resource.Id.listMode;
 			global::FAB.Droid.Resource.Id.list_item = global::FABSample.Droid.Resource.Id.list_item;
+			global::FAB.Droid.Resource.Id.masked = global::FABSample.Droid.Resource.Id.masked;
 			global::FAB.Droid.Resource.Id.media_actions = global::FABSample.Droid.Resource.Id.media_actions;
 			global::FAB.Droid.Resource.Id.middle = global::FABSample.Droid.Resource.Id.middle;
 			global::FAB.Droid.Resource.Id.mini = global::FABSample.Droid.Resource.Id.mini;
@@ -815,9 +1005,10 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.mr_chooser_route_desc = global::FABSample.Droid.Resource.Id.mr_chooser_route_desc;
 			global::FAB.Droid.Resource.Id.mr_chooser_route_icon = global::FABSample.Droid.Resource.Id.mr_chooser_route_icon;
 			global::FAB.Droid.Resource.Id.mr_chooser_route_name = global::FABSample.Droid.Resource.Id.mr_chooser_route_name;
+			global::FAB.Droid.Resource.Id.mr_chooser_title = global::FABSample.Droid.Resource.Id.mr_chooser_title;
 			global::FAB.Droid.Resource.Id.mr_close = global::FABSample.Droid.Resource.Id.mr_close;
 			global::FAB.Droid.Resource.Id.mr_control_divider = global::FABSample.Droid.Resource.Id.mr_control_divider;
-			global::FAB.Droid.Resource.Id.mr_control_play_pause = global::FABSample.Droid.Resource.Id.mr_control_play_pause;
+			global::FAB.Droid.Resource.Id.mr_control_playback_ctrl = global::FABSample.Droid.Resource.Id.mr_control_playback_ctrl;
 			global::FAB.Droid.Resource.Id.mr_control_subtitle = global::FABSample.Droid.Resource.Id.mr_control_subtitle;
 			global::FAB.Droid.Resource.Id.mr_control_title = global::FABSample.Droid.Resource.Id.mr_control_title;
 			global::FAB.Droid.Resource.Id.mr_control_title_container = global::FABSample.Droid.Resource.Id.mr_control_title_container;
@@ -839,6 +1030,9 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.never = global::FABSample.Droid.Resource.Id.never;
 			global::FAB.Droid.Resource.Id.none = global::FABSample.Droid.Resource.Id.none;
 			global::FAB.Droid.Resource.Id.normal = global::FABSample.Droid.Resource.Id.normal;
+			global::FAB.Droid.Resource.Id.notification_background = global::FABSample.Droid.Resource.Id.notification_background;
+			global::FAB.Droid.Resource.Id.notification_main_column = global::FABSample.Droid.Resource.Id.notification_main_column;
+			global::FAB.Droid.Resource.Id.notification_main_column_container = global::FABSample.Droid.Resource.Id.notification_main_column_container;
 			global::FAB.Droid.Resource.Id.parallax = global::FABSample.Droid.Resource.Id.parallax;
 			global::FAB.Droid.Resource.Id.parentPanel = global::FABSample.Droid.Resource.Id.parentPanel;
 			global::FAB.Droid.Resource.Id.pin = global::FABSample.Droid.Resource.Id.pin;
@@ -846,6 +1040,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.progress_horizontal = global::FABSample.Droid.Resource.Id.progress_horizontal;
 			global::FAB.Droid.Resource.Id.radio = global::FABSample.Droid.Resource.Id.radio;
 			global::FAB.Droid.Resource.Id.right = global::FABSample.Droid.Resource.Id.right;
+			global::FAB.Droid.Resource.Id.right_icon = global::FABSample.Droid.Resource.Id.right_icon;
+			global::FAB.Droid.Resource.Id.right_side = global::FABSample.Droid.Resource.Id.right_side;
 			global::FAB.Droid.Resource.Id.screen = global::FABSample.Droid.Resource.Id.screen;
 			global::FAB.Droid.Resource.Id.scroll = global::FABSample.Droid.Resource.Id.scroll;
 			global::FAB.Droid.Resource.Id.scrollIndicatorDown = global::FABSample.Droid.Resource.Id.scrollIndicatorDown;
@@ -867,6 +1063,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.showCustom = global::FABSample.Droid.Resource.Id.showCustom;
 			global::FAB.Droid.Resource.Id.showHome = global::FABSample.Droid.Resource.Id.showHome;
 			global::FAB.Droid.Resource.Id.showTitle = global::FABSample.Droid.Resource.Id.showTitle;
+			global::FAB.Droid.Resource.Id.smallLabel = global::FABSample.Droid.Resource.Id.smallLabel;
 			global::FAB.Droid.Resource.Id.snackbar_action = global::FABSample.Droid.Resource.Id.snackbar_action;
 			global::FAB.Droid.Resource.Id.snackbar_text = global::FABSample.Droid.Resource.Id.snackbar_text;
 			global::FAB.Droid.Resource.Id.snap = global::FABSample.Droid.Resource.Id.snap;
@@ -877,32 +1074,43 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Id.src_over = global::FABSample.Droid.Resource.Id.src_over;
 			global::FAB.Droid.Resource.Id.start = global::FABSample.Droid.Resource.Id.start;
 			global::FAB.Droid.Resource.Id.status_bar_latest_event_content = global::FABSample.Droid.Resource.Id.status_bar_latest_event_content;
+			global::FAB.Droid.Resource.Id.submenuarrow = global::FABSample.Droid.Resource.Id.submenuarrow;
 			global::FAB.Droid.Resource.Id.submit_area = global::FABSample.Droid.Resource.Id.submit_area;
 			global::FAB.Droid.Resource.Id.tabMode = global::FABSample.Droid.Resource.Id.tabMode;
 			global::FAB.Droid.Resource.Id.text = global::FABSample.Droid.Resource.Id.text;
 			global::FAB.Droid.Resource.Id.text2 = global::FABSample.Droid.Resource.Id.text2;
 			global::FAB.Droid.Resource.Id.textSpacerNoButtons = global::FABSample.Droid.Resource.Id.textSpacerNoButtons;
+			global::FAB.Droid.Resource.Id.textSpacerNoTitle = global::FABSample.Droid.Resource.Id.textSpacerNoTitle;
+			global::FAB.Droid.Resource.Id.text_input_password_toggle = global::FABSample.Droid.Resource.Id.text_input_password_toggle;
+			global::FAB.Droid.Resource.Id.textinput_counter = global::FABSample.Droid.Resource.Id.textinput_counter;
+			global::FAB.Droid.Resource.Id.textinput_error = global::FABSample.Droid.Resource.Id.textinput_error;
 			global::FAB.Droid.Resource.Id.time = global::FABSample.Droid.Resource.Id.time;
 			global::FAB.Droid.Resource.Id.title = global::FABSample.Droid.Resource.Id.title;
+			global::FAB.Droid.Resource.Id.titleDividerNoCustom = global::FABSample.Droid.Resource.Id.titleDividerNoCustom;
 			global::FAB.Droid.Resource.Id.title_template = global::FABSample.Droid.Resource.Id.title_template;
 			global::FAB.Droid.Resource.Id.top = global::FABSample.Droid.Resource.Id.top;
 			global::FAB.Droid.Resource.Id.topPanel = global::FABSample.Droid.Resource.Id.topPanel;
 			global::FAB.Droid.Resource.Id.touch_outside = global::FABSample.Droid.Resource.Id.touch_outside;
+			global::FAB.Droid.Resource.Id.transition_current_scene = global::FABSample.Droid.Resource.Id.transition_current_scene;
+			global::FAB.Droid.Resource.Id.transition_scene_layoutid_cache = global::FABSample.Droid.Resource.Id.transition_scene_layoutid_cache;
 			global::FAB.Droid.Resource.Id.up = global::FABSample.Droid.Resource.Id.up;
 			global::FAB.Droid.Resource.Id.useLogo = global::FABSample.Droid.Resource.Id.useLogo;
 			global::FAB.Droid.Resource.Id.view_offset_helper = global::FABSample.Droid.Resource.Id.view_offset_helper;
+			global::FAB.Droid.Resource.Id.visible = global::FABSample.Droid.Resource.Id.visible;
 			global::FAB.Droid.Resource.Id.volume_item_container = global::FABSample.Droid.Resource.Id.volume_item_container;
 			global::FAB.Droid.Resource.Id.withText = global::FABSample.Droid.Resource.Id.withText;
 			global::FAB.Droid.Resource.Id.wrap_content = global::FABSample.Droid.Resource.Id.wrap_content;
 			global::FAB.Droid.Resource.Integer.abc_config_activityDefaultDur = global::FABSample.Droid.Resource.Integer.abc_config_activityDefaultDur;
 			global::FAB.Droid.Resource.Integer.abc_config_activityShortDur = global::FABSample.Droid.Resource.Integer.abc_config_activityShortDur;
-			global::FAB.Droid.Resource.Integer.abc_max_action_buttons = global::FABSample.Droid.Resource.Integer.abc_max_action_buttons;
+			global::FAB.Droid.Resource.Integer.app_bar_elevation_anim_duration = global::FABSample.Droid.Resource.Integer.app_bar_elevation_anim_duration;
 			global::FAB.Droid.Resource.Integer.bottom_sheet_slide_duration = global::FABSample.Droid.Resource.Integer.bottom_sheet_slide_duration;
 			global::FAB.Droid.Resource.Integer.cancel_button_image_alpha = global::FABSample.Droid.Resource.Integer.cancel_button_image_alpha;
 			global::FAB.Droid.Resource.Integer.design_snackbar_text_max_lines = global::FABSample.Droid.Resource.Integer.design_snackbar_text_max_lines;
+			global::FAB.Droid.Resource.Integer.hide_password_duration = global::FABSample.Droid.Resource.Integer.hide_password_duration;
 			global::FAB.Droid.Resource.Integer.mr_controller_volume_group_list_animation_duration_ms = global::FABSample.Droid.Resource.Integer.mr_controller_volume_group_list_animation_duration_ms;
 			global::FAB.Droid.Resource.Integer.mr_controller_volume_group_list_fade_in_duration_ms = global::FABSample.Droid.Resource.Integer.mr_controller_volume_group_list_fade_in_duration_ms;
 			global::FAB.Droid.Resource.Integer.mr_controller_volume_group_list_fade_out_duration_ms = global::FABSample.Droid.Resource.Integer.mr_controller_volume_group_list_fade_out_duration_ms;
+			global::FAB.Droid.Resource.Integer.show_password_duration = global::FABSample.Droid.Resource.Integer.show_password_duration;
 			global::FAB.Droid.Resource.Integer.status_bar_notification_info_maxnum = global::FABSample.Droid.Resource.Integer.status_bar_notification_info_maxnum;
 			global::FAB.Droid.Resource.Interpolator.mr_fast_out_slow_in = global::FABSample.Droid.Resource.Interpolator.mr_fast_out_slow_in;
 			global::FAB.Droid.Resource.Interpolator.mr_linear_out_slow_in = global::FABSample.Droid.Resource.Interpolator.mr_linear_out_slow_in;
@@ -917,12 +1125,14 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Layout.abc_activity_chooser_view_list_item = global::FABSample.Droid.Resource.Layout.abc_activity_chooser_view_list_item;
 			global::FAB.Droid.Resource.Layout.abc_alert_dialog_button_bar_material = global::FABSample.Droid.Resource.Layout.abc_alert_dialog_button_bar_material;
 			global::FAB.Droid.Resource.Layout.abc_alert_dialog_material = global::FABSample.Droid.Resource.Layout.abc_alert_dialog_material;
+			global::FAB.Droid.Resource.Layout.abc_alert_dialog_title_material = global::FABSample.Droid.Resource.Layout.abc_alert_dialog_title_material;
 			global::FAB.Droid.Resource.Layout.abc_dialog_title_material = global::FABSample.Droid.Resource.Layout.abc_dialog_title_material;
 			global::FAB.Droid.Resource.Layout.abc_expanded_menu_layout = global::FABSample.Droid.Resource.Layout.abc_expanded_menu_layout;
 			global::FAB.Droid.Resource.Layout.abc_list_menu_item_checkbox = global::FABSample.Droid.Resource.Layout.abc_list_menu_item_checkbox;
 			global::FAB.Droid.Resource.Layout.abc_list_menu_item_icon = global::FABSample.Droid.Resource.Layout.abc_list_menu_item_icon;
 			global::FAB.Droid.Resource.Layout.abc_list_menu_item_layout = global::FABSample.Droid.Resource.Layout.abc_list_menu_item_layout;
 			global::FAB.Droid.Resource.Layout.abc_list_menu_item_radio = global::FABSample.Droid.Resource.Layout.abc_list_menu_item_radio;
+			global::FAB.Droid.Resource.Layout.abc_popup_menu_header_item_layout = global::FABSample.Droid.Resource.Layout.abc_popup_menu_header_item_layout;
 			global::FAB.Droid.Resource.Layout.abc_popup_menu_item_layout = global::FABSample.Droid.Resource.Layout.abc_popup_menu_item_layout;
 			global::FAB.Droid.Resource.Layout.abc_screen_content_include = global::FABSample.Droid.Resource.Layout.abc_screen_content_include;
 			global::FAB.Droid.Resource.Layout.abc_screen_simple = global::FABSample.Droid.Resource.Layout.abc_screen_simple;
@@ -931,6 +1141,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line = global::FABSample.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line;
 			global::FAB.Droid.Resource.Layout.abc_search_view = global::FABSample.Droid.Resource.Layout.abc_search_view;
 			global::FAB.Droid.Resource.Layout.abc_select_dialog_material = global::FABSample.Droid.Resource.Layout.abc_select_dialog_material;
+			global::FAB.Droid.Resource.Layout.design_bottom_navigation_item = global::FABSample.Droid.Resource.Layout.design_bottom_navigation_item;
 			global::FAB.Droid.Resource.Layout.design_bottom_sheet_dialog = global::FABSample.Droid.Resource.Layout.design_bottom_sheet_dialog;
 			global::FAB.Droid.Resource.Layout.design_layout_snackbar = global::FABSample.Droid.Resource.Layout.design_layout_snackbar;
 			global::FAB.Droid.Resource.Layout.design_layout_snackbar_include = global::FABSample.Droid.Resource.Layout.design_layout_snackbar_include;
@@ -943,6 +1154,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Layout.design_navigation_item_subheader = global::FABSample.Droid.Resource.Layout.design_navigation_item_subheader;
 			global::FAB.Droid.Resource.Layout.design_navigation_menu = global::FABSample.Droid.Resource.Layout.design_navigation_menu;
 			global::FAB.Droid.Resource.Layout.design_navigation_menu_item = global::FABSample.Droid.Resource.Layout.design_navigation_menu_item;
+			global::FAB.Droid.Resource.Layout.design_text_input_password_icon = global::FABSample.Droid.Resource.Layout.design_text_input_password_icon;
 			global::FAB.Droid.Resource.Layout.mini_fab = global::FABSample.Droid.Resource.Layout.mini_fab;
 			global::FAB.Droid.Resource.Layout.mr_chooser_dialog = global::FABSample.Droid.Resource.Layout.mr_chooser_dialog;
 			global::FAB.Droid.Resource.Layout.mr_chooser_list_item = global::FABSample.Droid.Resource.Layout.mr_chooser_list_item;
@@ -951,12 +1163,19 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Layout.mr_playback_control = global::FABSample.Droid.Resource.Layout.mr_playback_control;
 			global::FAB.Droid.Resource.Layout.mr_volume_control = global::FABSample.Droid.Resource.Layout.mr_volume_control;
 			global::FAB.Droid.Resource.Layout.normal_fab = global::FABSample.Droid.Resource.Layout.normal_fab;
+			global::FAB.Droid.Resource.Layout.notification_action = global::FABSample.Droid.Resource.Layout.notification_action;
+			global::FAB.Droid.Resource.Layout.notification_action_tombstone = global::FABSample.Droid.Resource.Layout.notification_action_tombstone;
 			global::FAB.Droid.Resource.Layout.notification_media_action = global::FABSample.Droid.Resource.Layout.notification_media_action;
 			global::FAB.Droid.Resource.Layout.notification_media_cancel_action = global::FABSample.Droid.Resource.Layout.notification_media_cancel_action;
 			global::FAB.Droid.Resource.Layout.notification_template_big_media = global::FABSample.Droid.Resource.Layout.notification_template_big_media;
+			global::FAB.Droid.Resource.Layout.notification_template_big_media_custom = global::FABSample.Droid.Resource.Layout.notification_template_big_media_custom;
 			global::FAB.Droid.Resource.Layout.notification_template_big_media_narrow = global::FABSample.Droid.Resource.Layout.notification_template_big_media_narrow;
-			global::FAB.Droid.Resource.Layout.notification_template_lines = global::FABSample.Droid.Resource.Layout.notification_template_lines;
+			global::FAB.Droid.Resource.Layout.notification_template_big_media_narrow_custom = global::FABSample.Droid.Resource.Layout.notification_template_big_media_narrow_custom;
+			global::FAB.Droid.Resource.Layout.notification_template_custom_big = global::FABSample.Droid.Resource.Layout.notification_template_custom_big;
+			global::FAB.Droid.Resource.Layout.notification_template_icon_group = global::FABSample.Droid.Resource.Layout.notification_template_icon_group;
+			global::FAB.Droid.Resource.Layout.notification_template_lines_media = global::FABSample.Droid.Resource.Layout.notification_template_lines_media;
 			global::FAB.Droid.Resource.Layout.notification_template_media = global::FABSample.Droid.Resource.Layout.notification_template_media;
+			global::FAB.Droid.Resource.Layout.notification_template_media_custom = global::FABSample.Droid.Resource.Layout.notification_template_media_custom;
 			global::FAB.Droid.Resource.Layout.notification_template_part_chronometer = global::FABSample.Droid.Resource.Layout.notification_template_part_chronometer;
 			global::FAB.Droid.Resource.Layout.notification_template_part_time = global::FABSample.Droid.Resource.Layout.notification_template_part_time;
 			global::FAB.Droid.Resource.Layout.select_dialog_item_material = global::FABSample.Droid.Resource.Layout.select_dialog_item_material;
@@ -973,6 +1192,18 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.String.abc_activitychooserview_choose_application = global::FABSample.Droid.Resource.String.abc_activitychooserview_choose_application;
 			global::FAB.Droid.Resource.String.abc_capital_off = global::FABSample.Droid.Resource.String.abc_capital_off;
 			global::FAB.Droid.Resource.String.abc_capital_on = global::FABSample.Droid.Resource.String.abc_capital_on;
+			global::FAB.Droid.Resource.String.abc_font_family_body_1_material = global::FABSample.Droid.Resource.String.abc_font_family_body_1_material;
+			global::FAB.Droid.Resource.String.abc_font_family_body_2_material = global::FABSample.Droid.Resource.String.abc_font_family_body_2_material;
+			global::FAB.Droid.Resource.String.abc_font_family_button_material = global::FABSample.Droid.Resource.String.abc_font_family_button_material;
+			global::FAB.Droid.Resource.String.abc_font_family_caption_material = global::FABSample.Droid.Resource.String.abc_font_family_caption_material;
+			global::FAB.Droid.Resource.String.abc_font_family_display_1_material = global::FABSample.Droid.Resource.String.abc_font_family_display_1_material;
+			global::FAB.Droid.Resource.String.abc_font_family_display_2_material = global::FABSample.Droid.Resource.String.abc_font_family_display_2_material;
+			global::FAB.Droid.Resource.String.abc_font_family_display_3_material = global::FABSample.Droid.Resource.String.abc_font_family_display_3_material;
+			global::FAB.Droid.Resource.String.abc_font_family_display_4_material = global::FABSample.Droid.Resource.String.abc_font_family_display_4_material;
+			global::FAB.Droid.Resource.String.abc_font_family_headline_material = global::FABSample.Droid.Resource.String.abc_font_family_headline_material;
+			global::FAB.Droid.Resource.String.abc_font_family_menu_material = global::FABSample.Droid.Resource.String.abc_font_family_menu_material;
+			global::FAB.Droid.Resource.String.abc_font_family_subhead_material = global::FABSample.Droid.Resource.String.abc_font_family_subhead_material;
+			global::FAB.Droid.Resource.String.abc_font_family_title_material = global::FABSample.Droid.Resource.String.abc_font_family_title_material;
 			global::FAB.Droid.Resource.String.abc_search_hint = global::FABSample.Droid.Resource.String.abc_search_hint;
 			global::FAB.Droid.Resource.String.abc_searchview_description_clear = global::FABSample.Droid.Resource.String.abc_searchview_description_clear;
 			global::FAB.Droid.Resource.String.abc_searchview_description_query = global::FABSample.Droid.Resource.String.abc_searchview_description_query;
@@ -997,8 +1228,12 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.String.library_FloatingActionButton_repositoryLink = global::FABSample.Droid.Resource.String.library_FloatingActionButton_repositoryLink;
 			global::FAB.Droid.Resource.String.library_name = global::FABSample.Droid.Resource.String.library_name;
 			global::FAB.Droid.Resource.String.mr_button_content_description = global::FABSample.Droid.Resource.String.mr_button_content_description;
+			global::FAB.Droid.Resource.String.mr_cast_button_connected = global::FABSample.Droid.Resource.String.mr_cast_button_connected;
+			global::FAB.Droid.Resource.String.mr_cast_button_connecting = global::FABSample.Droid.Resource.String.mr_cast_button_connecting;
+			global::FAB.Droid.Resource.String.mr_cast_button_disconnected = global::FABSample.Droid.Resource.String.mr_cast_button_disconnected;
 			global::FAB.Droid.Resource.String.mr_chooser_searching = global::FABSample.Droid.Resource.String.mr_chooser_searching;
 			global::FAB.Droid.Resource.String.mr_chooser_title = global::FABSample.Droid.Resource.String.mr_chooser_title;
+			global::FAB.Droid.Resource.String.mr_controller_album_art = global::FABSample.Droid.Resource.String.mr_controller_album_art;
 			global::FAB.Droid.Resource.String.mr_controller_casting_screen = global::FABSample.Droid.Resource.String.mr_controller_casting_screen;
 			global::FAB.Droid.Resource.String.mr_controller_close_description = global::FABSample.Droid.Resource.String.mr_controller_close_description;
 			global::FAB.Droid.Resource.String.mr_controller_collapse_group = global::FABSample.Droid.Resource.String.mr_controller_collapse_group;
@@ -1009,8 +1244,16 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.String.mr_controller_pause = global::FABSample.Droid.Resource.String.mr_controller_pause;
 			global::FAB.Droid.Resource.String.mr_controller_play = global::FABSample.Droid.Resource.String.mr_controller_play;
 			global::FAB.Droid.Resource.String.mr_controller_stop = global::FABSample.Droid.Resource.String.mr_controller_stop;
+			global::FAB.Droid.Resource.String.mr_controller_stop_casting = global::FABSample.Droid.Resource.String.mr_controller_stop_casting;
+			global::FAB.Droid.Resource.String.mr_controller_volume_slider = global::FABSample.Droid.Resource.String.mr_controller_volume_slider;
 			global::FAB.Droid.Resource.String.mr_system_route_name = global::FABSample.Droid.Resource.String.mr_system_route_name;
 			global::FAB.Droid.Resource.String.mr_user_route_category_name = global::FABSample.Droid.Resource.String.mr_user_route_category_name;
+			global::FAB.Droid.Resource.String.password_toggle_content_description = global::FABSample.Droid.Resource.String.password_toggle_content_description;
+			global::FAB.Droid.Resource.String.path_password_eye = global::FABSample.Droid.Resource.String.path_password_eye;
+			global::FAB.Droid.Resource.String.path_password_eye_mask_strike_through = global::FABSample.Droid.Resource.String.path_password_eye_mask_strike_through;
+			global::FAB.Droid.Resource.String.path_password_eye_mask_visible = global::FABSample.Droid.Resource.String.path_password_eye_mask_visible;
+			global::FAB.Droid.Resource.String.path_password_strike_through = global::FABSample.Droid.Resource.String.path_password_strike_through;
+			global::FAB.Droid.Resource.String.search_menu_title = global::FABSample.Droid.Resource.String.search_menu_title;
 			global::FAB.Droid.Resource.String.status_bar_notification_info_overflow = global::FABSample.Droid.Resource.String.status_bar_notification_info_overflow;
 			global::FAB.Droid.Resource.Style.AlertDialog_AppCompat = global::FABSample.Droid.Resource.Style.AlertDialog_AppCompat;
 			global::FAB.Droid.Resource.Style.AlertDialog_AppCompat_Light = global::FABSample.Droid.Resource.Style.AlertDialog_AppCompat_Light;
@@ -1059,8 +1302,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Title = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Title;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button;
+			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored;
+			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Colored = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Colored;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Inverse = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Inverse;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_DropDownItem = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_DropDownItem;
+			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Header;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Large;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Small;
 			global::FAB.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Switch = global::FABSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Switch;
@@ -1086,15 +1332,19 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar = global::FABSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar;
 			global::FAB.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark = global::FABSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark;
 			global::FAB.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark_ActionBar = global::FABSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark_ActionBar;
+			global::FAB.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog;
+			global::FAB.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert = global::FABSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert;
 			global::FAB.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light = global::FABSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light;
 			global::FAB.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog;
 			global::FAB.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog = global::FABSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog;
+			global::FAB.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog;
 			global::FAB.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView = global::FABSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView;
 			global::FAB.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText = global::FABSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText;
 			global::FAB.Droid.Resource.Style.Base_V21_Theme_AppCompat = global::FABSample.Droid.Resource.Style.Base_V21_Theme_AppCompat;
 			global::FAB.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog;
 			global::FAB.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light = global::FABSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light;
 			global::FAB.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog = global::FABSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog;
+			global::FAB.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog;
 			global::FAB.Droid.Resource.Style.Base_V22_Theme_AppCompat = global::FABSample.Droid.Resource.Style.Base_V22_Theme_AppCompat;
 			global::FAB.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light = global::FABSample.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light;
 			global::FAB.Droid.Resource.Style.Base_V23_Theme_AppCompat = global::FABSample.Droid.Resource.Style.Base_V23_Theme_AppCompat;
@@ -1103,6 +1353,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog;
 			global::FAB.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light = global::FABSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light;
 			global::FAB.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light_Dialog = global::FABSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light_Dialog;
+			global::FAB.Droid.Resource.Style.Base_V7_ThemeOverlay_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.Base_V7_ThemeOverlay_AppCompat_Dialog;
 			global::FAB.Droid.Resource.Style.Base_V7_Widget_AppCompat_AutoCompleteTextView = global::FABSample.Droid.Resource.Style.Base_V7_Widget_AppCompat_AutoCompleteTextView;
 			global::FAB.Droid.Resource.Style.Base_V7_Widget_AppCompat_EditText = global::FABSample.Droid.Resource.Style.Base_V7_Widget_AppCompat_EditText;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_ActionBar = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_ActionBar;
@@ -1140,6 +1391,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Light_ActionBar_TabView = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Light_ActionBar_TabView;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu_Overflow = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu_Overflow;
+			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_ListMenuView = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_ListMenuView;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_ListPopupWindow = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_ListPopupWindow;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_ListView = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_ListView;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_ListView_DropDown = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_ListView_DropDown;
@@ -1155,11 +1407,13 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_SearchView = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_SearchView;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_SearchView_ActionBar = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_SearchView_ActionBar;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar;
+			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar_Discrete = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar_Discrete;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Spinner = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Spinner;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Spinner_Underlined = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Spinner_Underlined;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar;
 			global::FAB.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation = global::FABSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation;
+			global::FAB.Droid.Resource.Style.Base_Widget_Design_AppBarLayout = global::FABSample.Droid.Resource.Style.Base_Widget_Design_AppBarLayout;
 			global::FAB.Droid.Resource.Style.Base_Widget_Design_TabLayout = global::FABSample.Droid.Resource.Style.Base_Widget_Design_TabLayout;
 			global::FAB.Droid.Resource.Style.CardView = global::FABSample.Droid.Resource.Style.CardView;
 			global::FAB.Droid.Resource.Style.CardView_Dark = global::FABSample.Droid.Resource.Style.CardView_Dark;
@@ -1173,6 +1427,10 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Platform_V11_AppCompat_Light = global::FABSample.Droid.Resource.Style.Platform_V11_AppCompat_Light;
 			global::FAB.Droid.Resource.Style.Platform_V14_AppCompat = global::FABSample.Droid.Resource.Style.Platform_V14_AppCompat;
 			global::FAB.Droid.Resource.Style.Platform_V14_AppCompat_Light = global::FABSample.Droid.Resource.Style.Platform_V14_AppCompat_Light;
+			global::FAB.Droid.Resource.Style.Platform_V21_AppCompat = global::FABSample.Droid.Resource.Style.Platform_V21_AppCompat;
+			global::FAB.Droid.Resource.Style.Platform_V21_AppCompat_Light = global::FABSample.Droid.Resource.Style.Platform_V21_AppCompat_Light;
+			global::FAB.Droid.Resource.Style.Platform_V25_AppCompat = global::FABSample.Droid.Resource.Style.Platform_V25_AppCompat;
+			global::FAB.Droid.Resource.Style.Platform_V25_AppCompat_Light = global::FABSample.Droid.Resource.Style.Platform_V25_AppCompat_Light;
 			global::FAB.Droid.Resource.Style.Platform_Widget_AppCompat_Spinner = global::FABSample.Droid.Resource.Style.Platform_Widget_AppCompat_Spinner;
 			global::FAB.Droid.Resource.Style.RtlOverlay_DialogWindowTitle_AppCompat = global::FABSample.Droid.Resource.Style.RtlOverlay_DialogWindowTitle_AppCompat;
 			global::FAB.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = global::FABSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_ActionBar_TitleItem;
@@ -1208,6 +1466,16 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Medium = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Medium;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Medium_Inverse = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Medium_Inverse;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Menu = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Menu;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info_Media = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info_Media;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2 = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2_Media = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2_Media;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Media = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Media;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time_Media = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time_Media;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title_Media = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title_Media;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Subtitle = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Subtitle;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Title = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Title;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Small = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Small;
@@ -1226,8 +1494,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Borderless_Colored = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Borderless_Colored;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Colored = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Colored;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Inverse = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Inverse;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_DropDownItem = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_DropDownItem;
+			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Header = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Header;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Large = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Large;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Small = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Small;
 			global::FAB.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Switch = global::FABSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Switch;
@@ -1239,6 +1510,9 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.TextAppearance_Design_Hint = global::FABSample.Droid.Resource.Style.TextAppearance_Design_Hint;
 			global::FAB.Droid.Resource.Style.TextAppearance_Design_Snackbar_Message = global::FABSample.Droid.Resource.Style.TextAppearance_Design_Snackbar_Message;
 			global::FAB.Droid.Resource.Style.TextAppearance_Design_Tab = global::FABSample.Droid.Resource.Style.TextAppearance_Design_Tab;
+			global::FAB.Droid.Resource.Style.TextAppearance_MediaRouter_PrimaryText = global::FABSample.Droid.Resource.Style.TextAppearance_MediaRouter_PrimaryText;
+			global::FAB.Droid.Resource.Style.TextAppearance_MediaRouter_SecondaryText = global::FABSample.Droid.Resource.Style.TextAppearance_MediaRouter_SecondaryText;
+			global::FAB.Droid.Resource.Style.TextAppearance_MediaRouter_Title = global::FABSample.Droid.Resource.Style.TextAppearance_MediaRouter_Title;
 			global::FAB.Droid.Resource.Style.TextAppearance_StatusBar_EventContent = global::FABSample.Droid.Resource.Style.TextAppearance_StatusBar_EventContent;
 			global::FAB.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Info = global::FABSample.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Info;
 			global::FAB.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Line2 = global::FABSample.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Line2;
@@ -1282,7 +1556,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar = global::FABSample.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar;
 			global::FAB.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark = global::FABSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark;
 			global::FAB.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark_ActionBar = global::FABSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark_ActionBar;
+			global::FAB.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog = global::FABSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog;
+			global::FAB.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert = global::FABSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert;
 			global::FAB.Droid.Resource.Style.ThemeOverlay_AppCompat_Light = global::FABSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Light;
+			global::FAB.Droid.Resource.Style.ThemeOverlay_MediaRouter_Dark = global::FABSample.Droid.Resource.Style.ThemeOverlay_MediaRouter_Dark;
+			global::FAB.Droid.Resource.Style.ThemeOverlay_MediaRouter_Light = global::FABSample.Droid.Resource.Style.ThemeOverlay_MediaRouter_Light;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ActionBar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ActionBar;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ActionBar_TabBar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_TabBar;
@@ -1331,10 +1609,13 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Light_PopupMenu_Overflow = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Light_PopupMenu_Overflow;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Light_SearchView = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Light_SearchView;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Light_Spinner_DropDown_ActionBar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Light_Spinner_DropDown_ActionBar;
+			global::FAB.Droid.Resource.Style.Widget_AppCompat_ListMenuView = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ListMenuView;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ListPopupWindow = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ListPopupWindow;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ListView = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ListView;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ListView_DropDown = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ListView_DropDown;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_ListView_Menu = global::FABSample.Droid.Resource.Style.Widget_AppCompat_ListView_Menu;
+			global::FAB.Droid.Resource.Style.Widget_AppCompat_NotificationActionContainer = global::FABSample.Droid.Resource.Style.Widget_AppCompat_NotificationActionContainer;
+			global::FAB.Droid.Resource.Style.Widget_AppCompat_NotificationActionText = global::FABSample.Droid.Resource.Style.Widget_AppCompat_NotificationActionText;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_PopupMenu = global::FABSample.Droid.Resource.Style.Widget_AppCompat_PopupMenu;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_PopupMenu_Overflow = global::FABSample.Droid.Resource.Style.Widget_AppCompat_PopupMenu_Overflow;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_PopupWindow = global::FABSample.Droid.Resource.Style.Widget_AppCompat_PopupWindow;
@@ -1346,6 +1627,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_SearchView = global::FABSample.Droid.Resource.Style.Widget_AppCompat_SearchView;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_SearchView_ActionBar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_SearchView_ActionBar;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_SeekBar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_SeekBar;
+			global::FAB.Droid.Resource.Style.Widget_AppCompat_SeekBar_Discrete = global::FABSample.Droid.Resource.Style.Widget_AppCompat_SeekBar_Discrete;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Spinner = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Spinner;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown_ActionBar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown_ActionBar;
@@ -1354,6 +1636,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Toolbar = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Toolbar;
 			global::FAB.Droid.Resource.Style.Widget_AppCompat_Toolbar_Button_Navigation = global::FABSample.Droid.Resource.Style.Widget_AppCompat_Toolbar_Button_Navigation;
 			global::FAB.Droid.Resource.Style.Widget_Design_AppBarLayout = global::FABSample.Droid.Resource.Style.Widget_Design_AppBarLayout;
+			global::FAB.Droid.Resource.Style.Widget_Design_BottomNavigationView = global::FABSample.Droid.Resource.Style.Widget_Design_BottomNavigationView;
 			global::FAB.Droid.Resource.Style.Widget_Design_BottomSheet_Modal = global::FABSample.Droid.Resource.Style.Widget_Design_BottomSheet_Modal;
 			global::FAB.Droid.Resource.Style.Widget_Design_CollapsingToolbar = global::FABSample.Droid.Resource.Style.Widget_Design_CollapsingToolbar;
 			global::FAB.Droid.Resource.Style.Widget_Design_CoordinatorLayout = global::FABSample.Droid.Resource.Style.Widget_Design_CoordinatorLayout;
@@ -1363,23 +1646,6 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Style.Widget_Design_Snackbar = global::FABSample.Droid.Resource.Style.Widget_Design_Snackbar;
 			global::FAB.Droid.Resource.Style.Widget_Design_TabLayout = global::FABSample.Droid.Resource.Style.Widget_Design_TabLayout;
 			global::FAB.Droid.Resource.Style.Widget_Design_TextInputLayout = global::FABSample.Droid.Resource.Style.Widget_Design_TextInputLayout;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Dark = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Dark;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Light = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Light;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Dark = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Dark;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Light = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Light;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Dark = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Dark;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Light = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Light;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Dark = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Dark;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Light = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Light;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Dark = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Dark;
-			global::FAB.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Light = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Light;
 			global::FAB.Droid.Resource.Style.Widget_MediaRouter_Light_MediaRouteButton = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_Light_MediaRouteButton;
 			global::FAB.Droid.Resource.Style.Widget_MediaRouter_MediaRouteButton = global::FABSample.Droid.Resource.Style.Widget_MediaRouter_MediaRouteButton;
 			global::FAB.Droid.Resource.Styleable.ActionBar = global::FABSample.Droid.Resource.Styleable.ActionBar;
@@ -1387,9 +1653,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.ActionBar_backgroundSplit = global::FABSample.Droid.Resource.Styleable.ActionBar_backgroundSplit;
 			global::FAB.Droid.Resource.Styleable.ActionBar_backgroundStacked = global::FABSample.Droid.Resource.Styleable.ActionBar_backgroundStacked;
 			global::FAB.Droid.Resource.Styleable.ActionBar_contentInsetEnd = global::FABSample.Droid.Resource.Styleable.ActionBar_contentInsetEnd;
+			global::FAB.Droid.Resource.Styleable.ActionBar_contentInsetEndWithActions = global::FABSample.Droid.Resource.Styleable.ActionBar_contentInsetEndWithActions;
 			global::FAB.Droid.Resource.Styleable.ActionBar_contentInsetLeft = global::FABSample.Droid.Resource.Styleable.ActionBar_contentInsetLeft;
 			global::FAB.Droid.Resource.Styleable.ActionBar_contentInsetRight = global::FABSample.Droid.Resource.Styleable.ActionBar_contentInsetRight;
 			global::FAB.Droid.Resource.Styleable.ActionBar_contentInsetStart = global::FABSample.Droid.Resource.Styleable.ActionBar_contentInsetStart;
+			global::FAB.Droid.Resource.Styleable.ActionBar_contentInsetStartWithNavigation = global::FABSample.Droid.Resource.Styleable.ActionBar_contentInsetStartWithNavigation;
 			global::FAB.Droid.Resource.Styleable.ActionBar_customNavigationLayout = global::FABSample.Droid.Resource.Styleable.ActionBar_customNavigationLayout;
 			global::FAB.Droid.Resource.Styleable.ActionBar_displayOptions = global::FABSample.Droid.Resource.Styleable.ActionBar_displayOptions;
 			global::FAB.Droid.Resource.Styleable.ActionBar_divider = global::FABSample.Droid.Resource.Styleable.ActionBar_divider;
@@ -1431,17 +1699,34 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.AlertDialog_listItemLayout = global::FABSample.Droid.Resource.Styleable.AlertDialog_listItemLayout;
 			global::FAB.Droid.Resource.Styleable.AlertDialog_listLayout = global::FABSample.Droid.Resource.Styleable.AlertDialog_listLayout;
 			global::FAB.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout = global::FABSample.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout;
+			global::FAB.Droid.Resource.Styleable.AlertDialog_showTitle = global::FABSample.Droid.Resource.Styleable.AlertDialog_showTitle;
 			global::FAB.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout = global::FABSample.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout;
 			global::FAB.Droid.Resource.Styleable.AppBarLayout = global::FABSample.Droid.Resource.Styleable.AppBarLayout;
 			global::FAB.Droid.Resource.Styleable.AppBarLayout_android_background = global::FABSample.Droid.Resource.Styleable.AppBarLayout_android_background;
 			global::FAB.Droid.Resource.Styleable.AppBarLayout_elevation = global::FABSample.Droid.Resource.Styleable.AppBarLayout_elevation;
 			global::FAB.Droid.Resource.Styleable.AppBarLayout_expanded = global::FABSample.Droid.Resource.Styleable.AppBarLayout_expanded;
-			global::FAB.Droid.Resource.Styleable.AppBarLayout_LayoutParams = global::FABSample.Droid.Resource.Styleable.AppBarLayout_LayoutParams;
-			global::FAB.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollFlags = global::FABSample.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollFlags;
-			global::FAB.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollInterpolator = global::FABSample.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollInterpolator;
+			global::FAB.Droid.Resource.Styleable.AppBarLayoutStates = global::FABSample.Droid.Resource.Styleable.AppBarLayoutStates;
+			global::FAB.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsed = global::FABSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsed;
+			global::FAB.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsible = global::FABSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsible;
+			global::FAB.Droid.Resource.Styleable.AppBarLayout_Layout = global::FABSample.Droid.Resource.Styleable.AppBarLayout_Layout;
+			global::FAB.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags = global::FABSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags;
+			global::FAB.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator = global::FABSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator;
 			global::FAB.Droid.Resource.Styleable.AppCompatImageView = global::FABSample.Droid.Resource.Styleable.AppCompatImageView;
 			global::FAB.Droid.Resource.Styleable.AppCompatImageView_android_src = global::FABSample.Droid.Resource.Styleable.AppCompatImageView_android_src;
 			global::FAB.Droid.Resource.Styleable.AppCompatImageView_srcCompat = global::FABSample.Droid.Resource.Styleable.AppCompatImageView_srcCompat;
+			global::FAB.Droid.Resource.Styleable.AppCompatSeekBar = global::FABSample.Droid.Resource.Styleable.AppCompatSeekBar;
+			global::FAB.Droid.Resource.Styleable.AppCompatSeekBar_android_thumb = global::FABSample.Droid.Resource.Styleable.AppCompatSeekBar_android_thumb;
+			global::FAB.Droid.Resource.Styleable.AppCompatSeekBar_tickMark = global::FABSample.Droid.Resource.Styleable.AppCompatSeekBar_tickMark;
+			global::FAB.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTint = global::FABSample.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTint;
+			global::FAB.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTintMode = global::FABSample.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTintMode;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableBottom = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableBottom;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableEnd = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableEnd;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableLeft = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableLeft;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableRight = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableRight;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableStart = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableStart;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableTop = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableTop;
+			global::FAB.Droid.Resource.Styleable.AppCompatTextHelper_android_textAppearance = global::FABSample.Droid.Resource.Styleable.AppCompatTextHelper_android_textAppearance;
 			global::FAB.Droid.Resource.Styleable.AppCompatTextView = global::FABSample.Droid.Resource.Styleable.AppCompatTextView;
 			global::FAB.Droid.Resource.Styleable.AppCompatTextView_android_textAppearance = global::FABSample.Droid.Resource.Styleable.AppCompatTextView_android_textAppearance;
 			global::FAB.Droid.Resource.Styleable.AppCompatTextView_textAllCaps = global::FABSample.Droid.Resource.Styleable.AppCompatTextView_textAllCaps;
@@ -1495,6 +1780,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_checkboxStyle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_checkboxStyle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_checkedTextViewStyle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_checkedTextViewStyle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_colorAccent = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_colorAccent;
+			global::FAB.Droid.Resource.Styleable.AppCompatTheme_colorBackgroundFloating = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_colorBackgroundFloating;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_colorButtonNormal = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_colorButtonNormal;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_colorControlActivated = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_colorControlActivated;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_colorControlHighlight = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_colorControlHighlight;
@@ -1516,6 +1802,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_imageButtonStyle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_imageButtonStyle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_listChoiceBackgroundIndicator = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_listChoiceBackgroundIndicator;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_listDividerAlertDialog = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_listDividerAlertDialog;
+			global::FAB.Droid.Resource.Styleable.AppCompatTheme_listMenuViewStyle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_listMenuViewStyle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_listPopupWindowStyle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_listPopupWindowStyle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeight = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeight;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeightLarge = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeightLarge;
@@ -1541,6 +1828,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearanceLargePopupMenu = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceLargePopupMenu;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItem = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItem;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItemSmall = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItemSmall;
+			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearancePopupMenuHeader = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearancePopupMenuHeader;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultSubtitle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultSubtitle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultTitle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultTitle;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSmallPopupMenu = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSmallPopupMenu;
@@ -1558,9 +1846,16 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMajor = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMajor;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMinor = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMinor;
 			global::FAB.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle = global::FABSample.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle;
-			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Params = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Params;
-			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_hideable = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_hideable;
-			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_peekHeight = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_peekHeight;
+			global::FAB.Droid.Resource.Styleable.BottomNavigationView = global::FABSample.Droid.Resource.Styleable.BottomNavigationView;
+			global::FAB.Droid.Resource.Styleable.BottomNavigationView_elevation = global::FABSample.Droid.Resource.Styleable.BottomNavigationView_elevation;
+			global::FAB.Droid.Resource.Styleable.BottomNavigationView_itemBackground = global::FABSample.Droid.Resource.Styleable.BottomNavigationView_itemBackground;
+			global::FAB.Droid.Resource.Styleable.BottomNavigationView_itemIconTint = global::FABSample.Droid.Resource.Styleable.BottomNavigationView_itemIconTint;
+			global::FAB.Droid.Resource.Styleable.BottomNavigationView_itemTextColor = global::FABSample.Droid.Resource.Styleable.BottomNavigationView_itemTextColor;
+			global::FAB.Droid.Resource.Styleable.BottomNavigationView_menu = global::FABSample.Droid.Resource.Styleable.BottomNavigationView_menu;
+			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Layout = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout;
+			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable;
+			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight;
+			global::FAB.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed = global::FABSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed;
 			global::FAB.Droid.Resource.Styleable.ButtonBarLayout = global::FABSample.Droid.Resource.Styleable.ButtonBarLayout;
 			global::FAB.Droid.Resource.Styleable.ButtonBarLayout_allowStacking = global::FABSample.Droid.Resource.Styleable.ButtonBarLayout_allowStacking;
 			global::FAB.Droid.Resource.Styleable.CardView = global::FABSample.Droid.Resource.Styleable.CardView;
@@ -1577,9 +1872,6 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.CardView_contentPaddingLeft = global::FABSample.Droid.Resource.Styleable.CardView_contentPaddingLeft;
 			global::FAB.Droid.Resource.Styleable.CardView_contentPaddingRight = global::FABSample.Droid.Resource.Styleable.CardView_contentPaddingRight;
 			global::FAB.Droid.Resource.Styleable.CardView_contentPaddingTop = global::FABSample.Droid.Resource.Styleable.CardView_contentPaddingTop;
-			global::FAB.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams = global::FABSample.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams;
-			global::FAB.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseMode = global::FABSample.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseMode;
-			global::FAB.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = global::FABSample.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance;
@@ -1591,10 +1883,19 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginStart = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginStart;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginTop = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginTop;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleTextAppearance = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleTextAppearance;
+			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimAnimationDuration = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimAnimationDuration;
+			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimVisibleHeightTrigger = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimVisibleHeightTrigger;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_statusBarScrim = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_statusBarScrim;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_title = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_title;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_titleEnabled = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_titleEnabled;
 			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_toolbarId = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_toolbarId;
+			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout;
+			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseMode = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseMode;
+			global::FAB.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = global::FABSample.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier;
+			global::FAB.Droid.Resource.Styleable.ColorStateListItem = global::FABSample.Droid.Resource.Styleable.ColorStateListItem;
+			global::FAB.Droid.Resource.Styleable.ColorStateListItem_alpha = global::FABSample.Droid.Resource.Styleable.ColorStateListItem_alpha;
+			global::FAB.Droid.Resource.Styleable.ColorStateListItem_android_alpha = global::FABSample.Droid.Resource.Styleable.ColorStateListItem_android_alpha;
+			global::FAB.Droid.Resource.Styleable.ColorStateListItem_android_color = global::FABSample.Droid.Resource.Styleable.ColorStateListItem_android_color;
 			global::FAB.Droid.Resource.Styleable.CompoundButton = global::FABSample.Droid.Resource.Styleable.CompoundButton;
 			global::FAB.Droid.Resource.Styleable.CompoundButton_android_button = global::FABSample.Droid.Resource.Styleable.CompoundButton_android_button;
 			global::FAB.Droid.Resource.Styleable.CompoundButton_buttonTint = global::FABSample.Droid.Resource.Styleable.CompoundButton_buttonTint;
@@ -1602,12 +1903,14 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.CoordinatorLayout = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout;
 			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_keylines = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_keylines;
 			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_statusBarBackground = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_statusBarBackground;
-			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams;
-			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_android_layout_gravity = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_android_layout_gravity;
-			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchor = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchor;
-			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchorGravity = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchorGravity;
-			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_behavior = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_behavior;
-			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_keyline = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_keyline;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_android_layout_gravity = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_android_layout_gravity;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchor = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchor;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchorGravity = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchorGravity;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_behavior = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_behavior;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_dodgeInsetEdges = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_dodgeInsetEdges;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_insetEdge = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_insetEdge;
+			global::FAB.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_keyline = global::FABSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_keyline;
 			global::FAB.Droid.Resource.Styleable.DesignTheme = global::FABSample.Droid.Resource.Styleable.DesignTheme;
 			global::FAB.Droid.Resource.Styleable.DesignTheme_bottomSheetDialogTheme = global::FABSample.Droid.Resource.Styleable.DesignTheme_bottomSheetDialogTheme;
 			global::FAB.Droid.Resource.Styleable.DesignTheme_bottomSheetStyle = global::FABSample.Droid.Resource.Styleable.DesignTheme_bottomSheetStyle;
@@ -1636,6 +1939,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.FloatingActionButton_pressedTranslationZ = global::FABSample.Droid.Resource.Styleable.FloatingActionButton_pressedTranslationZ;
 			global::FAB.Droid.Resource.Styleable.FloatingActionButton_rippleColor = global::FABSample.Droid.Resource.Styleable.FloatingActionButton_rippleColor;
 			global::FAB.Droid.Resource.Styleable.FloatingActionButton_useCompatPadding = global::FABSample.Droid.Resource.Styleable.FloatingActionButton_useCompatPadding;
+			global::FAB.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout = global::FABSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout;
+			global::FAB.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide = global::FABSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide;
 			global::FAB.Droid.Resource.Styleable.ForegroundLinearLayout = global::FABSample.Droid.Resource.Styleable.ForegroundLinearLayout;
 			global::FAB.Droid.Resource.Styleable.ForegroundLinearLayout_android_foreground = global::FABSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foreground;
 			global::FAB.Droid.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity = global::FABSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity;
@@ -1661,6 +1966,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.MediaRouteButton = global::FABSample.Droid.Resource.Styleable.MediaRouteButton;
 			global::FAB.Droid.Resource.Styleable.MediaRouteButton_android_minHeight = global::FABSample.Droid.Resource.Styleable.MediaRouteButton_android_minHeight;
 			global::FAB.Droid.Resource.Styleable.MediaRouteButton_android_minWidth = global::FABSample.Droid.Resource.Styleable.MediaRouteButton_android_minWidth;
+			global::FAB.Droid.Resource.Styleable.MediaRouteButton_buttonTint = global::FABSample.Droid.Resource.Styleable.MediaRouteButton_buttonTint;
 			global::FAB.Droid.Resource.Styleable.MediaRouteButton_externalRouteEnabledDrawable = global::FABSample.Droid.Resource.Styleable.MediaRouteButton_externalRouteEnabledDrawable;
 			global::FAB.Droid.Resource.Styleable.MenuGroup = global::FABSample.Droid.Resource.Styleable.MenuGroup;
 			global::FAB.Droid.Resource.Styleable.MenuGroup_android_checkableBehavior = global::FABSample.Droid.Resource.Styleable.MenuGroup_android_checkableBehavior;
@@ -1696,6 +2002,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.MenuView_android_verticalDivider = global::FABSample.Droid.Resource.Styleable.MenuView_android_verticalDivider;
 			global::FAB.Droid.Resource.Styleable.MenuView_android_windowAnimationStyle = global::FABSample.Droid.Resource.Styleable.MenuView_android_windowAnimationStyle;
 			global::FAB.Droid.Resource.Styleable.MenuView_preserveIconSpacing = global::FABSample.Droid.Resource.Styleable.MenuView_preserveIconSpacing;
+			global::FAB.Droid.Resource.Styleable.MenuView_subMenuArrow = global::FABSample.Droid.Resource.Styleable.MenuView_subMenuArrow;
 			global::FAB.Droid.Resource.Styleable.NavigationView = global::FABSample.Droid.Resource.Styleable.NavigationView;
 			global::FAB.Droid.Resource.Styleable.NavigationView_android_background = global::FABSample.Droid.Resource.Styleable.NavigationView_android_background;
 			global::FAB.Droid.Resource.Styleable.NavigationView_android_fitsSystemWindows = global::FABSample.Droid.Resource.Styleable.NavigationView_android_fitsSystemWindows;
@@ -1708,11 +2015,16 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.NavigationView_itemTextColor = global::FABSample.Droid.Resource.Styleable.NavigationView_itemTextColor;
 			global::FAB.Droid.Resource.Styleable.NavigationView_menu = global::FABSample.Droid.Resource.Styleable.NavigationView_menu;
 			global::FAB.Droid.Resource.Styleable.PopupWindow = global::FABSample.Droid.Resource.Styleable.PopupWindow;
+			global::FAB.Droid.Resource.Styleable.PopupWindow_android_popupAnimationStyle = global::FABSample.Droid.Resource.Styleable.PopupWindow_android_popupAnimationStyle;
 			global::FAB.Droid.Resource.Styleable.PopupWindow_android_popupBackground = global::FABSample.Droid.Resource.Styleable.PopupWindow_android_popupBackground;
 			global::FAB.Droid.Resource.Styleable.PopupWindow_overlapAnchor = global::FABSample.Droid.Resource.Styleable.PopupWindow_overlapAnchor;
 			global::FAB.Droid.Resource.Styleable.PopupWindowBackgroundState = global::FABSample.Droid.Resource.Styleable.PopupWindowBackgroundState;
 			global::FAB.Droid.Resource.Styleable.PopupWindowBackgroundState_state_above_anchor = global::FABSample.Droid.Resource.Styleable.PopupWindowBackgroundState_state_above_anchor;
+			global::FAB.Droid.Resource.Styleable.RecycleListView = global::FABSample.Droid.Resource.Styleable.RecycleListView;
+			global::FAB.Droid.Resource.Styleable.RecycleListView_paddingBottomNoButtons = global::FABSample.Droid.Resource.Styleable.RecycleListView_paddingBottomNoButtons;
+			global::FAB.Droid.Resource.Styleable.RecycleListView_paddingTopNoTitle = global::FABSample.Droid.Resource.Styleable.RecycleListView_paddingTopNoTitle;
 			global::FAB.Droid.Resource.Styleable.RecyclerView = global::FABSample.Droid.Resource.Styleable.RecyclerView;
+			global::FAB.Droid.Resource.Styleable.RecyclerView_android_descendantFocusability = global::FABSample.Droid.Resource.Styleable.RecyclerView_android_descendantFocusability;
 			global::FAB.Droid.Resource.Styleable.RecyclerView_android_orientation = global::FABSample.Droid.Resource.Styleable.RecyclerView_android_orientation;
 			global::FAB.Droid.Resource.Styleable.RecyclerView_layoutManager = global::FABSample.Droid.Resource.Styleable.RecyclerView_layoutManager;
 			global::FAB.Droid.Resource.Styleable.RecyclerView_reverseLayout = global::FABSample.Droid.Resource.Styleable.RecyclerView_reverseLayout;
@@ -1720,8 +2032,8 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.RecyclerView_stackFromEnd = global::FABSample.Droid.Resource.Styleable.RecyclerView_stackFromEnd;
 			global::FAB.Droid.Resource.Styleable.ScrimInsetsFrameLayout = global::FABSample.Droid.Resource.Styleable.ScrimInsetsFrameLayout;
 			global::FAB.Droid.Resource.Styleable.ScrimInsetsFrameLayout_insetForeground = global::FABSample.Droid.Resource.Styleable.ScrimInsetsFrameLayout_insetForeground;
-			global::FAB.Droid.Resource.Styleable.ScrollingViewBehavior_Params = global::FABSample.Droid.Resource.Styleable.ScrollingViewBehavior_Params;
-			global::FAB.Droid.Resource.Styleable.ScrollingViewBehavior_Params_behavior_overlapTop = global::FABSample.Droid.Resource.Styleable.ScrollingViewBehavior_Params_behavior_overlapTop;
+			global::FAB.Droid.Resource.Styleable.ScrollingViewBehavior_Layout = global::FABSample.Droid.Resource.Styleable.ScrollingViewBehavior_Layout;
+			global::FAB.Droid.Resource.Styleable.ScrollingViewBehavior_Layout_behavior_overlapTop = global::FABSample.Droid.Resource.Styleable.ScrollingViewBehavior_Layout_behavior_overlapTop;
 			global::FAB.Droid.Resource.Styleable.SearchView = global::FABSample.Droid.Resource.Styleable.SearchView;
 			global::FAB.Droid.Resource.Styleable.SearchView_android_focusable = global::FABSample.Droid.Resource.Styleable.SearchView_android_focusable;
 			global::FAB.Droid.Resource.Styleable.SearchView_android_imeOptions = global::FABSample.Droid.Resource.Styleable.SearchView_android_imeOptions;
@@ -1760,7 +2072,11 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.SwitchCompat_switchPadding = global::FABSample.Droid.Resource.Styleable.SwitchCompat_switchPadding;
 			global::FAB.Droid.Resource.Styleable.SwitchCompat_switchTextAppearance = global::FABSample.Droid.Resource.Styleable.SwitchCompat_switchTextAppearance;
 			global::FAB.Droid.Resource.Styleable.SwitchCompat_thumbTextPadding = global::FABSample.Droid.Resource.Styleable.SwitchCompat_thumbTextPadding;
+			global::FAB.Droid.Resource.Styleable.SwitchCompat_thumbTint = global::FABSample.Droid.Resource.Styleable.SwitchCompat_thumbTint;
+			global::FAB.Droid.Resource.Styleable.SwitchCompat_thumbTintMode = global::FABSample.Droid.Resource.Styleable.SwitchCompat_thumbTintMode;
 			global::FAB.Droid.Resource.Styleable.SwitchCompat_track = global::FABSample.Droid.Resource.Styleable.SwitchCompat_track;
+			global::FAB.Droid.Resource.Styleable.SwitchCompat_trackTint = global::FABSample.Droid.Resource.Styleable.SwitchCompat_trackTint;
+			global::FAB.Droid.Resource.Styleable.SwitchCompat_trackTintMode = global::FABSample.Droid.Resource.Styleable.SwitchCompat_trackTintMode;
 			global::FAB.Droid.Resource.Styleable.TabItem = global::FABSample.Droid.Resource.Styleable.TabItem;
 			global::FAB.Droid.Resource.Styleable.TabItem_android_icon = global::FABSample.Droid.Resource.Styleable.TabItem_android_icon;
 			global::FAB.Droid.Resource.Styleable.TabItem_android_layout = global::FABSample.Droid.Resource.Styleable.TabItem_android_layout;
@@ -1788,6 +2104,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.TextAppearance_android_shadowDy = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_shadowDy;
 			global::FAB.Droid.Resource.Styleable.TextAppearance_android_shadowRadius = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_shadowRadius;
 			global::FAB.Droid.Resource.Styleable.TextAppearance_android_textColor = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_textColor;
+			global::FAB.Droid.Resource.Styleable.TextAppearance_android_textColorHint = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_textColorHint;
 			global::FAB.Droid.Resource.Styleable.TextAppearance_android_textSize = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_textSize;
 			global::FAB.Droid.Resource.Styleable.TextAppearance_android_textStyle = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_textStyle;
 			global::FAB.Droid.Resource.Styleable.TextAppearance_android_typeface = global::FABSample.Droid.Resource.Styleable.TextAppearance_android_typeface;
@@ -1804,15 +2121,23 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.TextInputLayout_hintAnimationEnabled = global::FABSample.Droid.Resource.Styleable.TextInputLayout_hintAnimationEnabled;
 			global::FAB.Droid.Resource.Styleable.TextInputLayout_hintEnabled = global::FABSample.Droid.Resource.Styleable.TextInputLayout_hintEnabled;
 			global::FAB.Droid.Resource.Styleable.TextInputLayout_hintTextAppearance = global::FABSample.Droid.Resource.Styleable.TextInputLayout_hintTextAppearance;
+			global::FAB.Droid.Resource.Styleable.TextInputLayout_passwordToggleContentDescription = global::FABSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleContentDescription;
+			global::FAB.Droid.Resource.Styleable.TextInputLayout_passwordToggleDrawable = global::FABSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleDrawable;
+			global::FAB.Droid.Resource.Styleable.TextInputLayout_passwordToggleEnabled = global::FABSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleEnabled;
+			global::FAB.Droid.Resource.Styleable.TextInputLayout_passwordToggleTint = global::FABSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTint;
+			global::FAB.Droid.Resource.Styleable.TextInputLayout_passwordToggleTintMode = global::FABSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTintMode;
 			global::FAB.Droid.Resource.Styleable.Toolbar = global::FABSample.Droid.Resource.Styleable.Toolbar;
 			global::FAB.Droid.Resource.Styleable.Toolbar_android_gravity = global::FABSample.Droid.Resource.Styleable.Toolbar_android_gravity;
 			global::FAB.Droid.Resource.Styleable.Toolbar_android_minHeight = global::FABSample.Droid.Resource.Styleable.Toolbar_android_minHeight;
+			global::FAB.Droid.Resource.Styleable.Toolbar_buttonGravity = global::FABSample.Droid.Resource.Styleable.Toolbar_buttonGravity;
 			global::FAB.Droid.Resource.Styleable.Toolbar_collapseContentDescription = global::FABSample.Droid.Resource.Styleable.Toolbar_collapseContentDescription;
 			global::FAB.Droid.Resource.Styleable.Toolbar_collapseIcon = global::FABSample.Droid.Resource.Styleable.Toolbar_collapseIcon;
 			global::FAB.Droid.Resource.Styleable.Toolbar_contentInsetEnd = global::FABSample.Droid.Resource.Styleable.Toolbar_contentInsetEnd;
+			global::FAB.Droid.Resource.Styleable.Toolbar_contentInsetEndWithActions = global::FABSample.Droid.Resource.Styleable.Toolbar_contentInsetEndWithActions;
 			global::FAB.Droid.Resource.Styleable.Toolbar_contentInsetLeft = global::FABSample.Droid.Resource.Styleable.Toolbar_contentInsetLeft;
 			global::FAB.Droid.Resource.Styleable.Toolbar_contentInsetRight = global::FABSample.Droid.Resource.Styleable.Toolbar_contentInsetRight;
 			global::FAB.Droid.Resource.Styleable.Toolbar_contentInsetStart = global::FABSample.Droid.Resource.Styleable.Toolbar_contentInsetStart;
+			global::FAB.Droid.Resource.Styleable.Toolbar_contentInsetStartWithNavigation = global::FABSample.Droid.Resource.Styleable.Toolbar_contentInsetStartWithNavigation;
 			global::FAB.Droid.Resource.Styleable.Toolbar_logo = global::FABSample.Droid.Resource.Styleable.Toolbar_logo;
 			global::FAB.Droid.Resource.Styleable.Toolbar_logoDescription = global::FABSample.Droid.Resource.Styleable.Toolbar_logoDescription;
 			global::FAB.Droid.Resource.Styleable.Toolbar_maxButtonHeight = global::FABSample.Droid.Resource.Styleable.Toolbar_maxButtonHeight;
@@ -1823,6 +2148,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.Toolbar_subtitleTextAppearance = global::FABSample.Droid.Resource.Styleable.Toolbar_subtitleTextAppearance;
 			global::FAB.Droid.Resource.Styleable.Toolbar_subtitleTextColor = global::FABSample.Droid.Resource.Styleable.Toolbar_subtitleTextColor;
 			global::FAB.Droid.Resource.Styleable.Toolbar_title = global::FABSample.Droid.Resource.Styleable.Toolbar_title;
+			global::FAB.Droid.Resource.Styleable.Toolbar_titleMargin = global::FABSample.Droid.Resource.Styleable.Toolbar_titleMargin;
 			global::FAB.Droid.Resource.Styleable.Toolbar_titleMarginBottom = global::FABSample.Droid.Resource.Styleable.Toolbar_titleMarginBottom;
 			global::FAB.Droid.Resource.Styleable.Toolbar_titleMarginEnd = global::FABSample.Droid.Resource.Styleable.Toolbar_titleMarginEnd;
 			global::FAB.Droid.Resource.Styleable.Toolbar_titleMarginStart = global::FABSample.Droid.Resource.Styleable.Toolbar_titleMarginStart;
@@ -1844,6 +2170,7 @@ namespace FABSample.Droid
 			global::FAB.Droid.Resource.Styleable.ViewStubCompat_android_id = global::FABSample.Droid.Resource.Styleable.ViewStubCompat_android_id;
 			global::FAB.Droid.Resource.Styleable.ViewStubCompat_android_inflatedId = global::FABSample.Droid.Resource.Styleable.ViewStubCompat_android_inflatedId;
 			global::FAB.Droid.Resource.Styleable.ViewStubCompat_android_layout = global::FABSample.Droid.Resource.Styleable.ViewStubCompat_android_layout;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarSize = global::FABSample.Droid.Resource.Attribute.actionBarSize;
 		}
 		
 		public partial class Animation
@@ -1907,974 +2234,1056 @@ namespace FABSample.Droid
 			}
 		}
 		
+		public partial class Animator
+		{
+			
+			// aapt resource value: 0x7f050000
+			public const int design_appbar_state_list_animator = 2131034112;
+			
+			static Animator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animator()
+			{
+			}
+		}
+		
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010000
-			public const int MediaRouteControllerWindowBackground = 2130771968;
-			
-			// aapt resource value: 0x7f010097
-			public const int actionBarDivider = 2130772119;
-			
-			// aapt resource value: 0x7f010098
-			public const int actionBarItemBackground = 2130772120;
-			
-			// aapt resource value: 0x7f010091
-			public const int actionBarPopupTheme = 2130772113;
-			
-			// aapt resource value: 0x7f010096
-			public const int actionBarSize = 2130772118;
-			
-			// aapt resource value: 0x7f010093
-			public const int actionBarSplitStyle = 2130772115;
-			
-			// aapt resource value: 0x7f010092
-			public const int actionBarStyle = 2130772114;
-			
-			// aapt resource value: 0x7f01008d
-			public const int actionBarTabBarStyle = 2130772109;
-			
-			// aapt resource value: 0x7f01008c
-			public const int actionBarTabStyle = 2130772108;
-			
-			// aapt resource value: 0x7f01008e
-			public const int actionBarTabTextStyle = 2130772110;
-			
-			// aapt resource value: 0x7f010094
-			public const int actionBarTheme = 2130772116;
-			
-			// aapt resource value: 0x7f010095
-			public const int actionBarWidgetTheme = 2130772117;
-			
-			// aapt resource value: 0x7f0100b1
-			public const int actionButtonStyle = 2130772145;
-			
-			// aapt resource value: 0x7f0100ad
-			public const int actionDropDownStyle = 2130772141;
-			
-			// aapt resource value: 0x7f0100ff
-			public const int actionLayout = 2130772223;
-			
-			// aapt resource value: 0x7f010099
-			public const int actionMenuTextAppearance = 2130772121;
-			
-			// aapt resource value: 0x7f01009a
-			public const int actionMenuTextColor = 2130772122;
-			
-			// aapt resource value: 0x7f01009d
-			public const int actionModeBackground = 2130772125;
-			
-			// aapt resource value: 0x7f01009c
-			public const int actionModeCloseButtonStyle = 2130772124;
-			
-			// aapt resource value: 0x7f01009f
-			public const int actionModeCloseDrawable = 2130772127;
-			
-			// aapt resource value: 0x7f0100a1
-			public const int actionModeCopyDrawable = 2130772129;
-			
-			// aapt resource value: 0x7f0100a0
-			public const int actionModeCutDrawable = 2130772128;
-			
-			// aapt resource value: 0x7f0100a5
-			public const int actionModeFindDrawable = 2130772133;
-			
-			// aapt resource value: 0x7f0100a2
-			public const int actionModePasteDrawable = 2130772130;
-			
-			// aapt resource value: 0x7f0100a7
-			public const int actionModePopupWindowStyle = 2130772135;
-			
-			// aapt resource value: 0x7f0100a3
-			public const int actionModeSelectAllDrawable = 2130772131;
-			
-			// aapt resource value: 0x7f0100a4
-			public const int actionModeShareDrawable = 2130772132;
-			
-			// aapt resource value: 0x7f01009e
-			public const int actionModeSplitBackground = 2130772126;
-			
-			// aapt resource value: 0x7f01009b
-			public const int actionModeStyle = 2130772123;
-			
-			// aapt resource value: 0x7f0100a6
-			public const int actionModeWebSearchDrawable = 2130772134;
-			
-			// aapt resource value: 0x7f01008f
-			public const int actionOverflowButtonStyle = 2130772111;
-			
-			// aapt resource value: 0x7f010090
-			public const int actionOverflowMenuStyle = 2130772112;
-			
-			// aapt resource value: 0x7f010101
-			public const int actionProviderClass = 2130772225;
-			
-			// aapt resource value: 0x7f010100
-			public const int actionViewClass = 2130772224;
-			
-			// aapt resource value: 0x7f0100b9
-			public const int activityChooserViewStyle = 2130772153;
-			
-			// aapt resource value: 0x7f0100dc
-			public const int alertDialogButtonGroupStyle = 2130772188;
-			
-			// aapt resource value: 0x7f0100dd
-			public const int alertDialogCenterButtons = 2130772189;
-			
-			// aapt resource value: 0x7f0100db
-			public const int alertDialogStyle = 2130772187;
-			
-			// aapt resource value: 0x7f0100de
-			public const int alertDialogTheme = 2130772190;
-			
-			// aapt resource value: 0x7f0100f0
-			public const int allowStacking = 2130772208;
-			
-			// aapt resource value: 0x7f0100f7
-			public const int arrowHeadLength = 2130772215;
-			
-			// aapt resource value: 0x7f0100f8
-			public const int arrowShaftLength = 2130772216;
-			
-			// aapt resource value: 0x7f0100e3
-			public const int autoCompleteTextViewStyle = 2130772195;
-			
-			// aapt resource value: 0x7f010068
-			public const int background = 2130772072;
-			
-			// aapt resource value: 0x7f01006a
-			public const int backgroundSplit = 2130772074;
-			
-			// aapt resource value: 0x7f010069
-			public const int backgroundStacked = 2130772073;
-			
-			// aapt resource value: 0x7f01012b
-			public const int backgroundTint = 2130772267;
-			
-			// aapt resource value: 0x7f01012c
-			public const int backgroundTintMode = 2130772268;
-			
-			// aapt resource value: 0x7f0100f9
-			public const int barLength = 2130772217;
-			
-			// aapt resource value: 0x7f01001b
-			public const int behavior_hideable = 2130771995;
-			
-			// aapt resource value: 0x7f010041
-			public const int behavior_overlapTop = 2130772033;
-			
-			// aapt resource value: 0x7f01001a
-			public const int behavior_peekHeight = 2130771994;
-			
-			// aapt resource value: 0x7f010037
-			public const int borderWidth = 2130772023;
-			
-			// aapt resource value: 0x7f0100b6
-			public const int borderlessButtonStyle = 2130772150;
-			
-			// aapt resource value: 0x7f010031
-			public const int bottomSheetDialogTheme = 2130772017;
-			
-			// aapt resource value: 0x7f010032
-			public const int bottomSheetStyle = 2130772018;
-			
-			// aapt resource value: 0x7f0100b3
-			public const int buttonBarButtonStyle = 2130772147;
-			
-			// aapt resource value: 0x7f0100e1
-			public const int buttonBarNegativeButtonStyle = 2130772193;
-			
-			// aapt resource value: 0x7f0100e2
-			public const int buttonBarNeutralButtonStyle = 2130772194;
-			
-			// aapt resource value: 0x7f0100e0
-			public const int buttonBarPositiveButtonStyle = 2130772192;
-			
-			// aapt resource value: 0x7f0100b2
-			public const int buttonBarStyle = 2130772146;
-			
-			// aapt resource value: 0x7f01007b
-			public const int buttonPanelSideLayout = 2130772091;
-			
-			// aapt resource value: 0x7f0100e4
-			public const int buttonStyle = 2130772196;
-			
-			// aapt resource value: 0x7f0100e5
-			public const int buttonStyleSmall = 2130772197;
-			
-			// aapt resource value: 0x7f0100f1
-			public const int buttonTint = 2130772209;
-			
-			// aapt resource value: 0x7f0100f2
-			public const int buttonTintMode = 2130772210;
-			
-			// aapt resource value: 0x7f010131
-			public const int cardBackgroundColor = 2130772273;
-			
-			// aapt resource value: 0x7f010132
-			public const int cardCornerRadius = 2130772274;
-			
-			// aapt resource value: 0x7f010133
-			public const int cardElevation = 2130772275;
-			
-			// aapt resource value: 0x7f010134
-			public const int cardMaxElevation = 2130772276;
-			
-			// aapt resource value: 0x7f010136
-			public const int cardPreventCornerOverlap = 2130772278;
-			
-			// aapt resource value: 0x7f010135
-			public const int cardUseCompatPadding = 2130772277;
-			
-			// aapt resource value: 0x7f0100e6
-			public const int checkboxStyle = 2130772198;
-			
-			// aapt resource value: 0x7f0100e7
-			public const int checkedTextViewStyle = 2130772199;
-			
-			// aapt resource value: 0x7f010109
-			public const int closeIcon = 2130772233;
-			
-			// aapt resource value: 0x7f010078
-			public const int closeItemLayout = 2130772088;
-			
-			// aapt resource value: 0x7f010122
-			public const int collapseContentDescription = 2130772258;
-			
-			// aapt resource value: 0x7f010121
-			public const int collapseIcon = 2130772257;
-			
-			// aapt resource value: 0x7f010028
-			public const int collapsedTitleGravity = 2130772008;
-			
-			// aapt resource value: 0x7f010024
-			public const int collapsedTitleTextAppearance = 2130772004;
-			
-			// aapt resource value: 0x7f0100f3
-			public const int color = 2130772211;
-			
-			// aapt resource value: 0x7f0100d4
-			public const int colorAccent = 2130772180;
-			
-			// aapt resource value: 0x7f0100d8
-			public const int colorButtonNormal = 2130772184;
-			
-			// aapt resource value: 0x7f0100d6
-			public const int colorControlActivated = 2130772182;
-			
-			// aapt resource value: 0x7f0100d7
-			public const int colorControlHighlight = 2130772183;
-			
-			// aapt resource value: 0x7f0100d5
-			public const int colorControlNormal = 2130772181;
-			
-			// aapt resource value: 0x7f0100d2
-			public const int colorPrimary = 2130772178;
-			
-			// aapt resource value: 0x7f0100d3
-			public const int colorPrimaryDark = 2130772179;
-			
-			// aapt resource value: 0x7f0100d9
-			public const int colorSwitchThumbNormal = 2130772185;
-			
-			// aapt resource value: 0x7f01010e
-			public const int commitIcon = 2130772238;
-			
-			// aapt resource value: 0x7f010073
-			public const int contentInsetEnd = 2130772083;
-			
-			// aapt resource value: 0x7f010074
-			public const int contentInsetLeft = 2130772084;
-			
-			// aapt resource value: 0x7f010075
-			public const int contentInsetRight = 2130772085;
-			
-			// aapt resource value: 0x7f010072
-			public const int contentInsetStart = 2130772082;
-			
-			// aapt resource value: 0x7f010137
-			public const int contentPadding = 2130772279;
-			
-			// aapt resource value: 0x7f01013b
-			public const int contentPaddingBottom = 2130772283;
-			
-			// aapt resource value: 0x7f010138
-			public const int contentPaddingLeft = 2130772280;
-			
-			// aapt resource value: 0x7f010139
-			public const int contentPaddingRight = 2130772281;
-			
-			// aapt resource value: 0x7f01013a
-			public const int contentPaddingTop = 2130772282;
-			
-			// aapt resource value: 0x7f010025
-			public const int contentScrim = 2130772005;
-			
-			// aapt resource value: 0x7f0100da
-			public const int controlBackground = 2130772186;
-			
-			// aapt resource value: 0x7f010057
-			public const int counterEnabled = 2130772055;
-			
-			// aapt resource value: 0x7f010058
-			public const int counterMaxLength = 2130772056;
-			
-			// aapt resource value: 0x7f01005a
-			public const int counterOverflowTextAppearance = 2130772058;
-			
-			// aapt resource value: 0x7f010059
-			public const int counterTextAppearance = 2130772057;
-			
-			// aapt resource value: 0x7f01006b
-			public const int customNavigationLayout = 2130772075;
-			
-			// aapt resource value: 0x7f010108
-			public const int defaultQueryHint = 2130772232;
-			
-			// aapt resource value: 0x7f0100ab
-			public const int dialogPreferredPadding = 2130772139;
-			
-			// aapt resource value: 0x7f0100aa
-			public const int dialogTheme = 2130772138;
-			
-			// aapt resource value: 0x7f010061
-			public const int displayOptions = 2130772065;
-			
-			// aapt resource value: 0x7f010067
-			public const int divider = 2130772071;
-			
-			// aapt resource value: 0x7f0100b8
-			public const int dividerHorizontal = 2130772152;
-			
-			// aapt resource value: 0x7f0100fd
-			public const int dividerPadding = 2130772221;
-			
-			// aapt resource value: 0x7f0100b7
-			public const int dividerVertical = 2130772151;
-			
-			// aapt resource value: 0x7f0100f5
-			public const int drawableSize = 2130772213;
-			
-			// aapt resource value: 0x7f01005c
-			public const int drawerArrowStyle = 2130772060;
-			
-			// aapt resource value: 0x7f0100ca
-			public const int dropDownListViewStyle = 2130772170;
-			
-			// aapt resource value: 0x7f0100ae
-			public const int dropdownListPreferredItemHeight = 2130772142;
-			
-			// aapt resource value: 0x7f0100bf
-			public const int editTextBackground = 2130772159;
-			
-			// aapt resource value: 0x7f0100be
-			public const int editTextColor = 2130772158;
-			
-			// aapt resource value: 0x7f0100e8
-			public const int editTextStyle = 2130772200;
-			
-			// aapt resource value: 0x7f010076
-			public const int elevation = 2130772086;
-			
-			// aapt resource value: 0x7f010055
-			public const int errorEnabled = 2130772053;
-			
-			// aapt resource value: 0x7f010056
-			public const int errorTextAppearance = 2130772054;
-			
-			// aapt resource value: 0x7f01007a
-			public const int expandActivityOverflowButtonDrawable = 2130772090;
-			
-			// aapt resource value: 0x7f010017
-			public const int expanded = 2130771991;
-			
-			// aapt resource value: 0x7f010029
-			public const int expandedTitleGravity = 2130772009;
-			
-			// aapt resource value: 0x7f01001e
-			public const int expandedTitleMargin = 2130771998;
-			
-			// aapt resource value: 0x7f010022
-			public const int expandedTitleMarginBottom = 2130772002;
-			
-			// aapt resource value: 0x7f010021
-			public const int expandedTitleMarginEnd = 2130772001;
-			
-			// aapt resource value: 0x7f01001f
-			public const int expandedTitleMarginStart = 2130771999;
-			
-			// aapt resource value: 0x7f010020
-			public const int expandedTitleMarginTop = 2130772000;
-			
-			// aapt resource value: 0x7f010023
-			public const int expandedTitleTextAppearance = 2130772003;
-			
-			// aapt resource value: 0x7f010016
-			public const int externalRouteEnabledDrawable = 2130771990;
-			
-			// aapt resource value: 0x7f010035
-			public const int fabSize = 2130772021;
-			
-			// aapt resource value: 0x7f01013e
-			public const int fab_colorDisabled = 2130772286;
-			
-			// aapt resource value: 0x7f01013d
-			public const int fab_colorNormal = 2130772285;
-			
-			// aapt resource value: 0x7f01013c
-			public const int fab_colorPressed = 2130772284;
-			
-			// aapt resource value: 0x7f01013f
-			public const int fab_colorRipple = 2130772287;
-			
-			// aapt resource value: 0x7f010140
-			public const int fab_shadow = 2130772288;
-			
-			// aapt resource value: 0x7f010141
-			public const int fab_size = 2130772289;
-			
-			// aapt resource value: 0x7f010039
-			public const int foregroundInsidePadding = 2130772025;
-			
-			// aapt resource value: 0x7f0100f6
-			public const int gapBetweenBars = 2130772214;
-			
-			// aapt resource value: 0x7f01010a
-			public const int goIcon = 2130772234;
-			
-			// aapt resource value: 0x7f01003f
-			public const int headerLayout = 2130772031;
-			
 			// aapt resource value: 0x7f01005d
-			public const int height = 2130772061;
-			
-			// aapt resource value: 0x7f010071
-			public const int hideOnContentScroll = 2130772081;
-			
-			// aapt resource value: 0x7f01005b
-			public const int hintAnimationEnabled = 2130772059;
-			
-			// aapt resource value: 0x7f010054
-			public const int hintEnabled = 2130772052;
-			
-			// aapt resource value: 0x7f010053
-			public const int hintTextAppearance = 2130772051;
-			
-			// aapt resource value: 0x7f0100b0
-			public const int homeAsUpIndicator = 2130772144;
-			
-			// aapt resource value: 0x7f01006c
-			public const int homeLayout = 2130772076;
-			
-			// aapt resource value: 0x7f010065
-			public const int icon = 2130772069;
-			
-			// aapt resource value: 0x7f010106
-			public const int iconifiedByDefault = 2130772230;
-			
-			// aapt resource value: 0x7f0100c0
-			public const int imageButtonStyle = 2130772160;
-			
-			// aapt resource value: 0x7f01006e
-			public const int indeterminateProgressStyle = 2130772078;
-			
-			// aapt resource value: 0x7f010079
-			public const int initialActivityCount = 2130772089;
-			
-			// aapt resource value: 0x7f010040
-			public const int insetForeground = 2130772032;
+			public const int actionBarDivider = 2130772061;
 			
 			// aapt resource value: 0x7f01005e
-			public const int isLightTheme = 2130772062;
+			public const int actionBarItemBackground = 2130772062;
 			
-			// aapt resource value: 0x7f01003d
-			public const int itemBackground = 2130772029;
+			// aapt resource value: 0x7f010057
+			public const int actionBarPopupTheme = 2130772055;
 			
-			// aapt resource value: 0x7f01003b
-			public const int itemIconTint = 2130772027;
+			// aapt resource value: 0x7f01005c
+			public const int actionBarSize = 2130772060;
 			
-			// aapt resource value: 0x7f010070
-			public const int itemPadding = 2130772080;
+			// aapt resource value: 0x7f010059
+			public const int actionBarSplitStyle = 2130772057;
 			
-			// aapt resource value: 0x7f01003e
-			public const int itemTextAppearance = 2130772030;
+			// aapt resource value: 0x7f010058
+			public const int actionBarStyle = 2130772056;
 			
-			// aapt resource value: 0x7f01003c
-			public const int itemTextColor = 2130772028;
-			
-			// aapt resource value: 0x7f01002b
-			public const int keylines = 2130772011;
-			
-			// aapt resource value: 0x7f010105
-			public const int layout = 2130772229;
-			
-			// aapt resource value: 0x7f01012d
-			public const int layoutManager = 2130772269;
-			
-			// aapt resource value: 0x7f01002e
-			public const int layout_anchor = 2130772014;
-			
-			// aapt resource value: 0x7f010030
-			public const int layout_anchorGravity = 2130772016;
-			
-			// aapt resource value: 0x7f01002d
-			public const int layout_behavior = 2130772013;
-			
-			// aapt resource value: 0x7f01001c
-			public const int layout_collapseMode = 2130771996;
-			
-			// aapt resource value: 0x7f01001d
-			public const int layout_collapseParallaxMultiplier = 2130771997;
-			
-			// aapt resource value: 0x7f01002f
-			public const int layout_keyline = 2130772015;
-			
-			// aapt resource value: 0x7f010018
-			public const int layout_scrollFlags = 2130771992;
-			
-			// aapt resource value: 0x7f010019
-			public const int layout_scrollInterpolator = 2130771993;
-			
-			// aapt resource value: 0x7f0100d1
-			public const int listChoiceBackgroundIndicator = 2130772177;
-			
-			// aapt resource value: 0x7f0100ac
-			public const int listDividerAlertDialog = 2130772140;
-			
-			// aapt resource value: 0x7f01007f
-			public const int listItemLayout = 2130772095;
-			
-			// aapt resource value: 0x7f01007c
-			public const int listLayout = 2130772092;
-			
-			// aapt resource value: 0x7f0100cb
-			public const int listPopupWindowStyle = 2130772171;
-			
-			// aapt resource value: 0x7f0100c5
-			public const int listPreferredItemHeight = 2130772165;
-			
-			// aapt resource value: 0x7f0100c7
-			public const int listPreferredItemHeightLarge = 2130772167;
-			
-			// aapt resource value: 0x7f0100c6
-			public const int listPreferredItemHeightSmall = 2130772166;
-			
-			// aapt resource value: 0x7f0100c8
-			public const int listPreferredItemPaddingLeft = 2130772168;
-			
-			// aapt resource value: 0x7f0100c9
-			public const int listPreferredItemPaddingRight = 2130772169;
-			
-			// aapt resource value: 0x7f010066
-			public const int logo = 2130772070;
-			
-			// aapt resource value: 0x7f010125
-			public const int logoDescription = 2130772261;
-			
-			// aapt resource value: 0x7f010042
-			public const int maxActionInlineWidth = 2130772034;
-			
-			// aapt resource value: 0x7f010120
-			public const int maxButtonHeight = 2130772256;
-			
-			// aapt resource value: 0x7f0100fb
-			public const int measureWithLargestChild = 2130772219;
-			
-			// aapt resource value: 0x7f010001
-			public const int mediaRouteAudioTrackDrawable = 2130771969;
-			
-			// aapt resource value: 0x7f010002
-			public const int mediaRouteBluetoothIconDrawable = 2130771970;
-			
-			// aapt resource value: 0x7f010003
-			public const int mediaRouteButtonStyle = 2130771971;
-			
-			// aapt resource value: 0x7f010004
-			public const int mediaRouteCastDrawable = 2130771972;
-			
-			// aapt resource value: 0x7f010005
-			public const int mediaRouteChooserPrimaryTextStyle = 2130771973;
-			
-			// aapt resource value: 0x7f010006
-			public const int mediaRouteChooserSecondaryTextStyle = 2130771974;
-			
-			// aapt resource value: 0x7f010007
-			public const int mediaRouteCloseDrawable = 2130771975;
-			
-			// aapt resource value: 0x7f010008
-			public const int mediaRouteCollapseGroupDrawable = 2130771976;
-			
-			// aapt resource value: 0x7f010009
-			public const int mediaRouteConnectingDrawable = 2130771977;
-			
-			// aapt resource value: 0x7f01000a
-			public const int mediaRouteControllerPrimaryTextStyle = 2130771978;
-			
-			// aapt resource value: 0x7f01000b
-			public const int mediaRouteControllerSecondaryTextStyle = 2130771979;
-			
-			// aapt resource value: 0x7f01000c
-			public const int mediaRouteControllerTitleTextStyle = 2130771980;
-			
-			// aapt resource value: 0x7f01000d
-			public const int mediaRouteDefaultIconDrawable = 2130771981;
-			
-			// aapt resource value: 0x7f01000e
-			public const int mediaRouteExpandGroupDrawable = 2130771982;
-			
-			// aapt resource value: 0x7f01000f
-			public const int mediaRouteOffDrawable = 2130771983;
-			
-			// aapt resource value: 0x7f010010
-			public const int mediaRouteOnDrawable = 2130771984;
-			
-			// aapt resource value: 0x7f010011
-			public const int mediaRoutePauseDrawable = 2130771985;
-			
-			// aapt resource value: 0x7f010012
-			public const int mediaRoutePlayDrawable = 2130771986;
-			
-			// aapt resource value: 0x7f010013
-			public const int mediaRouteSpeakerGroupIconDrawable = 2130771987;
-			
-			// aapt resource value: 0x7f010014
-			public const int mediaRouteSpeakerIconDrawable = 2130771988;
-			
-			// aapt resource value: 0x7f010015
-			public const int mediaRouteTvIconDrawable = 2130771989;
-			
-			// aapt resource value: 0x7f01003a
-			public const int menu = 2130772026;
-			
-			// aapt resource value: 0x7f01007d
-			public const int multiChoiceItemLayout = 2130772093;
-			
-			// aapt resource value: 0x7f010124
-			public const int navigationContentDescription = 2130772260;
-			
-			// aapt resource value: 0x7f010123
-			public const int navigationIcon = 2130772259;
-			
-			// aapt resource value: 0x7f010060
-			public const int navigationMode = 2130772064;
-			
-			// aapt resource value: 0x7f010103
-			public const int overlapAnchor = 2130772227;
-			
-			// aapt resource value: 0x7f010129
-			public const int paddingEnd = 2130772265;
-			
-			// aapt resource value: 0x7f010128
-			public const int paddingStart = 2130772264;
-			
-			// aapt resource value: 0x7f0100ce
-			public const int panelBackground = 2130772174;
-			
-			// aapt resource value: 0x7f0100d0
-			public const int panelMenuListTheme = 2130772176;
-			
-			// aapt resource value: 0x7f0100cf
-			public const int panelMenuListWidth = 2130772175;
-			
-			// aapt resource value: 0x7f0100bc
-			public const int popupMenuStyle = 2130772156;
-			
-			// aapt resource value: 0x7f010077
-			public const int popupTheme = 2130772087;
-			
-			// aapt resource value: 0x7f0100bd
-			public const int popupWindowStyle = 2130772157;
-			
-			// aapt resource value: 0x7f010102
-			public const int preserveIconSpacing = 2130772226;
-			
-			// aapt resource value: 0x7f010036
-			public const int pressedTranslationZ = 2130772022;
-			
-			// aapt resource value: 0x7f01006f
-			public const int progressBarPadding = 2130772079;
-			
-			// aapt resource value: 0x7f01006d
-			public const int progressBarStyle = 2130772077;
-			
-			// aapt resource value: 0x7f010110
-			public const int queryBackground = 2130772240;
-			
-			// aapt resource value: 0x7f010107
-			public const int queryHint = 2130772231;
-			
-			// aapt resource value: 0x7f0100e9
-			public const int radioButtonStyle = 2130772201;
-			
-			// aapt resource value: 0x7f0100ea
-			public const int ratingBarStyle = 2130772202;
-			
-			// aapt resource value: 0x7f0100eb
-			public const int ratingBarStyleIndicator = 2130772203;
-			
-			// aapt resource value: 0x7f0100ec
-			public const int ratingBarStyleSmall = 2130772204;
-			
-			// aapt resource value: 0x7f01012f
-			public const int reverseLayout = 2130772271;
-			
-			// aapt resource value: 0x7f010034
-			public const int rippleColor = 2130772020;
-			
-			// aapt resource value: 0x7f01010c
-			public const int searchHintIcon = 2130772236;
-			
-			// aapt resource value: 0x7f01010b
-			public const int searchIcon = 2130772235;
-			
-			// aapt resource value: 0x7f0100c4
-			public const int searchViewStyle = 2130772164;
-			
-			// aapt resource value: 0x7f0100ed
-			public const int seekBarStyle = 2130772205;
-			
-			// aapt resource value: 0x7f0100b4
-			public const int selectableItemBackground = 2130772148;
-			
-			// aapt resource value: 0x7f0100b5
-			public const int selectableItemBackgroundBorderless = 2130772149;
-			
-			// aapt resource value: 0x7f0100fe
-			public const int showAsAction = 2130772222;
-			
-			// aapt resource value: 0x7f0100fc
-			public const int showDividers = 2130772220;
-			
-			// aapt resource value: 0x7f010118
-			public const int showText = 2130772248;
-			
-			// aapt resource value: 0x7f01007e
-			public const int singleChoiceItemLayout = 2130772094;
-			
-			// aapt resource value: 0x7f01012e
-			public const int spanCount = 2130772270;
-			
-			// aapt resource value: 0x7f0100f4
-			public const int spinBars = 2130772212;
-			
-			// aapt resource value: 0x7f0100af
-			public const int spinnerDropDownItemStyle = 2130772143;
-			
-			// aapt resource value: 0x7f0100ee
-			public const int spinnerStyle = 2130772206;
-			
-			// aapt resource value: 0x7f010117
-			public const int splitTrack = 2130772247;
-			
-			// aapt resource value: 0x7f010080
-			public const int srcCompat = 2130772096;
-			
-			// aapt resource value: 0x7f010130
-			public const int stackFromEnd = 2130772272;
-			
-			// aapt resource value: 0x7f010104
-			public const int state_above_anchor = 2130772228;
-			
-			// aapt resource value: 0x7f01002c
-			public const int statusBarBackground = 2130772012;
-			
-			// aapt resource value: 0x7f010026
-			public const int statusBarScrim = 2130772006;
-			
-			// aapt resource value: 0x7f010111
-			public const int submitBackground = 2130772241;
-			
-			// aapt resource value: 0x7f010062
-			public const int subtitle = 2130772066;
-			
-			// aapt resource value: 0x7f01011a
-			public const int subtitleTextAppearance = 2130772250;
-			
-			// aapt resource value: 0x7f010127
-			public const int subtitleTextColor = 2130772263;
-			
-			// aapt resource value: 0x7f010064
-			public const int subtitleTextStyle = 2130772068;
-			
-			// aapt resource value: 0x7f01010f
-			public const int suggestionRowLayout = 2130772239;
-			
-			// aapt resource value: 0x7f010115
-			public const int switchMinWidth = 2130772245;
-			
-			// aapt resource value: 0x7f010116
-			public const int switchPadding = 2130772246;
-			
-			// aapt resource value: 0x7f0100ef
-			public const int switchStyle = 2130772207;
-			
-			// aapt resource value: 0x7f010114
-			public const int switchTextAppearance = 2130772244;
-			
-			// aapt resource value: 0x7f010046
-			public const int tabBackground = 2130772038;
-			
-			// aapt resource value: 0x7f010045
-			public const int tabContentStart = 2130772037;
-			
-			// aapt resource value: 0x7f010048
-			public const int tabGravity = 2130772040;
-			
-			// aapt resource value: 0x7f010043
-			public const int tabIndicatorColor = 2130772035;
-			
-			// aapt resource value: 0x7f010044
-			public const int tabIndicatorHeight = 2130772036;
-			
-			// aapt resource value: 0x7f01004a
-			public const int tabMaxWidth = 2130772042;
-			
-			// aapt resource value: 0x7f010049
-			public const int tabMinWidth = 2130772041;
-			
-			// aapt resource value: 0x7f010047
-			public const int tabMode = 2130772039;
+			// aapt resource value: 0x7f010053
+			public const int actionBarTabBarStyle = 2130772051;
 			
 			// aapt resource value: 0x7f010052
-			public const int tabPadding = 2130772050;
+			public const int actionBarTabStyle = 2130772050;
 			
-			// aapt resource value: 0x7f010051
-			public const int tabPaddingBottom = 2130772049;
+			// aapt resource value: 0x7f010054
+			public const int actionBarTabTextStyle = 2130772052;
 			
-			// aapt resource value: 0x7f010050
-			public const int tabPaddingEnd = 2130772048;
+			// aapt resource value: 0x7f01005a
+			public const int actionBarTheme = 2130772058;
 			
-			// aapt resource value: 0x7f01004e
-			public const int tabPaddingStart = 2130772046;
+			// aapt resource value: 0x7f01005b
+			public const int actionBarWidgetTheme = 2130772059;
 			
-			// aapt resource value: 0x7f01004f
-			public const int tabPaddingTop = 2130772047;
+			// aapt resource value: 0x7f010078
+			public const int actionButtonStyle = 2130772088;
 			
-			// aapt resource value: 0x7f01004d
-			public const int tabSelectedTextColor = 2130772045;
+			// aapt resource value: 0x7f010074
+			public const int actionDropDownStyle = 2130772084;
 			
-			// aapt resource value: 0x7f01004b
-			public const int tabTextAppearance = 2130772043;
-			
-			// aapt resource value: 0x7f01004c
-			public const int tabTextColor = 2130772044;
-			
-			// aapt resource value: 0x7f010081
-			public const int textAllCaps = 2130772097;
-			
-			// aapt resource value: 0x7f0100a8
-			public const int textAppearanceLargePopupMenu = 2130772136;
-			
-			// aapt resource value: 0x7f0100cc
-			public const int textAppearanceListItem = 2130772172;
-			
-			// aapt resource value: 0x7f0100cd
-			public const int textAppearanceListItemSmall = 2130772173;
-			
-			// aapt resource value: 0x7f0100c2
-			public const int textAppearanceSearchResultSubtitle = 2130772162;
-			
-			// aapt resource value: 0x7f0100c1
-			public const int textAppearanceSearchResultTitle = 2130772161;
-			
-			// aapt resource value: 0x7f0100a9
-			public const int textAppearanceSmallPopupMenu = 2130772137;
-			
-			// aapt resource value: 0x7f0100df
-			public const int textColorAlertDialogListItem = 2130772191;
-			
-			// aapt resource value: 0x7f010033
-			public const int textColorError = 2130772019;
-			
-			// aapt resource value: 0x7f0100c3
-			public const int textColorSearchUrl = 2130772163;
-			
-			// aapt resource value: 0x7f01012a
-			public const int theme = 2130772266;
-			
-			// aapt resource value: 0x7f0100fa
-			public const int thickness = 2130772218;
-			
-			// aapt resource value: 0x7f010113
-			public const int thumbTextPadding = 2130772243;
+			// aapt resource value: 0x7f0100c9
+			public const int actionLayout = 2130772169;
 			
 			// aapt resource value: 0x7f01005f
-			public const int title = 2130772063;
+			public const int actionMenuTextAppearance = 2130772063;
 			
-			// aapt resource value: 0x7f01002a
-			public const int titleEnabled = 2130772010;
-			
-			// aapt resource value: 0x7f01011f
-			public const int titleMarginBottom = 2130772255;
-			
-			// aapt resource value: 0x7f01011d
-			public const int titleMarginEnd = 2130772253;
-			
-			// aapt resource value: 0x7f01011c
-			public const int titleMarginStart = 2130772252;
-			
-			// aapt resource value: 0x7f01011e
-			public const int titleMarginTop = 2130772254;
-			
-			// aapt resource value: 0x7f01011b
-			public const int titleMargins = 2130772251;
-			
-			// aapt resource value: 0x7f010119
-			public const int titleTextAppearance = 2130772249;
-			
-			// aapt resource value: 0x7f010126
-			public const int titleTextColor = 2130772262;
+			// aapt resource value: 0x7f010060
+			public const int actionMenuTextColor = 2130772064;
 			
 			// aapt resource value: 0x7f010063
-			public const int titleTextStyle = 2130772067;
+			public const int actionModeBackground = 2130772067;
 			
-			// aapt resource value: 0x7f010027
-			public const int toolbarId = 2130772007;
+			// aapt resource value: 0x7f010062
+			public const int actionModeCloseButtonStyle = 2130772066;
 			
-			// aapt resource value: 0x7f0100bb
-			public const int toolbarNavigationButtonStyle = 2130772155;
+			// aapt resource value: 0x7f010065
+			public const int actionModeCloseDrawable = 2130772069;
+			
+			// aapt resource value: 0x7f010067
+			public const int actionModeCopyDrawable = 2130772071;
+			
+			// aapt resource value: 0x7f010066
+			public const int actionModeCutDrawable = 2130772070;
+			
+			// aapt resource value: 0x7f01006b
+			public const int actionModeFindDrawable = 2130772075;
+			
+			// aapt resource value: 0x7f010068
+			public const int actionModePasteDrawable = 2130772072;
+			
+			// aapt resource value: 0x7f01006d
+			public const int actionModePopupWindowStyle = 2130772077;
+			
+			// aapt resource value: 0x7f010069
+			public const int actionModeSelectAllDrawable = 2130772073;
+			
+			// aapt resource value: 0x7f01006a
+			public const int actionModeShareDrawable = 2130772074;
+			
+			// aapt resource value: 0x7f010064
+			public const int actionModeSplitBackground = 2130772068;
+			
+			// aapt resource value: 0x7f010061
+			public const int actionModeStyle = 2130772065;
+			
+			// aapt resource value: 0x7f01006c
+			public const int actionModeWebSearchDrawable = 2130772076;
+			
+			// aapt resource value: 0x7f010055
+			public const int actionOverflowButtonStyle = 2130772053;
+			
+			// aapt resource value: 0x7f010056
+			public const int actionOverflowMenuStyle = 2130772054;
+			
+			// aapt resource value: 0x7f0100cb
+			public const int actionProviderClass = 2130772171;
+			
+			// aapt resource value: 0x7f0100ca
+			public const int actionViewClass = 2130772170;
+			
+			// aapt resource value: 0x7f010080
+			public const int activityChooserViewStyle = 2130772096;
+			
+			// aapt resource value: 0x7f0100a4
+			public const int alertDialogButtonGroupStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a5
+			public const int alertDialogCenterButtons = 2130772133;
+			
+			// aapt resource value: 0x7f0100a3
+			public const int alertDialogStyle = 2130772131;
+			
+			// aapt resource value: 0x7f0100a6
+			public const int alertDialogTheme = 2130772134;
+			
+			// aapt resource value: 0x7f0100b9
+			public const int allowStacking = 2130772153;
 			
 			// aapt resource value: 0x7f0100ba
-			public const int toolbarStyle = 2130772154;
+			public const int alpha = 2130772154;
 			
-			// aapt resource value: 0x7f010112
-			public const int track = 2130772242;
+			// aapt resource value: 0x7f0100c1
+			public const int arrowHeadLength = 2130772161;
 			
-			// aapt resource value: 0x7f010038
-			public const int useCompatPadding = 2130772024;
+			// aapt resource value: 0x7f0100c2
+			public const int arrowShaftLength = 2130772162;
 			
-			// aapt resource value: 0x7f01010d
-			public const int voiceIcon = 2130772237;
+			// aapt resource value: 0x7f0100ab
+			public const int autoCompleteTextViewStyle = 2130772139;
 			
-			// aapt resource value: 0x7f010082
-			public const int windowActionBar = 2130772098;
+			// aapt resource value: 0x7f010028
+			public const int background = 2130772008;
 			
-			// aapt resource value: 0x7f010084
-			public const int windowActionBarOverlay = 2130772100;
+			// aapt resource value: 0x7f01002a
+			public const int backgroundSplit = 2130772010;
 			
-			// aapt resource value: 0x7f010085
-			public const int windowActionModeOverlay = 2130772101;
+			// aapt resource value: 0x7f010029
+			public const int backgroundStacked = 2130772009;
 			
-			// aapt resource value: 0x7f010089
-			public const int windowFixedHeightMajor = 2130772105;
+			// aapt resource value: 0x7f0100fe
+			public const int backgroundTint = 2130772222;
 			
-			// aapt resource value: 0x7f010087
-			public const int windowFixedHeightMinor = 2130772103;
+			// aapt resource value: 0x7f0100ff
+			public const int backgroundTintMode = 2130772223;
+			
+			// aapt resource value: 0x7f0100c3
+			public const int barLength = 2130772163;
+			
+			// aapt resource value: 0x7f010129
+			public const int behavior_autoHide = 2130772265;
+			
+			// aapt resource value: 0x7f010106
+			public const int behavior_hideable = 2130772230;
+			
+			// aapt resource value: 0x7f010132
+			public const int behavior_overlapTop = 2130772274;
+			
+			// aapt resource value: 0x7f010105
+			public const int behavior_peekHeight = 2130772229;
+			
+			// aapt resource value: 0x7f010107
+			public const int behavior_skipCollapsed = 2130772231;
+			
+			// aapt resource value: 0x7f010127
+			public const int borderWidth = 2130772263;
+			
+			// aapt resource value: 0x7f01007d
+			public const int borderlessButtonStyle = 2130772093;
+			
+			// aapt resource value: 0x7f010121
+			public const int bottomSheetDialogTheme = 2130772257;
+			
+			// aapt resource value: 0x7f010122
+			public const int bottomSheetStyle = 2130772258;
+			
+			// aapt resource value: 0x7f01007a
+			public const int buttonBarButtonStyle = 2130772090;
+			
+			// aapt resource value: 0x7f0100a9
+			public const int buttonBarNegativeButtonStyle = 2130772137;
+			
+			// aapt resource value: 0x7f0100aa
+			public const int buttonBarNeutralButtonStyle = 2130772138;
+			
+			// aapt resource value: 0x7f0100a8
+			public const int buttonBarPositiveButtonStyle = 2130772136;
+			
+			// aapt resource value: 0x7f010079
+			public const int buttonBarStyle = 2130772089;
+			
+			// aapt resource value: 0x7f0100f3
+			public const int buttonGravity = 2130772211;
+			
+			// aapt resource value: 0x7f01003d
+			public const int buttonPanelSideLayout = 2130772029;
+			
+			// aapt resource value: 0x7f0100ac
+			public const int buttonStyle = 2130772140;
+			
+			// aapt resource value: 0x7f0100ad
+			public const int buttonStyleSmall = 2130772141;
+			
+			// aapt resource value: 0x7f0100bb
+			public const int buttonTint = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public const int buttonTintMode = 2130772156;
+			
+			// aapt resource value: 0x7f010011
+			public const int cardBackgroundColor = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public const int cardCornerRadius = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public const int cardElevation = 2130771987;
+			
+			// aapt resource value: 0x7f010014
+			public const int cardMaxElevation = 2130771988;
+			
+			// aapt resource value: 0x7f010016
+			public const int cardPreventCornerOverlap = 2130771990;
+			
+			// aapt resource value: 0x7f010015
+			public const int cardUseCompatPadding = 2130771989;
+			
+			// aapt resource value: 0x7f0100ae
+			public const int checkboxStyle = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public const int checkedTextViewStyle = 2130772143;
+			
+			// aapt resource value: 0x7f0100d6
+			public const int closeIcon = 2130772182;
+			
+			// aapt resource value: 0x7f01003a
+			public const int closeItemLayout = 2130772026;
+			
+			// aapt resource value: 0x7f0100f5
+			public const int collapseContentDescription = 2130772213;
+			
+			// aapt resource value: 0x7f0100f4
+			public const int collapseIcon = 2130772212;
+			
+			// aapt resource value: 0x7f010114
+			public const int collapsedTitleGravity = 2130772244;
+			
+			// aapt resource value: 0x7f01010e
+			public const int collapsedTitleTextAppearance = 2130772238;
+			
+			// aapt resource value: 0x7f0100bd
+			public const int color = 2130772157;
+			
+			// aapt resource value: 0x7f01009b
+			public const int colorAccent = 2130772123;
+			
+			// aapt resource value: 0x7f0100a2
+			public const int colorBackgroundFloating = 2130772130;
+			
+			// aapt resource value: 0x7f01009f
+			public const int colorButtonNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009d
+			public const int colorControlActivated = 2130772125;
+			
+			// aapt resource value: 0x7f01009e
+			public const int colorControlHighlight = 2130772126;
+			
+			// aapt resource value: 0x7f01009c
+			public const int colorControlNormal = 2130772124;
+			
+			// aapt resource value: 0x7f010099
+			public const int colorPrimary = 2130772121;
+			
+			// aapt resource value: 0x7f01009a
+			public const int colorPrimaryDark = 2130772122;
+			
+			// aapt resource value: 0x7f0100a0
+			public const int colorSwitchThumbNormal = 2130772128;
+			
+			// aapt resource value: 0x7f0100db
+			public const int commitIcon = 2130772187;
+			
+			// aapt resource value: 0x7f010033
+			public const int contentInsetEnd = 2130772019;
+			
+			// aapt resource value: 0x7f010037
+			public const int contentInsetEndWithActions = 2130772023;
+			
+			// aapt resource value: 0x7f010034
+			public const int contentInsetLeft = 2130772020;
+			
+			// aapt resource value: 0x7f010035
+			public const int contentInsetRight = 2130772021;
+			
+			// aapt resource value: 0x7f010032
+			public const int contentInsetStart = 2130772018;
+			
+			// aapt resource value: 0x7f010036
+			public const int contentInsetStartWithNavigation = 2130772022;
+			
+			// aapt resource value: 0x7f010017
+			public const int contentPadding = 2130771991;
+			
+			// aapt resource value: 0x7f01001b
+			public const int contentPaddingBottom = 2130771995;
+			
+			// aapt resource value: 0x7f010018
+			public const int contentPaddingLeft = 2130771992;
+			
+			// aapt resource value: 0x7f010019
+			public const int contentPaddingRight = 2130771993;
+			
+			// aapt resource value: 0x7f01001a
+			public const int contentPaddingTop = 2130771994;
+			
+			// aapt resource value: 0x7f01010f
+			public const int contentScrim = 2130772239;
+			
+			// aapt resource value: 0x7f0100a1
+			public const int controlBackground = 2130772129;
+			
+			// aapt resource value: 0x7f010148
+			public const int counterEnabled = 2130772296;
+			
+			// aapt resource value: 0x7f010149
+			public const int counterMaxLength = 2130772297;
+			
+			// aapt resource value: 0x7f01014b
+			public const int counterOverflowTextAppearance = 2130772299;
+			
+			// aapt resource value: 0x7f01014a
+			public const int counterTextAppearance = 2130772298;
+			
+			// aapt resource value: 0x7f01002b
+			public const int customNavigationLayout = 2130772011;
+			
+			// aapt resource value: 0x7f0100d5
+			public const int defaultQueryHint = 2130772181;
+			
+			// aapt resource value: 0x7f010072
+			public const int dialogPreferredPadding = 2130772082;
+			
+			// aapt resource value: 0x7f010071
+			public const int dialogTheme = 2130772081;
+			
+			// aapt resource value: 0x7f010021
+			public const int displayOptions = 2130772001;
+			
+			// aapt resource value: 0x7f010027
+			public const int divider = 2130772007;
+			
+			// aapt resource value: 0x7f01007f
+			public const int dividerHorizontal = 2130772095;
+			
+			// aapt resource value: 0x7f0100c7
+			public const int dividerPadding = 2130772167;
+			
+			// aapt resource value: 0x7f01007e
+			public const int dividerVertical = 2130772094;
+			
+			// aapt resource value: 0x7f0100bf
+			public const int drawableSize = 2130772159;
+			
+			// aapt resource value: 0x7f01001c
+			public const int drawerArrowStyle = 2130771996;
+			
+			// aapt resource value: 0x7f010091
+			public const int dropDownListViewStyle = 2130772113;
+			
+			// aapt resource value: 0x7f010075
+			public const int dropdownListPreferredItemHeight = 2130772085;
 			
 			// aapt resource value: 0x7f010086
-			public const int windowFixedWidthMajor = 2130772102;
+			public const int editTextBackground = 2130772102;
 			
-			// aapt resource value: 0x7f010088
-			public const int windowFixedWidthMinor = 2130772104;
+			// aapt resource value: 0x7f010085
+			public const int editTextColor = 2130772101;
 			
-			// aapt resource value: 0x7f01008a
-			public const int windowMinWidthMajor = 2130772106;
+			// aapt resource value: 0x7f0100b0
+			public const int editTextStyle = 2130772144;
 			
-			// aapt resource value: 0x7f01008b
-			public const int windowMinWidthMinor = 2130772107;
+			// aapt resource value: 0x7f010038
+			public const int elevation = 2130772024;
+			
+			// aapt resource value: 0x7f010146
+			public const int errorEnabled = 2130772294;
+			
+			// aapt resource value: 0x7f010147
+			public const int errorTextAppearance = 2130772295;
+			
+			// aapt resource value: 0x7f01003c
+			public const int expandActivityOverflowButtonDrawable = 2130772028;
+			
+			// aapt resource value: 0x7f010100
+			public const int expanded = 2130772224;
+			
+			// aapt resource value: 0x7f010115
+			public const int expandedTitleGravity = 2130772245;
+			
+			// aapt resource value: 0x7f010108
+			public const int expandedTitleMargin = 2130772232;
+			
+			// aapt resource value: 0x7f01010c
+			public const int expandedTitleMarginBottom = 2130772236;
+			
+			// aapt resource value: 0x7f01010b
+			public const int expandedTitleMarginEnd = 2130772235;
+			
+			// aapt resource value: 0x7f010109
+			public const int expandedTitleMarginStart = 2130772233;
+			
+			// aapt resource value: 0x7f01010a
+			public const int expandedTitleMarginTop = 2130772234;
+			
+			// aapt resource value: 0x7f01010d
+			public const int expandedTitleTextAppearance = 2130772237;
+			
+			// aapt resource value: 0x7f010010
+			public const int externalRouteEnabledDrawable = 2130771984;
+			
+			// aapt resource value: 0x7f010125
+			public const int fabSize = 2130772261;
+			
+			// aapt resource value: 0x7f010154
+			public const int fab_colorDisabled = 2130772308;
+			
+			// aapt resource value: 0x7f010153
+			public const int fab_colorNormal = 2130772307;
+			
+			// aapt resource value: 0x7f010152
+			public const int fab_colorPressed = 2130772306;
+			
+			// aapt resource value: 0x7f010155
+			public const int fab_colorRipple = 2130772309;
+			
+			// aapt resource value: 0x7f010156
+			public const int fab_shadow = 2130772310;
+			
+			// aapt resource value: 0x7f010157
+			public const int fab_size = 2130772311;
+			
+			// aapt resource value: 0x7f01012a
+			public const int foregroundInsidePadding = 2130772266;
+			
+			// aapt resource value: 0x7f0100c0
+			public const int gapBetweenBars = 2130772160;
+			
+			// aapt resource value: 0x7f0100d7
+			public const int goIcon = 2130772183;
+			
+			// aapt resource value: 0x7f010130
+			public const int headerLayout = 2130772272;
+			
+			// aapt resource value: 0x7f01001d
+			public const int height = 2130771997;
+			
+			// aapt resource value: 0x7f010031
+			public const int hideOnContentScroll = 2130772017;
+			
+			// aapt resource value: 0x7f01014c
+			public const int hintAnimationEnabled = 2130772300;
+			
+			// aapt resource value: 0x7f010145
+			public const int hintEnabled = 2130772293;
+			
+			// aapt resource value: 0x7f010144
+			public const int hintTextAppearance = 2130772292;
+			
+			// aapt resource value: 0x7f010077
+			public const int homeAsUpIndicator = 2130772087;
+			
+			// aapt resource value: 0x7f01002c
+			public const int homeLayout = 2130772012;
+			
+			// aapt resource value: 0x7f010025
+			public const int icon = 2130772005;
+			
+			// aapt resource value: 0x7f0100d3
+			public const int iconifiedByDefault = 2130772179;
+			
+			// aapt resource value: 0x7f010087
+			public const int imageButtonStyle = 2130772103;
+			
+			// aapt resource value: 0x7f01002e
+			public const int indeterminateProgressStyle = 2130772014;
+			
+			// aapt resource value: 0x7f01003b
+			public const int initialActivityCount = 2130772027;
+			
+			// aapt resource value: 0x7f010131
+			public const int insetForeground = 2130772273;
+			
+			// aapt resource value: 0x7f01001e
+			public const int isLightTheme = 2130771998;
+			
+			// aapt resource value: 0x7f01012e
+			public const int itemBackground = 2130772270;
+			
+			// aapt resource value: 0x7f01012c
+			public const int itemIconTint = 2130772268;
+			
+			// aapt resource value: 0x7f010030
+			public const int itemPadding = 2130772016;
+			
+			// aapt resource value: 0x7f01012f
+			public const int itemTextAppearance = 2130772271;
+			
+			// aapt resource value: 0x7f01012d
+			public const int itemTextColor = 2130772269;
+			
+			// aapt resource value: 0x7f010119
+			public const int keylines = 2130772249;
+			
+			// aapt resource value: 0x7f0100d2
+			public const int layout = 2130772178;
+			
+			// aapt resource value: 0x7f010000
+			public const int layoutManager = 2130771968;
+			
+			// aapt resource value: 0x7f01011c
+			public const int layout_anchor = 2130772252;
+			
+			// aapt resource value: 0x7f01011e
+			public const int layout_anchorGravity = 2130772254;
+			
+			// aapt resource value: 0x7f01011b
+			public const int layout_behavior = 2130772251;
+			
+			// aapt resource value: 0x7f010117
+			public const int layout_collapseMode = 2130772247;
+			
+			// aapt resource value: 0x7f010118
+			public const int layout_collapseParallaxMultiplier = 2130772248;
+			
+			// aapt resource value: 0x7f010120
+			public const int layout_dodgeInsetEdges = 2130772256;
+			
+			// aapt resource value: 0x7f01011f
+			public const int layout_insetEdge = 2130772255;
+			
+			// aapt resource value: 0x7f01011d
+			public const int layout_keyline = 2130772253;
+			
+			// aapt resource value: 0x7f010103
+			public const int layout_scrollFlags = 2130772227;
+			
+			// aapt resource value: 0x7f010104
+			public const int layout_scrollInterpolator = 2130772228;
+			
+			// aapt resource value: 0x7f010098
+			public const int listChoiceBackgroundIndicator = 2130772120;
+			
+			// aapt resource value: 0x7f010073
+			public const int listDividerAlertDialog = 2130772083;
+			
+			// aapt resource value: 0x7f010041
+			public const int listItemLayout = 2130772033;
+			
+			// aapt resource value: 0x7f01003e
+			public const int listLayout = 2130772030;
+			
+			// aapt resource value: 0x7f0100b8
+			public const int listMenuViewStyle = 2130772152;
+			
+			// aapt resource value: 0x7f010092
+			public const int listPopupWindowStyle = 2130772114;
+			
+			// aapt resource value: 0x7f01008c
+			public const int listPreferredItemHeight = 2130772108;
+			
+			// aapt resource value: 0x7f01008e
+			public const int listPreferredItemHeightLarge = 2130772110;
+			
+			// aapt resource value: 0x7f01008d
+			public const int listPreferredItemHeightSmall = 2130772109;
+			
+			// aapt resource value: 0x7f01008f
+			public const int listPreferredItemPaddingLeft = 2130772111;
+			
+			// aapt resource value: 0x7f010090
+			public const int listPreferredItemPaddingRight = 2130772112;
+			
+			// aapt resource value: 0x7f010026
+			public const int logo = 2130772006;
+			
+			// aapt resource value: 0x7f0100f8
+			public const int logoDescription = 2130772216;
+			
+			// aapt resource value: 0x7f010133
+			public const int maxActionInlineWidth = 2130772275;
+			
+			// aapt resource value: 0x7f0100f2
+			public const int maxButtonHeight = 2130772210;
+			
+			// aapt resource value: 0x7f0100c5
+			public const int measureWithLargestChild = 2130772165;
+			
+			// aapt resource value: 0x7f010004
+			public const int mediaRouteAudioTrackDrawable = 2130771972;
+			
+			// aapt resource value: 0x7f010005
+			public const int mediaRouteButtonStyle = 2130771973;
+			
+			// aapt resource value: 0x7f010006
+			public const int mediaRouteCloseDrawable = 2130771974;
+			
+			// aapt resource value: 0x7f010007
+			public const int mediaRouteControlPanelThemeOverlay = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public const int mediaRouteDefaultIconDrawable = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public const int mediaRoutePauseDrawable = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public const int mediaRoutePlayDrawable = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130771979;
+			
+			// aapt resource value: 0x7f01000c
+			public const int mediaRouteSpeakerIconDrawable = 2130771980;
+			
+			// aapt resource value: 0x7f01000d
+			public const int mediaRouteStopDrawable = 2130771981;
+			
+			// aapt resource value: 0x7f01000e
+			public const int mediaRouteTheme = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public const int mediaRouteTvIconDrawable = 2130771983;
+			
+			// aapt resource value: 0x7f01012b
+			public const int menu = 2130772267;
+			
+			// aapt resource value: 0x7f01003f
+			public const int multiChoiceItemLayout = 2130772031;
+			
+			// aapt resource value: 0x7f0100f7
+			public const int navigationContentDescription = 2130772215;
+			
+			// aapt resource value: 0x7f0100f6
+			public const int navigationIcon = 2130772214;
+			
+			// aapt resource value: 0x7f010020
+			public const int navigationMode = 2130772000;
+			
+			// aapt resource value: 0x7f0100ce
+			public const int overlapAnchor = 2130772174;
+			
+			// aapt resource value: 0x7f0100d0
+			public const int paddingBottomNoButtons = 2130772176;
+			
+			// aapt resource value: 0x7f0100fc
+			public const int paddingEnd = 2130772220;
+			
+			// aapt resource value: 0x7f0100fb
+			public const int paddingStart = 2130772219;
+			
+			// aapt resource value: 0x7f0100d1
+			public const int paddingTopNoTitle = 2130772177;
+			
+			// aapt resource value: 0x7f010095
+			public const int panelBackground = 2130772117;
+			
+			// aapt resource value: 0x7f010097
+			public const int panelMenuListTheme = 2130772119;
+			
+			// aapt resource value: 0x7f010096
+			public const int panelMenuListWidth = 2130772118;
+			
+			// aapt resource value: 0x7f01014f
+			public const int passwordToggleContentDescription = 2130772303;
+			
+			// aapt resource value: 0x7f01014e
+			public const int passwordToggleDrawable = 2130772302;
+			
+			// aapt resource value: 0x7f01014d
+			public const int passwordToggleEnabled = 2130772301;
+			
+			// aapt resource value: 0x7f010150
+			public const int passwordToggleTint = 2130772304;
+			
+			// aapt resource value: 0x7f010151
+			public const int passwordToggleTintMode = 2130772305;
 			
 			// aapt resource value: 0x7f010083
-			public const int windowNoTitle = 2130772099;
+			public const int popupMenuStyle = 2130772099;
+			
+			// aapt resource value: 0x7f010039
+			public const int popupTheme = 2130772025;
+			
+			// aapt resource value: 0x7f010084
+			public const int popupWindowStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100cc
+			public const int preserveIconSpacing = 2130772172;
+			
+			// aapt resource value: 0x7f010126
+			public const int pressedTranslationZ = 2130772262;
+			
+			// aapt resource value: 0x7f01002f
+			public const int progressBarPadding = 2130772015;
+			
+			// aapt resource value: 0x7f01002d
+			public const int progressBarStyle = 2130772013;
+			
+			// aapt resource value: 0x7f0100dd
+			public const int queryBackground = 2130772189;
+			
+			// aapt resource value: 0x7f0100d4
+			public const int queryHint = 2130772180;
+			
+			// aapt resource value: 0x7f0100b1
+			public const int radioButtonStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100b2
+			public const int ratingBarStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b3
+			public const int ratingBarStyleIndicator = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public const int ratingBarStyleSmall = 2130772148;
+			
+			// aapt resource value: 0x7f010002
+			public const int reverseLayout = 2130771970;
+			
+			// aapt resource value: 0x7f010124
+			public const int rippleColor = 2130772260;
+			
+			// aapt resource value: 0x7f010113
+			public const int scrimAnimationDuration = 2130772243;
+			
+			// aapt resource value: 0x7f010112
+			public const int scrimVisibleHeightTrigger = 2130772242;
+			
+			// aapt resource value: 0x7f0100d9
+			public const int searchHintIcon = 2130772185;
+			
+			// aapt resource value: 0x7f0100d8
+			public const int searchIcon = 2130772184;
+			
+			// aapt resource value: 0x7f01008b
+			public const int searchViewStyle = 2130772107;
+			
+			// aapt resource value: 0x7f0100b5
+			public const int seekBarStyle = 2130772149;
+			
+			// aapt resource value: 0x7f01007b
+			public const int selectableItemBackground = 2130772091;
+			
+			// aapt resource value: 0x7f01007c
+			public const int selectableItemBackgroundBorderless = 2130772092;
+			
+			// aapt resource value: 0x7f0100c8
+			public const int showAsAction = 2130772168;
+			
+			// aapt resource value: 0x7f0100c6
+			public const int showDividers = 2130772166;
+			
+			// aapt resource value: 0x7f0100e9
+			public const int showText = 2130772201;
+			
+			// aapt resource value: 0x7f010042
+			public const int showTitle = 2130772034;
+			
+			// aapt resource value: 0x7f010040
+			public const int singleChoiceItemLayout = 2130772032;
+			
+			// aapt resource value: 0x7f010001
+			public const int spanCount = 2130771969;
+			
+			// aapt resource value: 0x7f0100be
+			public const int spinBars = 2130772158;
+			
+			// aapt resource value: 0x7f010076
+			public const int spinnerDropDownItemStyle = 2130772086;
+			
+			// aapt resource value: 0x7f0100b6
+			public const int spinnerStyle = 2130772150;
+			
+			// aapt resource value: 0x7f0100e8
+			public const int splitTrack = 2130772200;
+			
+			// aapt resource value: 0x7f010043
+			public const int srcCompat = 2130772035;
+			
+			// aapt resource value: 0x7f010003
+			public const int stackFromEnd = 2130771971;
+			
+			// aapt resource value: 0x7f0100cf
+			public const int state_above_anchor = 2130772175;
+			
+			// aapt resource value: 0x7f010101
+			public const int state_collapsed = 2130772225;
+			
+			// aapt resource value: 0x7f010102
+			public const int state_collapsible = 2130772226;
+			
+			// aapt resource value: 0x7f01011a
+			public const int statusBarBackground = 2130772250;
+			
+			// aapt resource value: 0x7f010110
+			public const int statusBarScrim = 2130772240;
+			
+			// aapt resource value: 0x7f0100cd
+			public const int subMenuArrow = 2130772173;
+			
+			// aapt resource value: 0x7f0100de
+			public const int submitBackground = 2130772190;
+			
+			// aapt resource value: 0x7f010022
+			public const int subtitle = 2130772002;
+			
+			// aapt resource value: 0x7f0100eb
+			public const int subtitleTextAppearance = 2130772203;
+			
+			// aapt resource value: 0x7f0100fa
+			public const int subtitleTextColor = 2130772218;
+			
+			// aapt resource value: 0x7f010024
+			public const int subtitleTextStyle = 2130772004;
+			
+			// aapt resource value: 0x7f0100dc
+			public const int suggestionRowLayout = 2130772188;
+			
+			// aapt resource value: 0x7f0100e6
+			public const int switchMinWidth = 2130772198;
+			
+			// aapt resource value: 0x7f0100e7
+			public const int switchPadding = 2130772199;
+			
+			// aapt resource value: 0x7f0100b7
+			public const int switchStyle = 2130772151;
+			
+			// aapt resource value: 0x7f0100e5
+			public const int switchTextAppearance = 2130772197;
+			
+			// aapt resource value: 0x7f010137
+			public const int tabBackground = 2130772279;
+			
+			// aapt resource value: 0x7f010136
+			public const int tabContentStart = 2130772278;
+			
+			// aapt resource value: 0x7f010139
+			public const int tabGravity = 2130772281;
+			
+			// aapt resource value: 0x7f010134
+			public const int tabIndicatorColor = 2130772276;
+			
+			// aapt resource value: 0x7f010135
+			public const int tabIndicatorHeight = 2130772277;
+			
+			// aapt resource value: 0x7f01013b
+			public const int tabMaxWidth = 2130772283;
+			
+			// aapt resource value: 0x7f01013a
+			public const int tabMinWidth = 2130772282;
+			
+			// aapt resource value: 0x7f010138
+			public const int tabMode = 2130772280;
+			
+			// aapt resource value: 0x7f010143
+			public const int tabPadding = 2130772291;
+			
+			// aapt resource value: 0x7f010142
+			public const int tabPaddingBottom = 2130772290;
+			
+			// aapt resource value: 0x7f010141
+			public const int tabPaddingEnd = 2130772289;
+			
+			// aapt resource value: 0x7f01013f
+			public const int tabPaddingStart = 2130772287;
+			
+			// aapt resource value: 0x7f010140
+			public const int tabPaddingTop = 2130772288;
+			
+			// aapt resource value: 0x7f01013e
+			public const int tabSelectedTextColor = 2130772286;
+			
+			// aapt resource value: 0x7f01013c
+			public const int tabTextAppearance = 2130772284;
+			
+			// aapt resource value: 0x7f01013d
+			public const int tabTextColor = 2130772285;
+			
+			// aapt resource value: 0x7f010047
+			public const int textAllCaps = 2130772039;
+			
+			// aapt resource value: 0x7f01006e
+			public const int textAppearanceLargePopupMenu = 2130772078;
+			
+			// aapt resource value: 0x7f010093
+			public const int textAppearanceListItem = 2130772115;
+			
+			// aapt resource value: 0x7f010094
+			public const int textAppearanceListItemSmall = 2130772116;
+			
+			// aapt resource value: 0x7f010070
+			public const int textAppearancePopupMenuHeader = 2130772080;
+			
+			// aapt resource value: 0x7f010089
+			public const int textAppearanceSearchResultSubtitle = 2130772105;
+			
+			// aapt resource value: 0x7f010088
+			public const int textAppearanceSearchResultTitle = 2130772104;
+			
+			// aapt resource value: 0x7f01006f
+			public const int textAppearanceSmallPopupMenu = 2130772079;
+			
+			// aapt resource value: 0x7f0100a7
+			public const int textColorAlertDialogListItem = 2130772135;
+			
+			// aapt resource value: 0x7f010123
+			public const int textColorError = 2130772259;
+			
+			// aapt resource value: 0x7f01008a
+			public const int textColorSearchUrl = 2130772106;
+			
+			// aapt resource value: 0x7f0100fd
+			public const int theme = 2130772221;
+			
+			// aapt resource value: 0x7f0100c4
+			public const int thickness = 2130772164;
+			
+			// aapt resource value: 0x7f0100e4
+			public const int thumbTextPadding = 2130772196;
+			
+			// aapt resource value: 0x7f0100df
+			public const int thumbTint = 2130772191;
+			
+			// aapt resource value: 0x7f0100e0
+			public const int thumbTintMode = 2130772192;
+			
+			// aapt resource value: 0x7f010044
+			public const int tickMark = 2130772036;
+			
+			// aapt resource value: 0x7f010045
+			public const int tickMarkTint = 2130772037;
+			
+			// aapt resource value: 0x7f010046
+			public const int tickMarkTintMode = 2130772038;
+			
+			// aapt resource value: 0x7f01001f
+			public const int title = 2130771999;
+			
+			// aapt resource value: 0x7f010116
+			public const int titleEnabled = 2130772246;
+			
+			// aapt resource value: 0x7f0100ec
+			public const int titleMargin = 2130772204;
+			
+			// aapt resource value: 0x7f0100f0
+			public const int titleMarginBottom = 2130772208;
+			
+			// aapt resource value: 0x7f0100ee
+			public const int titleMarginEnd = 2130772206;
+			
+			// aapt resource value: 0x7f0100ed
+			public const int titleMarginStart = 2130772205;
+			
+			// aapt resource value: 0x7f0100ef
+			public const int titleMarginTop = 2130772207;
+			
+			// aapt resource value: 0x7f0100f1
+			public const int titleMargins = 2130772209;
+			
+			// aapt resource value: 0x7f0100ea
+			public const int titleTextAppearance = 2130772202;
+			
+			// aapt resource value: 0x7f0100f9
+			public const int titleTextColor = 2130772217;
+			
+			// aapt resource value: 0x7f010023
+			public const int titleTextStyle = 2130772003;
+			
+			// aapt resource value: 0x7f010111
+			public const int toolbarId = 2130772241;
+			
+			// aapt resource value: 0x7f010082
+			public const int toolbarNavigationButtonStyle = 2130772098;
+			
+			// aapt resource value: 0x7f010081
+			public const int toolbarStyle = 2130772097;
+			
+			// aapt resource value: 0x7f0100e1
+			public const int track = 2130772193;
+			
+			// aapt resource value: 0x7f0100e2
+			public const int trackTint = 2130772194;
+			
+			// aapt resource value: 0x7f0100e3
+			public const int trackTintMode = 2130772195;
+			
+			// aapt resource value: 0x7f010128
+			public const int useCompatPadding = 2130772264;
+			
+			// aapt resource value: 0x7f0100da
+			public const int voiceIcon = 2130772186;
+			
+			// aapt resource value: 0x7f010048
+			public const int windowActionBar = 2130772040;
+			
+			// aapt resource value: 0x7f01004a
+			public const int windowActionBarOverlay = 2130772042;
+			
+			// aapt resource value: 0x7f01004b
+			public const int windowActionModeOverlay = 2130772043;
+			
+			// aapt resource value: 0x7f01004f
+			public const int windowFixedHeightMajor = 2130772047;
+			
+			// aapt resource value: 0x7f01004d
+			public const int windowFixedHeightMinor = 2130772045;
+			
+			// aapt resource value: 0x7f01004c
+			public const int windowFixedWidthMajor = 2130772044;
+			
+			// aapt resource value: 0x7f01004e
+			public const int windowFixedWidthMinor = 2130772046;
+			
+			// aapt resource value: 0x7f010050
+			public const int windowMinWidthMajor = 2130772048;
+			
+			// aapt resource value: 0x7f010051
+			public const int windowMinWidthMinor = 2130772049;
+			
+			// aapt resource value: 0x7f010049
+			public const int windowNoTitle = 2130772041;
 			
 			static Attribute()
 			{
@@ -2889,29 +3298,20 @@ namespace FABSample.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0c0003
-			public const int abc_action_bar_embed_tabs = 2131492867;
+			// aapt resource value: 0x7f0d0000
+			public const int abc_action_bar_embed_tabs = 2131558400;
 			
-			// aapt resource value: 0x7f0c0001
-			public const int abc_action_bar_embed_tabs_pre_jb = 2131492865;
+			// aapt resource value: 0x7f0d0001
+			public const int abc_allow_stacked_button_bar = 2131558401;
 			
-			// aapt resource value: 0x7f0c0004
-			public const int abc_action_bar_expanded_action_views_exclusive = 2131492868;
+			// aapt resource value: 0x7f0d0002
+			public const int abc_config_actionMenuItemAllCaps = 2131558402;
 			
-			// aapt resource value: 0x7f0c0000
-			public const int abc_allow_stacked_button_bar = 2131492864;
+			// aapt resource value: 0x7f0d0003
+			public const int abc_config_closeDialogWhenTouchOutside = 2131558403;
 			
-			// aapt resource value: 0x7f0c0005
-			public const int abc_config_actionMenuItemAllCaps = 2131492869;
-			
-			// aapt resource value: 0x7f0c0002
-			public const int abc_config_allowActionMenuItemTextWithIcon = 2131492866;
-			
-			// aapt resource value: 0x7f0c0006
-			public const int abc_config_closeDialogWhenTouchOutside = 2131492870;
-			
-			// aapt resource value: 0x7f0c0007
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492871;
+			// aapt resource value: 0x7f0d0004
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131558404;
 			
 			static Boolean()
 			{
@@ -2926,260 +3326,305 @@ namespace FABSample.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0a0049
-			public const int abc_background_cache_hint_selector_material_dark = 2131361865;
+			// aapt resource value: 0x7f0c004b
+			public const int abc_background_cache_hint_selector_material_dark = 2131492939;
 			
-			// aapt resource value: 0x7f0a004a
-			public const int abc_background_cache_hint_selector_material_light = 2131361866;
+			// aapt resource value: 0x7f0c004c
+			public const int abc_background_cache_hint_selector_material_light = 2131492940;
 			
-			// aapt resource value: 0x7f0a004b
-			public const int abc_color_highlight_material = 2131361867;
+			// aapt resource value: 0x7f0c004d
+			public const int abc_btn_colored_borderless_text_material = 2131492941;
 			
-			// aapt resource value: 0x7f0a000a
-			public const int abc_input_method_navigation_guard = 2131361802;
+			// aapt resource value: 0x7f0c004e
+			public const int abc_btn_colored_text_material = 2131492942;
 			
-			// aapt resource value: 0x7f0a004c
-			public const int abc_primary_text_disable_only_material_dark = 2131361868;
+			// aapt resource value: 0x7f0c004f
+			public const int abc_color_highlight_material = 2131492943;
 			
-			// aapt resource value: 0x7f0a004d
-			public const int abc_primary_text_disable_only_material_light = 2131361869;
+			// aapt resource value: 0x7f0c0050
+			public const int abc_hint_foreground_material_dark = 2131492944;
 			
-			// aapt resource value: 0x7f0a004e
-			public const int abc_primary_text_material_dark = 2131361870;
+			// aapt resource value: 0x7f0c0051
+			public const int abc_hint_foreground_material_light = 2131492945;
 			
-			// aapt resource value: 0x7f0a004f
-			public const int abc_primary_text_material_light = 2131361871;
+			// aapt resource value: 0x7f0c0005
+			public const int abc_input_method_navigation_guard = 2131492869;
 			
-			// aapt resource value: 0x7f0a0050
-			public const int abc_search_url_text = 2131361872;
+			// aapt resource value: 0x7f0c0052
+			public const int abc_primary_text_disable_only_material_dark = 2131492946;
 			
-			// aapt resource value: 0x7f0a000b
-			public const int abc_search_url_text_normal = 2131361803;
+			// aapt resource value: 0x7f0c0053
+			public const int abc_primary_text_disable_only_material_light = 2131492947;
 			
-			// aapt resource value: 0x7f0a000c
-			public const int abc_search_url_text_pressed = 2131361804;
+			// aapt resource value: 0x7f0c0054
+			public const int abc_primary_text_material_dark = 2131492948;
 			
-			// aapt resource value: 0x7f0a000d
-			public const int abc_search_url_text_selected = 2131361805;
+			// aapt resource value: 0x7f0c0055
+			public const int abc_primary_text_material_light = 2131492949;
 			
-			// aapt resource value: 0x7f0a0051
-			public const int abc_secondary_text_material_dark = 2131361873;
+			// aapt resource value: 0x7f0c0056
+			public const int abc_search_url_text = 2131492950;
 			
-			// aapt resource value: 0x7f0a0052
-			public const int abc_secondary_text_material_light = 2131361874;
+			// aapt resource value: 0x7f0c0006
+			public const int abc_search_url_text_normal = 2131492870;
 			
-			// aapt resource value: 0x7f0a000e
-			public const int accent_material_dark = 2131361806;
+			// aapt resource value: 0x7f0c0007
+			public const int abc_search_url_text_pressed = 2131492871;
 			
-			// aapt resource value: 0x7f0a000f
-			public const int accent_material_light = 2131361807;
+			// aapt resource value: 0x7f0c0008
+			public const int abc_search_url_text_selected = 2131492872;
 			
-			// aapt resource value: 0x7f0a0010
-			public const int background_floating_material_dark = 2131361808;
+			// aapt resource value: 0x7f0c0057
+			public const int abc_secondary_text_material_dark = 2131492951;
 			
-			// aapt resource value: 0x7f0a0011
-			public const int background_floating_material_light = 2131361809;
+			// aapt resource value: 0x7f0c0058
+			public const int abc_secondary_text_material_light = 2131492952;
 			
-			// aapt resource value: 0x7f0a0012
-			public const int background_material_dark = 2131361810;
+			// aapt resource value: 0x7f0c0059
+			public const int abc_tint_btn_checkable = 2131492953;
 			
-			// aapt resource value: 0x7f0a0013
-			public const int background_material_light = 2131361811;
+			// aapt resource value: 0x7f0c005a
+			public const int abc_tint_default = 2131492954;
 			
-			// aapt resource value: 0x7f0a0014
-			public const int bright_foreground_disabled_material_dark = 2131361812;
+			// aapt resource value: 0x7f0c005b
+			public const int abc_tint_edittext = 2131492955;
 			
-			// aapt resource value: 0x7f0a0015
-			public const int bright_foreground_disabled_material_light = 2131361813;
+			// aapt resource value: 0x7f0c005c
+			public const int abc_tint_seek_thumb = 2131492956;
 			
-			// aapt resource value: 0x7f0a0016
-			public const int bright_foreground_inverse_material_dark = 2131361814;
+			// aapt resource value: 0x7f0c005d
+			public const int abc_tint_spinner = 2131492957;
 			
-			// aapt resource value: 0x7f0a0017
-			public const int bright_foreground_inverse_material_light = 2131361815;
+			// aapt resource value: 0x7f0c005e
+			public const int abc_tint_switch_thumb = 2131492958;
 			
-			// aapt resource value: 0x7f0a0018
-			public const int bright_foreground_material_dark = 2131361816;
+			// aapt resource value: 0x7f0c005f
+			public const int abc_tint_switch_track = 2131492959;
 			
-			// aapt resource value: 0x7f0a0019
-			public const int bright_foreground_material_light = 2131361817;
+			// aapt resource value: 0x7f0c0009
+			public const int accent_material_dark = 2131492873;
 			
-			// aapt resource value: 0x7f0a001a
-			public const int button_material_dark = 2131361818;
+			// aapt resource value: 0x7f0c000a
+			public const int accent_material_light = 2131492874;
 			
-			// aapt resource value: 0x7f0a001b
-			public const int button_material_light = 2131361819;
+			// aapt resource value: 0x7f0c000b
+			public const int background_floating_material_dark = 2131492875;
 			
-			// aapt resource value: 0x7f0a0044
-			public const int cardview_dark_background = 2131361860;
+			// aapt resource value: 0x7f0c000c
+			public const int background_floating_material_light = 2131492876;
 			
-			// aapt resource value: 0x7f0a0045
-			public const int cardview_light_background = 2131361861;
+			// aapt resource value: 0x7f0c000d
+			public const int background_material_dark = 2131492877;
 			
-			// aapt resource value: 0x7f0a0046
-			public const int cardview_shadow_end_color = 2131361862;
+			// aapt resource value: 0x7f0c000e
+			public const int background_material_light = 2131492878;
 			
-			// aapt resource value: 0x7f0a0047
-			public const int cardview_shadow_start_color = 2131361863;
+			// aapt resource value: 0x7f0c000f
+			public const int bright_foreground_disabled_material_dark = 2131492879;
 			
-			// aapt resource value: 0x7f0a0000
-			public const int design_fab_shadow_end_color = 2131361792;
+			// aapt resource value: 0x7f0c0010
+			public const int bright_foreground_disabled_material_light = 2131492880;
 			
-			// aapt resource value: 0x7f0a0001
-			public const int design_fab_shadow_mid_color = 2131361793;
+			// aapt resource value: 0x7f0c0011
+			public const int bright_foreground_inverse_material_dark = 2131492881;
 			
-			// aapt resource value: 0x7f0a0002
-			public const int design_fab_shadow_start_color = 2131361794;
+			// aapt resource value: 0x7f0c0012
+			public const int bright_foreground_inverse_material_light = 2131492882;
 			
-			// aapt resource value: 0x7f0a0003
-			public const int design_fab_stroke_end_inner_color = 2131361795;
+			// aapt resource value: 0x7f0c0013
+			public const int bright_foreground_material_dark = 2131492883;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int design_fab_stroke_end_outer_color = 2131361796;
+			// aapt resource value: 0x7f0c0014
+			public const int bright_foreground_material_light = 2131492884;
 			
-			// aapt resource value: 0x7f0a0005
-			public const int design_fab_stroke_top_inner_color = 2131361797;
+			// aapt resource value: 0x7f0c0015
+			public const int button_material_dark = 2131492885;
 			
-			// aapt resource value: 0x7f0a0006
-			public const int design_fab_stroke_top_outer_color = 2131361798;
+			// aapt resource value: 0x7f0c0016
+			public const int button_material_light = 2131492886;
 			
-			// aapt resource value: 0x7f0a0007
-			public const int design_snackbar_background_color = 2131361799;
+			// aapt resource value: 0x7f0c0000
+			public const int cardview_dark_background = 2131492864;
 			
-			// aapt resource value: 0x7f0a0008
-			public const int design_textinput_error_color_dark = 2131361800;
+			// aapt resource value: 0x7f0c0001
+			public const int cardview_light_background = 2131492865;
 			
-			// aapt resource value: 0x7f0a0009
-			public const int design_textinput_error_color_light = 2131361801;
+			// aapt resource value: 0x7f0c0002
+			public const int cardview_shadow_end_color = 2131492866;
 			
-			// aapt resource value: 0x7f0a001c
-			public const int dim_foreground_disabled_material_dark = 2131361820;
+			// aapt resource value: 0x7f0c0003
+			public const int cardview_shadow_start_color = 2131492867;
 			
-			// aapt resource value: 0x7f0a001d
-			public const int dim_foreground_disabled_material_light = 2131361821;
+			// aapt resource value: 0x7f0c003f
+			public const int design_bottom_navigation_shadow_color = 2131492927;
 			
-			// aapt resource value: 0x7f0a001e
-			public const int dim_foreground_material_dark = 2131361822;
+			// aapt resource value: 0x7f0c0060
+			public const int design_error = 2131492960;
 			
-			// aapt resource value: 0x7f0a001f
-			public const int dim_foreground_material_light = 2131361823;
+			// aapt resource value: 0x7f0c0040
+			public const int design_fab_shadow_end_color = 2131492928;
 			
-			// aapt resource value: 0x7f0a0048
-			public const int fab_material_blue_500 = 2131361864;
+			// aapt resource value: 0x7f0c0041
+			public const int design_fab_shadow_mid_color = 2131492929;
 			
-			// aapt resource value: 0x7f0a0020
-			public const int foreground_material_dark = 2131361824;
+			// aapt resource value: 0x7f0c0042
+			public const int design_fab_shadow_start_color = 2131492930;
 			
-			// aapt resource value: 0x7f0a0021
-			public const int foreground_material_light = 2131361825;
+			// aapt resource value: 0x7f0c0043
+			public const int design_fab_stroke_end_inner_color = 2131492931;
 			
-			// aapt resource value: 0x7f0a0022
-			public const int highlighted_text_material_dark = 2131361826;
+			// aapt resource value: 0x7f0c0044
+			public const int design_fab_stroke_end_outer_color = 2131492932;
 			
-			// aapt resource value: 0x7f0a0023
-			public const int highlighted_text_material_light = 2131361827;
+			// aapt resource value: 0x7f0c0045
+			public const int design_fab_stroke_top_inner_color = 2131492933;
 			
-			// aapt resource value: 0x7f0a0024
-			public const int hint_foreground_material_dark = 2131361828;
+			// aapt resource value: 0x7f0c0046
+			public const int design_fab_stroke_top_outer_color = 2131492934;
 			
-			// aapt resource value: 0x7f0a0025
-			public const int hint_foreground_material_light = 2131361829;
+			// aapt resource value: 0x7f0c0047
+			public const int design_snackbar_background_color = 2131492935;
 			
-			// aapt resource value: 0x7f0a0026
-			public const int material_blue_grey_800 = 2131361830;
+			// aapt resource value: 0x7f0c0048
+			public const int design_textinput_error_color_dark = 2131492936;
 			
-			// aapt resource value: 0x7f0a0027
-			public const int material_blue_grey_900 = 2131361831;
+			// aapt resource value: 0x7f0c0049
+			public const int design_textinput_error_color_light = 2131492937;
 			
-			// aapt resource value: 0x7f0a0028
-			public const int material_blue_grey_950 = 2131361832;
+			// aapt resource value: 0x7f0c0061
+			public const int design_tint_password_toggle = 2131492961;
 			
-			// aapt resource value: 0x7f0a0029
-			public const int material_deep_teal_200 = 2131361833;
+			// aapt resource value: 0x7f0c0017
+			public const int dim_foreground_disabled_material_dark = 2131492887;
 			
-			// aapt resource value: 0x7f0a002a
-			public const int material_deep_teal_500 = 2131361834;
+			// aapt resource value: 0x7f0c0018
+			public const int dim_foreground_disabled_material_light = 2131492888;
 			
-			// aapt resource value: 0x7f0a002b
-			public const int material_grey_100 = 2131361835;
+			// aapt resource value: 0x7f0c0019
+			public const int dim_foreground_material_dark = 2131492889;
 			
-			// aapt resource value: 0x7f0a002c
-			public const int material_grey_300 = 2131361836;
+			// aapt resource value: 0x7f0c001a
+			public const int dim_foreground_material_light = 2131492890;
 			
-			// aapt resource value: 0x7f0a002d
-			public const int material_grey_50 = 2131361837;
+			// aapt resource value: 0x7f0c004a
+			public const int fab_material_blue_500 = 2131492938;
 			
-			// aapt resource value: 0x7f0a002e
-			public const int material_grey_600 = 2131361838;
+			// aapt resource value: 0x7f0c001b
+			public const int foreground_material_dark = 2131492891;
 			
-			// aapt resource value: 0x7f0a002f
-			public const int material_grey_800 = 2131361839;
+			// aapt resource value: 0x7f0c001c
+			public const int foreground_material_light = 2131492892;
 			
-			// aapt resource value: 0x7f0a0030
-			public const int material_grey_850 = 2131361840;
+			// aapt resource value: 0x7f0c001d
+			public const int highlighted_text_material_dark = 2131492893;
 			
-			// aapt resource value: 0x7f0a0031
-			public const int material_grey_900 = 2131361841;
+			// aapt resource value: 0x7f0c001e
+			public const int highlighted_text_material_light = 2131492894;
 			
-			// aapt resource value: 0x7f0a0032
-			public const int primary_dark_material_dark = 2131361842;
+			// aapt resource value: 0x7f0c001f
+			public const int material_blue_grey_800 = 2131492895;
 			
-			// aapt resource value: 0x7f0a0033
-			public const int primary_dark_material_light = 2131361843;
+			// aapt resource value: 0x7f0c0020
+			public const int material_blue_grey_900 = 2131492896;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int primary_material_dark = 2131361844;
+			// aapt resource value: 0x7f0c0021
+			public const int material_blue_grey_950 = 2131492897;
 			
-			// aapt resource value: 0x7f0a0035
-			public const int primary_material_light = 2131361845;
+			// aapt resource value: 0x7f0c0022
+			public const int material_deep_teal_200 = 2131492898;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int primary_text_default_material_dark = 2131361846;
+			// aapt resource value: 0x7f0c0023
+			public const int material_deep_teal_500 = 2131492899;
 			
-			// aapt resource value: 0x7f0a0037
-			public const int primary_text_default_material_light = 2131361847;
+			// aapt resource value: 0x7f0c0024
+			public const int material_grey_100 = 2131492900;
 			
-			// aapt resource value: 0x7f0a0038
-			public const int primary_text_disabled_material_dark = 2131361848;
+			// aapt resource value: 0x7f0c0025
+			public const int material_grey_300 = 2131492901;
 			
-			// aapt resource value: 0x7f0a0039
-			public const int primary_text_disabled_material_light = 2131361849;
+			// aapt resource value: 0x7f0c0026
+			public const int material_grey_50 = 2131492902;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int ripple_material_dark = 2131361850;
+			// aapt resource value: 0x7f0c0027
+			public const int material_grey_600 = 2131492903;
 			
-			// aapt resource value: 0x7f0a003b
-			public const int ripple_material_light = 2131361851;
+			// aapt resource value: 0x7f0c0028
+			public const int material_grey_800 = 2131492904;
 			
-			// aapt resource value: 0x7f0a003c
-			public const int secondary_text_default_material_dark = 2131361852;
+			// aapt resource value: 0x7f0c0029
+			public const int material_grey_850 = 2131492905;
 			
-			// aapt resource value: 0x7f0a003d
-			public const int secondary_text_default_material_light = 2131361853;
+			// aapt resource value: 0x7f0c002a
+			public const int material_grey_900 = 2131492906;
 			
-			// aapt resource value: 0x7f0a003e
-			public const int secondary_text_disabled_material_dark = 2131361854;
+			// aapt resource value: 0x7f0c0004
+			public const int notification_action_color_filter = 2131492868;
 			
-			// aapt resource value: 0x7f0a003f
-			public const int secondary_text_disabled_material_light = 2131361855;
+			// aapt resource value: 0x7f0c002b
+			public const int notification_icon_bg_color = 2131492907;
 			
-			// aapt resource value: 0x7f0a0040
-			public const int switch_thumb_disabled_material_dark = 2131361856;
+			// aapt resource value: 0x7f0c002c
+			public const int notification_material_background_media_default_color = 2131492908;
 			
-			// aapt resource value: 0x7f0a0041
-			public const int switch_thumb_disabled_material_light = 2131361857;
+			// aapt resource value: 0x7f0c002d
+			public const int primary_dark_material_dark = 2131492909;
 			
-			// aapt resource value: 0x7f0a0053
-			public const int switch_thumb_material_dark = 2131361875;
+			// aapt resource value: 0x7f0c002e
+			public const int primary_dark_material_light = 2131492910;
 			
-			// aapt resource value: 0x7f0a0054
-			public const int switch_thumb_material_light = 2131361876;
+			// aapt resource value: 0x7f0c002f
+			public const int primary_material_dark = 2131492911;
 			
-			// aapt resource value: 0x7f0a0042
-			public const int switch_thumb_normal_material_dark = 2131361858;
+			// aapt resource value: 0x7f0c0030
+			public const int primary_material_light = 2131492912;
 			
-			// aapt resource value: 0x7f0a0043
-			public const int switch_thumb_normal_material_light = 2131361859;
+			// aapt resource value: 0x7f0c0031
+			public const int primary_text_default_material_dark = 2131492913;
+			
+			// aapt resource value: 0x7f0c0032
+			public const int primary_text_default_material_light = 2131492914;
+			
+			// aapt resource value: 0x7f0c0033
+			public const int primary_text_disabled_material_dark = 2131492915;
+			
+			// aapt resource value: 0x7f0c0034
+			public const int primary_text_disabled_material_light = 2131492916;
+			
+			// aapt resource value: 0x7f0c0035
+			public const int ripple_material_dark = 2131492917;
+			
+			// aapt resource value: 0x7f0c0036
+			public const int ripple_material_light = 2131492918;
+			
+			// aapt resource value: 0x7f0c0037
+			public const int secondary_text_default_material_dark = 2131492919;
+			
+			// aapt resource value: 0x7f0c0038
+			public const int secondary_text_default_material_light = 2131492920;
+			
+			// aapt resource value: 0x7f0c0039
+			public const int secondary_text_disabled_material_dark = 2131492921;
+			
+			// aapt resource value: 0x7f0c003a
+			public const int secondary_text_disabled_material_light = 2131492922;
+			
+			// aapt resource value: 0x7f0c003b
+			public const int switch_thumb_disabled_material_dark = 2131492923;
+			
+			// aapt resource value: 0x7f0c003c
+			public const int switch_thumb_disabled_material_light = 2131492924;
+			
+			// aapt resource value: 0x7f0c0062
+			public const int switch_thumb_material_dark = 2131492962;
+			
+			// aapt resource value: 0x7f0c0063
+			public const int switch_thumb_material_light = 2131492963;
+			
+			// aapt resource value: 0x7f0c003d
+			public const int switch_thumb_normal_material_dark = 2131492925;
+			
+			// aapt resource value: 0x7f0c003e
+			public const int switch_thumb_normal_material_light = 2131492926;
 			
 			static Color()
 			{
@@ -3194,368 +3639,464 @@ namespace FABSample.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f070030
-			public const int abc_action_bar_content_inset_material = 2131165232;
-			
-			// aapt resource value: 0x7f070024
-			public const int abc_action_bar_default_height_material = 2131165220;
-			
-			// aapt resource value: 0x7f070031
-			public const int abc_action_bar_default_padding_end_material = 2131165233;
-			
-			// aapt resource value: 0x7f070032
-			public const int abc_action_bar_default_padding_start_material = 2131165234;
-			
-			// aapt resource value: 0x7f070034
-			public const int abc_action_bar_icon_vertical_padding_material = 2131165236;
-			
-			// aapt resource value: 0x7f070035
-			public const int abc_action_bar_overflow_padding_end_material = 2131165237;
-			
-			// aapt resource value: 0x7f070036
-			public const int abc_action_bar_overflow_padding_start_material = 2131165238;
-			
-			// aapt resource value: 0x7f070025
-			public const int abc_action_bar_progress_bar_size = 2131165221;
-			
-			// aapt resource value: 0x7f070037
-			public const int abc_action_bar_stacked_max_height = 2131165239;
-			
-			// aapt resource value: 0x7f070038
-			public const int abc_action_bar_stacked_tab_max_width = 2131165240;
-			
-			// aapt resource value: 0x7f070039
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131165241;
-			
-			// aapt resource value: 0x7f07003a
-			public const int abc_action_bar_subtitle_top_margin_material = 2131165242;
-			
-			// aapt resource value: 0x7f07003b
-			public const int abc_action_button_min_height_material = 2131165243;
-			
-			// aapt resource value: 0x7f07003c
-			public const int abc_action_button_min_width_material = 2131165244;
-			
-			// aapt resource value: 0x7f07003d
-			public const int abc_action_button_min_width_overflow_material = 2131165245;
-			
-			// aapt resource value: 0x7f070023
-			public const int abc_alert_dialog_button_bar_height = 2131165219;
-			
-			// aapt resource value: 0x7f07003e
-			public const int abc_button_inset_horizontal_material = 2131165246;
-			
-			// aapt resource value: 0x7f07003f
-			public const int abc_button_inset_vertical_material = 2131165247;
-			
-			// aapt resource value: 0x7f070040
-			public const int abc_button_padding_horizontal_material = 2131165248;
-			
-			// aapt resource value: 0x7f070041
-			public const int abc_button_padding_vertical_material = 2131165249;
-			
-			// aapt resource value: 0x7f070028
-			public const int abc_config_prefDialogWidth = 2131165224;
-			
-			// aapt resource value: 0x7f070042
-			public const int abc_control_corner_material = 2131165250;
-			
-			// aapt resource value: 0x7f070043
-			public const int abc_control_inset_material = 2131165251;
-			
-			// aapt resource value: 0x7f070044
-			public const int abc_control_padding_material = 2131165252;
-			
-			// aapt resource value: 0x7f070029
-			public const int abc_dialog_fixed_height_major = 2131165225;
-			
-			// aapt resource value: 0x7f07002a
-			public const int abc_dialog_fixed_height_minor = 2131165226;
-			
-			// aapt resource value: 0x7f07002b
-			public const int abc_dialog_fixed_width_major = 2131165227;
-			
-			// aapt resource value: 0x7f07002c
-			public const int abc_dialog_fixed_width_minor = 2131165228;
-			
-			// aapt resource value: 0x7f070045
-			public const int abc_dialog_list_padding_vertical_material = 2131165253;
-			
-			// aapt resource value: 0x7f07002d
-			public const int abc_dialog_min_width_major = 2131165229;
-			
-			// aapt resource value: 0x7f07002e
-			public const int abc_dialog_min_width_minor = 2131165230;
-			
-			// aapt resource value: 0x7f070046
-			public const int abc_dialog_padding_material = 2131165254;
-			
-			// aapt resource value: 0x7f070047
-			public const int abc_dialog_padding_top_material = 2131165255;
-			
-			// aapt resource value: 0x7f070048
-			public const int abc_disabled_alpha_material_dark = 2131165256;
-			
-			// aapt resource value: 0x7f070049
-			public const int abc_disabled_alpha_material_light = 2131165257;
-			
-			// aapt resource value: 0x7f07004a
-			public const int abc_dropdownitem_icon_width = 2131165258;
-			
-			// aapt resource value: 0x7f07004b
-			public const int abc_dropdownitem_text_padding_left = 2131165259;
-			
-			// aapt resource value: 0x7f07004c
-			public const int abc_dropdownitem_text_padding_right = 2131165260;
-			
-			// aapt resource value: 0x7f07004d
-			public const int abc_edit_text_inset_bottom_material = 2131165261;
-			
-			// aapt resource value: 0x7f07004e
-			public const int abc_edit_text_inset_horizontal_material = 2131165262;
-			
-			// aapt resource value: 0x7f07004f
-			public const int abc_edit_text_inset_top_material = 2131165263;
-			
-			// aapt resource value: 0x7f070050
-			public const int abc_floating_window_z = 2131165264;
-			
-			// aapt resource value: 0x7f070051
-			public const int abc_list_item_padding_horizontal_material = 2131165265;
-			
-			// aapt resource value: 0x7f070052
-			public const int abc_panel_menu_list_width = 2131165266;
-			
-			// aapt resource value: 0x7f070053
-			public const int abc_search_view_preferred_width = 2131165267;
-			
-			// aapt resource value: 0x7f07002f
-			public const int abc_search_view_text_min_width = 2131165231;
-			
-			// aapt resource value: 0x7f070054
-			public const int abc_seekbar_track_background_height_material = 2131165268;
-			
-			// aapt resource value: 0x7f070055
-			public const int abc_seekbar_track_progress_height_material = 2131165269;
-			
-			// aapt resource value: 0x7f070056
-			public const int abc_select_dialog_padding_start_material = 2131165270;
-			
-			// aapt resource value: 0x7f070033
-			public const int abc_switch_padding = 2131165235;
-			
-			// aapt resource value: 0x7f070057
-			public const int abc_text_size_body_1_material = 2131165271;
-			
-			// aapt resource value: 0x7f070058
-			public const int abc_text_size_body_2_material = 2131165272;
-			
-			// aapt resource value: 0x7f070059
-			public const int abc_text_size_button_material = 2131165273;
-			
-			// aapt resource value: 0x7f07005a
-			public const int abc_text_size_caption_material = 2131165274;
-			
-			// aapt resource value: 0x7f07005b
-			public const int abc_text_size_display_1_material = 2131165275;
-			
-			// aapt resource value: 0x7f07005c
-			public const int abc_text_size_display_2_material = 2131165276;
-			
-			// aapt resource value: 0x7f07005d
-			public const int abc_text_size_display_3_material = 2131165277;
-			
-			// aapt resource value: 0x7f07005e
-			public const int abc_text_size_display_4_material = 2131165278;
-			
-			// aapt resource value: 0x7f07005f
-			public const int abc_text_size_headline_material = 2131165279;
-			
-			// aapt resource value: 0x7f070060
-			public const int abc_text_size_large_material = 2131165280;
-			
-			// aapt resource value: 0x7f070061
-			public const int abc_text_size_medium_material = 2131165281;
-			
-			// aapt resource value: 0x7f070062
-			public const int abc_text_size_menu_material = 2131165282;
-			
-			// aapt resource value: 0x7f070063
-			public const int abc_text_size_small_material = 2131165283;
-			
-			// aapt resource value: 0x7f070064
-			public const int abc_text_size_subhead_material = 2131165284;
-			
-			// aapt resource value: 0x7f070026
-			public const int abc_text_size_subtitle_material_toolbar = 2131165222;
-			
-			// aapt resource value: 0x7f070065
-			public const int abc_text_size_title_material = 2131165285;
-			
-			// aapt resource value: 0x7f070027
-			public const int abc_text_size_title_material_toolbar = 2131165223;
-			
-			// aapt resource value: 0x7f070071
-			public const int cardview_compat_inset_shadow = 2131165297;
-			
-			// aapt resource value: 0x7f070072
-			public const int cardview_default_elevation = 2131165298;
-			
-			// aapt resource value: 0x7f070073
-			public const int cardview_default_radius = 2131165299;
-			
-			// aapt resource value: 0x7f07000e
-			public const int design_appbar_elevation = 2131165198;
-			
-			// aapt resource value: 0x7f07000f
-			public const int design_bottom_sheet_modal_elevation = 2131165199;
-			
-			// aapt resource value: 0x7f070010
-			public const int design_bottom_sheet_modal_peek_height = 2131165200;
-			
-			// aapt resource value: 0x7f070011
-			public const int design_fab_border_width = 2131165201;
-			
-			// aapt resource value: 0x7f070012
-			public const int design_fab_elevation = 2131165202;
-			
-			// aapt resource value: 0x7f070013
-			public const int design_fab_image_size = 2131165203;
-			
-			// aapt resource value: 0x7f070014
-			public const int design_fab_size_mini = 2131165204;
-			
-			// aapt resource value: 0x7f070015
-			public const int design_fab_size_normal = 2131165205;
-			
-			// aapt resource value: 0x7f070016
-			public const int design_fab_translation_z_pressed = 2131165206;
-			
-			// aapt resource value: 0x7f070017
-			public const int design_navigation_elevation = 2131165207;
-			
 			// aapt resource value: 0x7f070018
-			public const int design_navigation_icon_padding = 2131165208;
+			public const int abc_action_bar_content_inset_material = 2131165208;
 			
 			// aapt resource value: 0x7f070019
-			public const int design_navigation_icon_size = 2131165209;
-			
-			// aapt resource value: 0x7f070006
-			public const int design_navigation_max_width = 2131165190;
-			
-			// aapt resource value: 0x7f07001a
-			public const int design_navigation_padding_bottom = 2131165210;
-			
-			// aapt resource value: 0x7f07001b
-			public const int design_navigation_separator_vertical_padding = 2131165211;
-			
-			// aapt resource value: 0x7f070007
-			public const int design_snackbar_action_inline_max_width = 2131165191;
-			
-			// aapt resource value: 0x7f070008
-			public const int design_snackbar_background_corner_radius = 2131165192;
-			
-			// aapt resource value: 0x7f07001c
-			public const int design_snackbar_elevation = 2131165212;
-			
-			// aapt resource value: 0x7f070009
-			public const int design_snackbar_extra_spacing_horizontal = 2131165193;
-			
-			// aapt resource value: 0x7f07000a
-			public const int design_snackbar_max_width = 2131165194;
-			
-			// aapt resource value: 0x7f07000b
-			public const int design_snackbar_min_width = 2131165195;
-			
-			// aapt resource value: 0x7f07001d
-			public const int design_snackbar_padding_horizontal = 2131165213;
-			
-			// aapt resource value: 0x7f07001e
-			public const int design_snackbar_padding_vertical = 2131165214;
-			
-			// aapt resource value: 0x7f07000c
-			public const int design_snackbar_padding_vertical_2lines = 2131165196;
-			
-			// aapt resource value: 0x7f07001f
-			public const int design_snackbar_text_size = 2131165215;
-			
-			// aapt resource value: 0x7f070020
-			public const int design_tab_max_width = 2131165216;
+			public const int abc_action_bar_content_inset_with_nav = 2131165209;
 			
 			// aapt resource value: 0x7f07000d
-			public const int design_tab_scrollable_min_width = 2131165197;
+			public const int abc_action_bar_default_height_material = 2131165197;
+			
+			// aapt resource value: 0x7f07001a
+			public const int abc_action_bar_default_padding_end_material = 2131165210;
+			
+			// aapt resource value: 0x7f07001b
+			public const int abc_action_bar_default_padding_start_material = 2131165211;
 			
 			// aapt resource value: 0x7f070021
-			public const int design_tab_text_size = 2131165217;
+			public const int abc_action_bar_elevation_material = 2131165217;
 			
 			// aapt resource value: 0x7f070022
-			public const int design_tab_text_size_2line = 2131165218;
+			public const int abc_action_bar_icon_vertical_padding_material = 2131165218;
 			
-			// aapt resource value: 0x7f070066
-			public const int disabled_alpha_material_dark = 2131165286;
+			// aapt resource value: 0x7f070023
+			public const int abc_action_bar_overflow_padding_end_material = 2131165219;
 			
-			// aapt resource value: 0x7f070067
-			public const int disabled_alpha_material_light = 2131165287;
+			// aapt resource value: 0x7f070024
+			public const int abc_action_bar_overflow_padding_start_material = 2131165220;
 			
-			// aapt resource value: 0x7f070078
-			public const int fab_elevation_lollipop = 2131165304;
+			// aapt resource value: 0x7f07000e
+			public const int abc_action_bar_progress_bar_size = 2131165198;
 			
-			// aapt resource value: 0x7f070077
-			public const int fab_scroll_threshold = 2131165303;
+			// aapt resource value: 0x7f070025
+			public const int abc_action_bar_stacked_max_height = 2131165221;
+			
+			// aapt resource value: 0x7f070026
+			public const int abc_action_bar_stacked_tab_max_width = 2131165222;
+			
+			// aapt resource value: 0x7f070027
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131165223;
+			
+			// aapt resource value: 0x7f070028
+			public const int abc_action_bar_subtitle_top_margin_material = 2131165224;
+			
+			// aapt resource value: 0x7f070029
+			public const int abc_action_button_min_height_material = 2131165225;
+			
+			// aapt resource value: 0x7f07002a
+			public const int abc_action_button_min_width_material = 2131165226;
+			
+			// aapt resource value: 0x7f07002b
+			public const int abc_action_button_min_width_overflow_material = 2131165227;
+			
+			// aapt resource value: 0x7f07000c
+			public const int abc_alert_dialog_button_bar_height = 2131165196;
+			
+			// aapt resource value: 0x7f07002c
+			public const int abc_button_inset_horizontal_material = 2131165228;
+			
+			// aapt resource value: 0x7f07002d
+			public const int abc_button_inset_vertical_material = 2131165229;
+			
+			// aapt resource value: 0x7f07002e
+			public const int abc_button_padding_horizontal_material = 2131165230;
+			
+			// aapt resource value: 0x7f07002f
+			public const int abc_button_padding_vertical_material = 2131165231;
+			
+			// aapt resource value: 0x7f070030
+			public const int abc_cascading_menus_min_smallest_width = 2131165232;
+			
+			// aapt resource value: 0x7f070011
+			public const int abc_config_prefDialogWidth = 2131165201;
+			
+			// aapt resource value: 0x7f070031
+			public const int abc_control_corner_material = 2131165233;
+			
+			// aapt resource value: 0x7f070032
+			public const int abc_control_inset_material = 2131165234;
+			
+			// aapt resource value: 0x7f070033
+			public const int abc_control_padding_material = 2131165235;
+			
+			// aapt resource value: 0x7f070012
+			public const int abc_dialog_fixed_height_major = 2131165202;
+			
+			// aapt resource value: 0x7f070013
+			public const int abc_dialog_fixed_height_minor = 2131165203;
+			
+			// aapt resource value: 0x7f070014
+			public const int abc_dialog_fixed_width_major = 2131165204;
+			
+			// aapt resource value: 0x7f070015
+			public const int abc_dialog_fixed_width_minor = 2131165205;
+			
+			// aapt resource value: 0x7f070034
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131165236;
+			
+			// aapt resource value: 0x7f070035
+			public const int abc_dialog_list_padding_top_no_title = 2131165237;
+			
+			// aapt resource value: 0x7f070016
+			public const int abc_dialog_min_width_major = 2131165206;
+			
+			// aapt resource value: 0x7f070017
+			public const int abc_dialog_min_width_minor = 2131165207;
+			
+			// aapt resource value: 0x7f070036
+			public const int abc_dialog_padding_material = 2131165238;
+			
+			// aapt resource value: 0x7f070037
+			public const int abc_dialog_padding_top_material = 2131165239;
+			
+			// aapt resource value: 0x7f070038
+			public const int abc_dialog_title_divider_material = 2131165240;
+			
+			// aapt resource value: 0x7f070039
+			public const int abc_disabled_alpha_material_dark = 2131165241;
+			
+			// aapt resource value: 0x7f07003a
+			public const int abc_disabled_alpha_material_light = 2131165242;
+			
+			// aapt resource value: 0x7f07003b
+			public const int abc_dropdownitem_icon_width = 2131165243;
+			
+			// aapt resource value: 0x7f07003c
+			public const int abc_dropdownitem_text_padding_left = 2131165244;
+			
+			// aapt resource value: 0x7f07003d
+			public const int abc_dropdownitem_text_padding_right = 2131165245;
+			
+			// aapt resource value: 0x7f07003e
+			public const int abc_edit_text_inset_bottom_material = 2131165246;
+			
+			// aapt resource value: 0x7f07003f
+			public const int abc_edit_text_inset_horizontal_material = 2131165247;
+			
+			// aapt resource value: 0x7f070040
+			public const int abc_edit_text_inset_top_material = 2131165248;
+			
+			// aapt resource value: 0x7f070041
+			public const int abc_floating_window_z = 2131165249;
+			
+			// aapt resource value: 0x7f070042
+			public const int abc_list_item_padding_horizontal_material = 2131165250;
+			
+			// aapt resource value: 0x7f070043
+			public const int abc_panel_menu_list_width = 2131165251;
+			
+			// aapt resource value: 0x7f070044
+			public const int abc_progress_bar_height_material = 2131165252;
+			
+			// aapt resource value: 0x7f070045
+			public const int abc_search_view_preferred_height = 2131165253;
+			
+			// aapt resource value: 0x7f070046
+			public const int abc_search_view_preferred_width = 2131165254;
+			
+			// aapt resource value: 0x7f070047
+			public const int abc_seekbar_track_background_height_material = 2131165255;
+			
+			// aapt resource value: 0x7f070048
+			public const int abc_seekbar_track_progress_height_material = 2131165256;
+			
+			// aapt resource value: 0x7f070049
+			public const int abc_select_dialog_padding_start_material = 2131165257;
+			
+			// aapt resource value: 0x7f07001d
+			public const int abc_switch_padding = 2131165213;
+			
+			// aapt resource value: 0x7f07004a
+			public const int abc_text_size_body_1_material = 2131165258;
+			
+			// aapt resource value: 0x7f07004b
+			public const int abc_text_size_body_2_material = 2131165259;
+			
+			// aapt resource value: 0x7f07004c
+			public const int abc_text_size_button_material = 2131165260;
+			
+			// aapt resource value: 0x7f07004d
+			public const int abc_text_size_caption_material = 2131165261;
+			
+			// aapt resource value: 0x7f07004e
+			public const int abc_text_size_display_1_material = 2131165262;
+			
+			// aapt resource value: 0x7f07004f
+			public const int abc_text_size_display_2_material = 2131165263;
+			
+			// aapt resource value: 0x7f070050
+			public const int abc_text_size_display_3_material = 2131165264;
+			
+			// aapt resource value: 0x7f070051
+			public const int abc_text_size_display_4_material = 2131165265;
+			
+			// aapt resource value: 0x7f070052
+			public const int abc_text_size_headline_material = 2131165266;
+			
+			// aapt resource value: 0x7f070053
+			public const int abc_text_size_large_material = 2131165267;
+			
+			// aapt resource value: 0x7f070054
+			public const int abc_text_size_medium_material = 2131165268;
+			
+			// aapt resource value: 0x7f070055
+			public const int abc_text_size_menu_header_material = 2131165269;
+			
+			// aapt resource value: 0x7f070056
+			public const int abc_text_size_menu_material = 2131165270;
+			
+			// aapt resource value: 0x7f070057
+			public const int abc_text_size_small_material = 2131165271;
+			
+			// aapt resource value: 0x7f070058
+			public const int abc_text_size_subhead_material = 2131165272;
+			
+			// aapt resource value: 0x7f07000f
+			public const int abc_text_size_subtitle_material_toolbar = 2131165199;
+			
+			// aapt resource value: 0x7f070059
+			public const int abc_text_size_title_material = 2131165273;
+			
+			// aapt resource value: 0x7f070010
+			public const int abc_text_size_title_material_toolbar = 2131165200;
+			
+			// aapt resource value: 0x7f070009
+			public const int cardview_compat_inset_shadow = 2131165193;
+			
+			// aapt resource value: 0x7f07000a
+			public const int cardview_default_elevation = 2131165194;
+			
+			// aapt resource value: 0x7f07000b
+			public const int cardview_default_radius = 2131165195;
 			
 			// aapt resource value: 0x7f070076
-			public const int fab_shadow_size = 2131165302;
+			public const int design_appbar_elevation = 2131165302;
 			
-			// aapt resource value: 0x7f070075
-			public const int fab_size_mini = 2131165301;
+			// aapt resource value: 0x7f070077
+			public const int design_bottom_navigation_active_item_max_width = 2131165303;
 			
-			// aapt resource value: 0x7f070074
-			public const int fab_size_normal = 2131165300;
+			// aapt resource value: 0x7f070078
+			public const int design_bottom_navigation_active_text_size = 2131165304;
 			
-			// aapt resource value: 0x7f070068
-			public const int highlight_alpha_material_colored = 2131165288;
+			// aapt resource value: 0x7f070079
+			public const int design_bottom_navigation_elevation = 2131165305;
 			
-			// aapt resource value: 0x7f070069
-			public const int highlight_alpha_material_dark = 2131165289;
+			// aapt resource value: 0x7f07007a
+			public const int design_bottom_navigation_height = 2131165306;
 			
-			// aapt resource value: 0x7f07006a
-			public const int highlight_alpha_material_light = 2131165290;
+			// aapt resource value: 0x7f07007b
+			public const int design_bottom_navigation_item_max_width = 2131165307;
+			
+			// aapt resource value: 0x7f07007c
+			public const int design_bottom_navigation_item_min_width = 2131165308;
+			
+			// aapt resource value: 0x7f07007d
+			public const int design_bottom_navigation_margin = 2131165309;
+			
+			// aapt resource value: 0x7f07007e
+			public const int design_bottom_navigation_shadow_height = 2131165310;
+			
+			// aapt resource value: 0x7f07007f
+			public const int design_bottom_navigation_text_size = 2131165311;
+			
+			// aapt resource value: 0x7f070080
+			public const int design_bottom_sheet_modal_elevation = 2131165312;
+			
+			// aapt resource value: 0x7f070081
+			public const int design_bottom_sheet_peek_height_min = 2131165313;
+			
+			// aapt resource value: 0x7f070082
+			public const int design_fab_border_width = 2131165314;
+			
+			// aapt resource value: 0x7f070083
+			public const int design_fab_elevation = 2131165315;
+			
+			// aapt resource value: 0x7f070084
+			public const int design_fab_image_size = 2131165316;
+			
+			// aapt resource value: 0x7f070085
+			public const int design_fab_size_mini = 2131165317;
+			
+			// aapt resource value: 0x7f070086
+			public const int design_fab_size_normal = 2131165318;
+			
+			// aapt resource value: 0x7f070087
+			public const int design_fab_translation_z_pressed = 2131165319;
+			
+			// aapt resource value: 0x7f070088
+			public const int design_navigation_elevation = 2131165320;
+			
+			// aapt resource value: 0x7f070089
+			public const int design_navigation_icon_padding = 2131165321;
+			
+			// aapt resource value: 0x7f07008a
+			public const int design_navigation_icon_size = 2131165322;
 			
 			// aapt resource value: 0x7f07006e
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131165294;
+			public const int design_navigation_max_width = 2131165294;
+			
+			// aapt resource value: 0x7f07008b
+			public const int design_navigation_padding_bottom = 2131165323;
+			
+			// aapt resource value: 0x7f07008c
+			public const int design_navigation_separator_vertical_padding = 2131165324;
 			
 			// aapt resource value: 0x7f07006f
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131165295;
+			public const int design_snackbar_action_inline_max_width = 2131165295;
 			
 			// aapt resource value: 0x7f070070
-			public const int item_touch_helper_swipe_escape_velocity = 2131165296;
+			public const int design_snackbar_background_corner_radius = 2131165296;
+			
+			// aapt resource value: 0x7f07008d
+			public const int design_snackbar_elevation = 2131165325;
+			
+			// aapt resource value: 0x7f070071
+			public const int design_snackbar_extra_spacing_horizontal = 2131165297;
+			
+			// aapt resource value: 0x7f070072
+			public const int design_snackbar_max_width = 2131165298;
+			
+			// aapt resource value: 0x7f070073
+			public const int design_snackbar_min_width = 2131165299;
+			
+			// aapt resource value: 0x7f07008e
+			public const int design_snackbar_padding_horizontal = 2131165326;
+			
+			// aapt resource value: 0x7f07008f
+			public const int design_snackbar_padding_vertical = 2131165327;
+			
+			// aapt resource value: 0x7f070074
+			public const int design_snackbar_padding_vertical_2lines = 2131165300;
+			
+			// aapt resource value: 0x7f070090
+			public const int design_snackbar_text_size = 2131165328;
+			
+			// aapt resource value: 0x7f070091
+			public const int design_tab_max_width = 2131165329;
+			
+			// aapt resource value: 0x7f070075
+			public const int design_tab_scrollable_min_width = 2131165301;
+			
+			// aapt resource value: 0x7f070092
+			public const int design_tab_text_size = 2131165330;
+			
+			// aapt resource value: 0x7f070093
+			public const int design_tab_text_size_2line = 2131165331;
+			
+			// aapt resource value: 0x7f07005a
+			public const int disabled_alpha_material_dark = 2131165274;
+			
+			// aapt resource value: 0x7f07005b
+			public const int disabled_alpha_material_light = 2131165275;
+			
+			// aapt resource value: 0x7f070098
+			public const int fab_elevation_lollipop = 2131165336;
+			
+			// aapt resource value: 0x7f070097
+			public const int fab_scroll_threshold = 2131165335;
+			
+			// aapt resource value: 0x7f070096
+			public const int fab_shadow_size = 2131165334;
+			
+			// aapt resource value: 0x7f070095
+			public const int fab_size_mini = 2131165333;
+			
+			// aapt resource value: 0x7f070094
+			public const int fab_size_normal = 2131165332;
+			
+			// aapt resource value: 0x7f07005c
+			public const int highlight_alpha_material_colored = 2131165276;
+			
+			// aapt resource value: 0x7f07005d
+			public const int highlight_alpha_material_dark = 2131165277;
+			
+			// aapt resource value: 0x7f07005e
+			public const int highlight_alpha_material_light = 2131165278;
+			
+			// aapt resource value: 0x7f07005f
+			public const int hint_alpha_material_dark = 2131165279;
+			
+			// aapt resource value: 0x7f070060
+			public const int hint_alpha_material_light = 2131165280;
+			
+			// aapt resource value: 0x7f070061
+			public const int hint_pressed_alpha_material_dark = 2131165281;
+			
+			// aapt resource value: 0x7f070062
+			public const int hint_pressed_alpha_material_light = 2131165282;
 			
 			// aapt resource value: 0x7f070000
-			public const int mr_controller_volume_group_list_item_height = 2131165184;
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131165184;
 			
 			// aapt resource value: 0x7f070001
-			public const int mr_controller_volume_group_list_item_icon_size = 2131165185;
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131165185;
 			
 			// aapt resource value: 0x7f070002
-			public const int mr_controller_volume_group_list_max_height = 2131165186;
-			
-			// aapt resource value: 0x7f070005
-			public const int mr_controller_volume_group_list_padding_top = 2131165189;
+			public const int item_touch_helper_swipe_escape_velocity = 2131165186;
 			
 			// aapt resource value: 0x7f070003
-			public const int mr_dialog_fixed_width_major = 2131165187;
+			public const int mr_controller_volume_group_list_item_height = 2131165187;
 			
 			// aapt resource value: 0x7f070004
-			public const int mr_dialog_fixed_width_minor = 2131165188;
+			public const int mr_controller_volume_group_list_item_icon_size = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public const int mr_controller_volume_group_list_max_height = 2131165189;
+			
+			// aapt resource value: 0x7f070008
+			public const int mr_controller_volume_group_list_padding_top = 2131165192;
+			
+			// aapt resource value: 0x7f070006
+			public const int mr_dialog_fixed_width_major = 2131165190;
+			
+			// aapt resource value: 0x7f070007
+			public const int mr_dialog_fixed_width_minor = 2131165191;
+			
+			// aapt resource value: 0x7f070063
+			public const int notification_action_icon_size = 2131165283;
+			
+			// aapt resource value: 0x7f070064
+			public const int notification_action_text_size = 2131165284;
+			
+			// aapt resource value: 0x7f070065
+			public const int notification_big_circle_margin = 2131165285;
+			
+			// aapt resource value: 0x7f07001e
+			public const int notification_content_margin_start = 2131165214;
+			
+			// aapt resource value: 0x7f070066
+			public const int notification_large_icon_height = 2131165286;
+			
+			// aapt resource value: 0x7f070067
+			public const int notification_large_icon_width = 2131165287;
+			
+			// aapt resource value: 0x7f07001f
+			public const int notification_main_column_padding_top = 2131165215;
+			
+			// aapt resource value: 0x7f070020
+			public const int notification_media_narrow_margin = 2131165216;
+			
+			// aapt resource value: 0x7f070068
+			public const int notification_right_icon_size = 2131165288;
+			
+			// aapt resource value: 0x7f07001c
+			public const int notification_right_side_padding_top = 2131165212;
+			
+			// aapt resource value: 0x7f070069
+			public const int notification_small_icon_background_padding = 2131165289;
+			
+			// aapt resource value: 0x7f07006a
+			public const int notification_small_icon_size_as_large = 2131165290;
 			
 			// aapt resource value: 0x7f07006b
-			public const int notification_large_icon_height = 2131165291;
+			public const int notification_subtext_size = 2131165291;
 			
 			// aapt resource value: 0x7f07006c
-			public const int notification_large_icon_width = 2131165292;
+			public const int notification_top_pad = 2131165292;
 			
 			// aapt resource value: 0x7f07006d
-			public const int notification_subtext_size = 2131165293;
+			public const int notification_top_pad_large_text = 2131165293;
 			
 			static Dimension()
 			{
@@ -3604,85 +4145,85 @@ namespace FABSample.Droid
 			public const int abc_btn_radio_to_on_mtrl_015 = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public const int abc_btn_rating_star_off_mtrl_alpha = 2130837515;
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public const int abc_btn_rating_star_on_mtrl_alpha = 2130837516;
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837517;
+			public const int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837518;
+			public const int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public const int abc_cab_background_internal_bg = 2130837519;
+			public const int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public const int abc_cab_background_top_material = 2130837520;
+			public const int abc_control_background_material = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public const int abc_cab_background_top_mtrl_alpha = 2130837521;
+			public const int abc_dialog_material_background = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public const int abc_control_background_material = 2130837522;
+			public const int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public const int abc_dialog_material_background_dark = 2130837523;
+			public const int abc_ic_ab_back_material = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public const int abc_dialog_material_background_light = 2130837524;
+			public const int abc_ic_arrow_drop_right_black_24dp = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public const int abc_edit_text_material = 2130837525;
+			public const int abc_ic_clear_material = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public const int abc_ic_ab_back_mtrl_am_alpha = 2130837526;
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public const int abc_ic_clear_mtrl_alpha = 2130837527;
+			public const int abc_ic_go_search_api_material = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837528;
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public const int abc_ic_go_search_api_mtrl_alpha = 2130837529;
+			public const int abc_ic_menu_cut_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837530;
+			public const int abc_ic_menu_overflow_material = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public const int abc_ic_menu_cut_mtrl_alpha = 2130837531;
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public const int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837532;
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837533;
+			public const int abc_ic_menu_share_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837534;
+			public const int abc_ic_search_api_material = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public const int abc_ic_menu_share_mtrl_alpha = 2130837535;
+			public const int abc_ic_star_black_16dp = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public const int abc_ic_search_api_mtrl_alpha = 2130837536;
+			public const int abc_ic_star_black_36dp = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public const int abc_ic_star_black_16dp = 2130837537;
+			public const int abc_ic_star_black_48dp = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public const int abc_ic_star_black_36dp = 2130837538;
+			public const int abc_ic_star_half_black_16dp = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public const int abc_ic_star_half_black_16dp = 2130837539;
+			public const int abc_ic_star_half_black_36dp = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public const int abc_ic_star_half_black_36dp = 2130837540;
+			public const int abc_ic_star_half_black_48dp = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public const int abc_ic_voice_search_api_mtrl_alpha = 2130837541;
+			public const int abc_ic_voice_search_api_material = 2130837541;
 			
 			// aapt resource value: 0x7f020026
 			public const int abc_item_background_holo_dark = 2130837542;
@@ -3730,10 +4271,10 @@ namespace FABSample.Droid
 			public const int abc_popup_background_mtrl_mult = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public const int abc_ratingbar_full_material = 2130837557;
+			public const int abc_ratingbar_indicator_material = 2130837557;
 			
 			// aapt resource value: 0x7f020036
-			public const int abc_ratingbar_indicator_material = 2130837558;
+			public const int abc_ratingbar_material = 2130837558;
 			
 			// aapt resource value: 0x7f020037
 			public const int abc_ratingbar_small_material = 2130837559;
@@ -3757,322 +4298,664 @@ namespace FABSample.Droid
 			public const int abc_seekbar_thumb_material = 2130837565;
 			
 			// aapt resource value: 0x7f02003e
-			public const int abc_seekbar_track_material = 2130837566;
+			public const int abc_seekbar_tick_mark_material = 2130837566;
 			
 			// aapt resource value: 0x7f02003f
-			public const int abc_spinner_mtrl_am_alpha = 2130837567;
+			public const int abc_seekbar_track_material = 2130837567;
 			
 			// aapt resource value: 0x7f020040
-			public const int abc_spinner_textfield_background_material = 2130837568;
+			public const int abc_spinner_mtrl_am_alpha = 2130837568;
 			
 			// aapt resource value: 0x7f020041
-			public const int abc_switch_thumb_material = 2130837569;
+			public const int abc_spinner_textfield_background_material = 2130837569;
 			
 			// aapt resource value: 0x7f020042
-			public const int abc_switch_track_mtrl_alpha = 2130837570;
+			public const int abc_switch_thumb_material = 2130837570;
 			
 			// aapt resource value: 0x7f020043
-			public const int abc_tab_indicator_material = 2130837571;
+			public const int abc_switch_track_mtrl_alpha = 2130837571;
 			
 			// aapt resource value: 0x7f020044
-			public const int abc_tab_indicator_mtrl_alpha = 2130837572;
+			public const int abc_tab_indicator_material = 2130837572;
 			
 			// aapt resource value: 0x7f020045
-			public const int abc_text_cursor_material = 2130837573;
+			public const int abc_tab_indicator_mtrl_alpha = 2130837573;
 			
 			// aapt resource value: 0x7f020046
-			public const int abc_textfield_activated_mtrl_alpha = 2130837574;
+			public const int abc_text_cursor_material = 2130837574;
 			
 			// aapt resource value: 0x7f020047
-			public const int abc_textfield_default_mtrl_alpha = 2130837575;
+			public const int abc_text_select_handle_left_mtrl_dark = 2130837575;
 			
 			// aapt resource value: 0x7f020048
-			public const int abc_textfield_search_activated_mtrl_alpha = 2130837576;
+			public const int abc_text_select_handle_left_mtrl_light = 2130837576;
 			
 			// aapt resource value: 0x7f020049
-			public const int abc_textfield_search_default_mtrl_alpha = 2130837577;
+			public const int abc_text_select_handle_middle_mtrl_dark = 2130837577;
 			
 			// aapt resource value: 0x7f02004a
-			public const int abc_textfield_search_material = 2130837578;
+			public const int abc_text_select_handle_middle_mtrl_light = 2130837578;
 			
 			// aapt resource value: 0x7f02004b
-			public const int csharp = 2130837579;
+			public const int abc_text_select_handle_right_mtrl_dark = 2130837579;
 			
 			// aapt resource value: 0x7f02004c
-			public const int design_fab_background = 2130837580;
+			public const int abc_text_select_handle_right_mtrl_light = 2130837580;
 			
 			// aapt resource value: 0x7f02004d
-			public const int design_snackbar_background = 2130837581;
+			public const int abc_textfield_activated_mtrl_alpha = 2130837581;
 			
 			// aapt resource value: 0x7f02004e
-			public const int fab_shadow = 2130837582;
+			public const int abc_textfield_default_mtrl_alpha = 2130837582;
 			
 			// aapt resource value: 0x7f02004f
-			public const int fab_shadow_mini = 2130837583;
+			public const int abc_textfield_search_activated_mtrl_alpha = 2130837583;
 			
 			// aapt resource value: 0x7f020050
-			public const int ic_audiotrack = 2130837584;
+			public const int abc_textfield_search_default_mtrl_alpha = 2130837584;
 			
 			// aapt resource value: 0x7f020051
-			public const int ic_audiotrack_light = 2130837585;
+			public const int abc_textfield_search_material = 2130837585;
 			
 			// aapt resource value: 0x7f020052
-			public const int ic_bluetooth_grey = 2130837586;
+			public const int abc_vector_test = 2130837586;
 			
 			// aapt resource value: 0x7f020053
-			public const int ic_bluetooth_white = 2130837587;
+			public const int avd_hide_password = 2130837587;
+			
+			// aapt resource value: 0x7f020114
+			public const int avd_hide_password_1 = 2130837780;
+			
+			// aapt resource value: 0x7f020115
+			public const int avd_hide_password_2 = 2130837781;
+			
+			// aapt resource value: 0x7f020116
+			public const int avd_hide_password_3 = 2130837782;
 			
 			// aapt resource value: 0x7f020054
-			public const int ic_cast_dark = 2130837588;
+			public const int avd_show_password = 2130837588;
+			
+			// aapt resource value: 0x7f020117
+			public const int avd_show_password_1 = 2130837783;
+			
+			// aapt resource value: 0x7f020118
+			public const int avd_show_password_2 = 2130837784;
+			
+			// aapt resource value: 0x7f020119
+			public const int avd_show_password_3 = 2130837785;
 			
 			// aapt resource value: 0x7f020055
-			public const int ic_cast_disabled_light = 2130837589;
+			public const int csharp = 2130837589;
 			
 			// aapt resource value: 0x7f020056
-			public const int ic_cast_grey = 2130837590;
+			public const int design_bottom_navigation_item_background = 2130837590;
 			
 			// aapt resource value: 0x7f020057
-			public const int ic_cast_light = 2130837591;
+			public const int design_fab_background = 2130837591;
 			
 			// aapt resource value: 0x7f020058
-			public const int ic_cast_off_light = 2130837592;
+			public const int design_ic_visibility = 2130837592;
 			
 			// aapt resource value: 0x7f020059
-			public const int ic_cast_on_0_light = 2130837593;
+			public const int design_ic_visibility_off = 2130837593;
 			
 			// aapt resource value: 0x7f02005a
-			public const int ic_cast_on_1_light = 2130837594;
+			public const int design_password_eye = 2130837594;
 			
 			// aapt resource value: 0x7f02005b
-			public const int ic_cast_on_2_light = 2130837595;
+			public const int design_snackbar_background = 2130837595;
 			
 			// aapt resource value: 0x7f02005c
-			public const int ic_cast_on_light = 2130837596;
+			public const int fab_shadow = 2130837596;
 			
 			// aapt resource value: 0x7f02005d
-			public const int ic_cast_white = 2130837597;
+			public const int fab_shadow_mini = 2130837597;
 			
 			// aapt resource value: 0x7f02005e
-			public const int ic_close_dark = 2130837598;
+			public const int ic_audiotrack_dark = 2130837598;
 			
 			// aapt resource value: 0x7f02005f
-			public const int ic_close_light = 2130837599;
+			public const int ic_audiotrack_light = 2130837599;
 			
 			// aapt resource value: 0x7f020060
-			public const int ic_collapse = 2130837600;
+			public const int ic_dialog_close_dark = 2130837600;
 			
 			// aapt resource value: 0x7f020061
-			public const int ic_collapse_00000 = 2130837601;
+			public const int ic_dialog_close_light = 2130837601;
 			
 			// aapt resource value: 0x7f020062
-			public const int ic_collapse_00001 = 2130837602;
+			public const int ic_group_collapse_00 = 2130837602;
 			
 			// aapt resource value: 0x7f020063
-			public const int ic_collapse_00002 = 2130837603;
+			public const int ic_group_collapse_01 = 2130837603;
 			
 			// aapt resource value: 0x7f020064
-			public const int ic_collapse_00003 = 2130837604;
+			public const int ic_group_collapse_02 = 2130837604;
 			
 			// aapt resource value: 0x7f020065
-			public const int ic_collapse_00004 = 2130837605;
+			public const int ic_group_collapse_03 = 2130837605;
 			
 			// aapt resource value: 0x7f020066
-			public const int ic_collapse_00005 = 2130837606;
+			public const int ic_group_collapse_04 = 2130837606;
 			
 			// aapt resource value: 0x7f020067
-			public const int ic_collapse_00006 = 2130837607;
+			public const int ic_group_collapse_05 = 2130837607;
 			
 			// aapt resource value: 0x7f020068
-			public const int ic_collapse_00007 = 2130837608;
+			public const int ic_group_collapse_06 = 2130837608;
 			
 			// aapt resource value: 0x7f020069
-			public const int ic_collapse_00008 = 2130837609;
+			public const int ic_group_collapse_07 = 2130837609;
 			
 			// aapt resource value: 0x7f02006a
-			public const int ic_collapse_00009 = 2130837610;
+			public const int ic_group_collapse_08 = 2130837610;
 			
 			// aapt resource value: 0x7f02006b
-			public const int ic_collapse_00010 = 2130837611;
+			public const int ic_group_collapse_09 = 2130837611;
 			
 			// aapt resource value: 0x7f02006c
-			public const int ic_collapse_00011 = 2130837612;
+			public const int ic_group_collapse_10 = 2130837612;
 			
 			// aapt resource value: 0x7f02006d
-			public const int ic_collapse_00012 = 2130837613;
+			public const int ic_group_collapse_11 = 2130837613;
 			
 			// aapt resource value: 0x7f02006e
-			public const int ic_collapse_00013 = 2130837614;
+			public const int ic_group_collapse_12 = 2130837614;
 			
 			// aapt resource value: 0x7f02006f
-			public const int ic_collapse_00014 = 2130837615;
+			public const int ic_group_collapse_13 = 2130837615;
 			
 			// aapt resource value: 0x7f020070
-			public const int ic_collapse_00015 = 2130837616;
+			public const int ic_group_collapse_14 = 2130837616;
 			
 			// aapt resource value: 0x7f020071
-			public const int ic_expand = 2130837617;
+			public const int ic_group_collapse_15 = 2130837617;
 			
 			// aapt resource value: 0x7f020072
-			public const int ic_expand_00000 = 2130837618;
+			public const int ic_group_expand_00 = 2130837618;
 			
 			// aapt resource value: 0x7f020073
-			public const int ic_expand_00001 = 2130837619;
+			public const int ic_group_expand_01 = 2130837619;
 			
 			// aapt resource value: 0x7f020074
-			public const int ic_expand_00002 = 2130837620;
+			public const int ic_group_expand_02 = 2130837620;
 			
 			// aapt resource value: 0x7f020075
-			public const int ic_expand_00003 = 2130837621;
+			public const int ic_group_expand_03 = 2130837621;
 			
 			// aapt resource value: 0x7f020076
-			public const int ic_expand_00004 = 2130837622;
+			public const int ic_group_expand_04 = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public const int ic_expand_00005 = 2130837623;
+			public const int ic_group_expand_05 = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public const int ic_expand_00006 = 2130837624;
+			public const int ic_group_expand_06 = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public const int ic_expand_00007 = 2130837625;
+			public const int ic_group_expand_07 = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public const int ic_expand_00008 = 2130837626;
+			public const int ic_group_expand_08 = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public const int ic_expand_00009 = 2130837627;
+			public const int ic_group_expand_09 = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public const int ic_expand_00010 = 2130837628;
+			public const int ic_group_expand_10 = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public const int ic_expand_00011 = 2130837629;
+			public const int ic_group_expand_11 = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public const int ic_expand_00012 = 2130837630;
+			public const int ic_group_expand_12 = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public const int ic_expand_00013 = 2130837631;
+			public const int ic_group_expand_13 = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public const int ic_expand_00014 = 2130837632;
+			public const int ic_group_expand_14 = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public const int ic_expand_00015 = 2130837633;
+			public const int ic_group_expand_15 = 2130837633;
 			
 			// aapt resource value: 0x7f020082
 			public const int ic_launcher = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public const int ic_media_pause = 2130837635;
+			public const int ic_media_pause_dark = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public const int ic_media_play = 2130837636;
+			public const int ic_media_pause_light = 2130837636;
 			
 			// aapt resource value: 0x7f020085
-			public const int ic_media_route_disabled_mono_dark = 2130837637;
+			public const int ic_media_play_dark = 2130837637;
 			
 			// aapt resource value: 0x7f020086
-			public const int ic_media_route_off_mono_dark = 2130837638;
+			public const int ic_media_play_light = 2130837638;
 			
 			// aapt resource value: 0x7f020087
-			public const int ic_media_route_on_0_mono_dark = 2130837639;
+			public const int ic_media_stop_dark = 2130837639;
 			
 			// aapt resource value: 0x7f020088
-			public const int ic_media_route_on_1_mono_dark = 2130837640;
+			public const int ic_media_stop_light = 2130837640;
 			
 			// aapt resource value: 0x7f020089
-			public const int ic_media_route_on_2_mono_dark = 2130837641;
+			public const int ic_mr_button_connected_00_dark = 2130837641;
 			
 			// aapt resource value: 0x7f02008a
-			public const int ic_media_route_on_mono_dark = 2130837642;
+			public const int ic_mr_button_connected_00_light = 2130837642;
 			
 			// aapt resource value: 0x7f02008b
-			public const int ic_pause_dark = 2130837643;
+			public const int ic_mr_button_connected_01_dark = 2130837643;
 			
 			// aapt resource value: 0x7f02008c
-			public const int ic_pause_light = 2130837644;
+			public const int ic_mr_button_connected_01_light = 2130837644;
 			
 			// aapt resource value: 0x7f02008d
-			public const int ic_play_dark = 2130837645;
+			public const int ic_mr_button_connected_02_dark = 2130837645;
 			
 			// aapt resource value: 0x7f02008e
-			public const int ic_play_light = 2130837646;
+			public const int ic_mr_button_connected_02_light = 2130837646;
 			
 			// aapt resource value: 0x7f02008f
-			public const int ic_speaker_dark = 2130837647;
+			public const int ic_mr_button_connected_03_dark = 2130837647;
 			
 			// aapt resource value: 0x7f020090
-			public const int ic_speaker_group_dark = 2130837648;
+			public const int ic_mr_button_connected_03_light = 2130837648;
 			
 			// aapt resource value: 0x7f020091
-			public const int ic_speaker_group_light = 2130837649;
+			public const int ic_mr_button_connected_04_dark = 2130837649;
 			
 			// aapt resource value: 0x7f020092
-			public const int ic_speaker_light = 2130837650;
+			public const int ic_mr_button_connected_04_light = 2130837650;
 			
 			// aapt resource value: 0x7f020093
-			public const int ic_tv_dark = 2130837651;
+			public const int ic_mr_button_connected_05_dark = 2130837651;
 			
 			// aapt resource value: 0x7f020094
-			public const int ic_tv_light = 2130837652;
+			public const int ic_mr_button_connected_05_light = 2130837652;
 			
 			// aapt resource value: 0x7f020095
-			public const int list = 2130837653;
+			public const int ic_mr_button_connected_06_dark = 2130837653;
 			
 			// aapt resource value: 0x7f020096
-			public const int mr_dialog_material_background_dark = 2130837654;
+			public const int ic_mr_button_connected_06_light = 2130837654;
 			
 			// aapt resource value: 0x7f020097
-			public const int mr_dialog_material_background_light = 2130837655;
+			public const int ic_mr_button_connected_07_dark = 2130837655;
 			
 			// aapt resource value: 0x7f020098
-			public const int mr_ic_audiotrack_light = 2130837656;
+			public const int ic_mr_button_connected_07_light = 2130837656;
 			
 			// aapt resource value: 0x7f020099
-			public const int mr_ic_cast_dark = 2130837657;
+			public const int ic_mr_button_connected_08_dark = 2130837657;
 			
 			// aapt resource value: 0x7f02009a
-			public const int mr_ic_cast_light = 2130837658;
+			public const int ic_mr_button_connected_08_light = 2130837658;
 			
 			// aapt resource value: 0x7f02009b
-			public const int mr_ic_close_dark = 2130837659;
+			public const int ic_mr_button_connected_09_dark = 2130837659;
 			
 			// aapt resource value: 0x7f02009c
-			public const int mr_ic_close_light = 2130837660;
+			public const int ic_mr_button_connected_09_light = 2130837660;
 			
 			// aapt resource value: 0x7f02009d
-			public const int mr_ic_media_route_connecting_mono_dark = 2130837661;
+			public const int ic_mr_button_connected_10_dark = 2130837661;
 			
 			// aapt resource value: 0x7f02009e
-			public const int mr_ic_media_route_connecting_mono_light = 2130837662;
+			public const int ic_mr_button_connected_10_light = 2130837662;
 			
 			// aapt resource value: 0x7f02009f
-			public const int mr_ic_media_route_mono_dark = 2130837663;
+			public const int ic_mr_button_connected_11_dark = 2130837663;
 			
 			// aapt resource value: 0x7f0200a0
-			public const int mr_ic_media_route_mono_light = 2130837664;
+			public const int ic_mr_button_connected_11_light = 2130837664;
 			
 			// aapt resource value: 0x7f0200a1
-			public const int mr_ic_pause_dark = 2130837665;
+			public const int ic_mr_button_connected_12_dark = 2130837665;
 			
 			// aapt resource value: 0x7f0200a2
-			public const int mr_ic_pause_light = 2130837666;
+			public const int ic_mr_button_connected_12_light = 2130837666;
 			
 			// aapt resource value: 0x7f0200a3
-			public const int mr_ic_play_dark = 2130837667;
+			public const int ic_mr_button_connected_13_dark = 2130837667;
 			
 			// aapt resource value: 0x7f0200a4
-			public const int mr_ic_play_light = 2130837668;
-			
-			// aapt resource value: 0x7f0200a7
-			public const int notification_template_icon_bg = 2130837671;
+			public const int ic_mr_button_connected_13_light = 2130837668;
 			
 			// aapt resource value: 0x7f0200a5
-			public const int plus = 2130837669;
+			public const int ic_mr_button_connected_14_dark = 2130837669;
 			
 			// aapt resource value: 0x7f0200a6
-			public const int xml = 2130837670;
+			public const int ic_mr_button_connected_14_light = 2130837670;
+			
+			// aapt resource value: 0x7f0200a7
+			public const int ic_mr_button_connected_15_dark = 2130837671;
+			
+			// aapt resource value: 0x7f0200a8
+			public const int ic_mr_button_connected_15_light = 2130837672;
+			
+			// aapt resource value: 0x7f0200a9
+			public const int ic_mr_button_connected_16_dark = 2130837673;
+			
+			// aapt resource value: 0x7f0200aa
+			public const int ic_mr_button_connected_16_light = 2130837674;
+			
+			// aapt resource value: 0x7f0200ab
+			public const int ic_mr_button_connected_17_dark = 2130837675;
+			
+			// aapt resource value: 0x7f0200ac
+			public const int ic_mr_button_connected_17_light = 2130837676;
+			
+			// aapt resource value: 0x7f0200ad
+			public const int ic_mr_button_connected_18_dark = 2130837677;
+			
+			// aapt resource value: 0x7f0200ae
+			public const int ic_mr_button_connected_18_light = 2130837678;
+			
+			// aapt resource value: 0x7f0200af
+			public const int ic_mr_button_connected_19_dark = 2130837679;
+			
+			// aapt resource value: 0x7f0200b0
+			public const int ic_mr_button_connected_19_light = 2130837680;
+			
+			// aapt resource value: 0x7f0200b1
+			public const int ic_mr_button_connected_20_dark = 2130837681;
+			
+			// aapt resource value: 0x7f0200b2
+			public const int ic_mr_button_connected_20_light = 2130837682;
+			
+			// aapt resource value: 0x7f0200b3
+			public const int ic_mr_button_connected_21_dark = 2130837683;
+			
+			// aapt resource value: 0x7f0200b4
+			public const int ic_mr_button_connected_21_light = 2130837684;
+			
+			// aapt resource value: 0x7f0200b5
+			public const int ic_mr_button_connected_22_dark = 2130837685;
+			
+			// aapt resource value: 0x7f0200b6
+			public const int ic_mr_button_connected_22_light = 2130837686;
+			
+			// aapt resource value: 0x7f0200b7
+			public const int ic_mr_button_connecting_00_dark = 2130837687;
+			
+			// aapt resource value: 0x7f0200b8
+			public const int ic_mr_button_connecting_00_light = 2130837688;
+			
+			// aapt resource value: 0x7f0200b9
+			public const int ic_mr_button_connecting_01_dark = 2130837689;
+			
+			// aapt resource value: 0x7f0200ba
+			public const int ic_mr_button_connecting_01_light = 2130837690;
+			
+			// aapt resource value: 0x7f0200bb
+			public const int ic_mr_button_connecting_02_dark = 2130837691;
+			
+			// aapt resource value: 0x7f0200bc
+			public const int ic_mr_button_connecting_02_light = 2130837692;
+			
+			// aapt resource value: 0x7f0200bd
+			public const int ic_mr_button_connecting_03_dark = 2130837693;
+			
+			// aapt resource value: 0x7f0200be
+			public const int ic_mr_button_connecting_03_light = 2130837694;
+			
+			// aapt resource value: 0x7f0200bf
+			public const int ic_mr_button_connecting_04_dark = 2130837695;
+			
+			// aapt resource value: 0x7f0200c0
+			public const int ic_mr_button_connecting_04_light = 2130837696;
+			
+			// aapt resource value: 0x7f0200c1
+			public const int ic_mr_button_connecting_05_dark = 2130837697;
+			
+			// aapt resource value: 0x7f0200c2
+			public const int ic_mr_button_connecting_05_light = 2130837698;
+			
+			// aapt resource value: 0x7f0200c3
+			public const int ic_mr_button_connecting_06_dark = 2130837699;
+			
+			// aapt resource value: 0x7f0200c4
+			public const int ic_mr_button_connecting_06_light = 2130837700;
+			
+			// aapt resource value: 0x7f0200c5
+			public const int ic_mr_button_connecting_07_dark = 2130837701;
+			
+			// aapt resource value: 0x7f0200c6
+			public const int ic_mr_button_connecting_07_light = 2130837702;
+			
+			// aapt resource value: 0x7f0200c7
+			public const int ic_mr_button_connecting_08_dark = 2130837703;
+			
+			// aapt resource value: 0x7f0200c8
+			public const int ic_mr_button_connecting_08_light = 2130837704;
+			
+			// aapt resource value: 0x7f0200c9
+			public const int ic_mr_button_connecting_09_dark = 2130837705;
+			
+			// aapt resource value: 0x7f0200ca
+			public const int ic_mr_button_connecting_09_light = 2130837706;
+			
+			// aapt resource value: 0x7f0200cb
+			public const int ic_mr_button_connecting_10_dark = 2130837707;
+			
+			// aapt resource value: 0x7f0200cc
+			public const int ic_mr_button_connecting_10_light = 2130837708;
+			
+			// aapt resource value: 0x7f0200cd
+			public const int ic_mr_button_connecting_11_dark = 2130837709;
+			
+			// aapt resource value: 0x7f0200ce
+			public const int ic_mr_button_connecting_11_light = 2130837710;
+			
+			// aapt resource value: 0x7f0200cf
+			public const int ic_mr_button_connecting_12_dark = 2130837711;
+			
+			// aapt resource value: 0x7f0200d0
+			public const int ic_mr_button_connecting_12_light = 2130837712;
+			
+			// aapt resource value: 0x7f0200d1
+			public const int ic_mr_button_connecting_13_dark = 2130837713;
+			
+			// aapt resource value: 0x7f0200d2
+			public const int ic_mr_button_connecting_13_light = 2130837714;
+			
+			// aapt resource value: 0x7f0200d3
+			public const int ic_mr_button_connecting_14_dark = 2130837715;
+			
+			// aapt resource value: 0x7f0200d4
+			public const int ic_mr_button_connecting_14_light = 2130837716;
+			
+			// aapt resource value: 0x7f0200d5
+			public const int ic_mr_button_connecting_15_dark = 2130837717;
+			
+			// aapt resource value: 0x7f0200d6
+			public const int ic_mr_button_connecting_15_light = 2130837718;
+			
+			// aapt resource value: 0x7f0200d7
+			public const int ic_mr_button_connecting_16_dark = 2130837719;
+			
+			// aapt resource value: 0x7f0200d8
+			public const int ic_mr_button_connecting_16_light = 2130837720;
+			
+			// aapt resource value: 0x7f0200d9
+			public const int ic_mr_button_connecting_17_dark = 2130837721;
+			
+			// aapt resource value: 0x7f0200da
+			public const int ic_mr_button_connecting_17_light = 2130837722;
+			
+			// aapt resource value: 0x7f0200db
+			public const int ic_mr_button_connecting_18_dark = 2130837723;
+			
+			// aapt resource value: 0x7f0200dc
+			public const int ic_mr_button_connecting_18_light = 2130837724;
+			
+			// aapt resource value: 0x7f0200dd
+			public const int ic_mr_button_connecting_19_dark = 2130837725;
+			
+			// aapt resource value: 0x7f0200de
+			public const int ic_mr_button_connecting_19_light = 2130837726;
+			
+			// aapt resource value: 0x7f0200df
+			public const int ic_mr_button_connecting_20_dark = 2130837727;
+			
+			// aapt resource value: 0x7f0200e0
+			public const int ic_mr_button_connecting_20_light = 2130837728;
+			
+			// aapt resource value: 0x7f0200e1
+			public const int ic_mr_button_connecting_21_dark = 2130837729;
+			
+			// aapt resource value: 0x7f0200e2
+			public const int ic_mr_button_connecting_21_light = 2130837730;
+			
+			// aapt resource value: 0x7f0200e3
+			public const int ic_mr_button_connecting_22_dark = 2130837731;
+			
+			// aapt resource value: 0x7f0200e4
+			public const int ic_mr_button_connecting_22_light = 2130837732;
+			
+			// aapt resource value: 0x7f0200e5
+			public const int ic_mr_button_disabled_dark = 2130837733;
+			
+			// aapt resource value: 0x7f0200e6
+			public const int ic_mr_button_disabled_light = 2130837734;
+			
+			// aapt resource value: 0x7f0200e7
+			public const int ic_mr_button_disconnected_dark = 2130837735;
+			
+			// aapt resource value: 0x7f0200e8
+			public const int ic_mr_button_disconnected_light = 2130837736;
+			
+			// aapt resource value: 0x7f0200e9
+			public const int ic_mr_button_grey = 2130837737;
+			
+			// aapt resource value: 0x7f0200ea
+			public const int ic_vol_type_speaker_dark = 2130837738;
+			
+			// aapt resource value: 0x7f0200eb
+			public const int ic_vol_type_speaker_group_dark = 2130837739;
+			
+			// aapt resource value: 0x7f0200ec
+			public const int ic_vol_type_speaker_group_light = 2130837740;
+			
+			// aapt resource value: 0x7f0200ed
+			public const int ic_vol_type_speaker_light = 2130837741;
+			
+			// aapt resource value: 0x7f0200ee
+			public const int ic_vol_type_tv_dark = 2130837742;
+			
+			// aapt resource value: 0x7f0200ef
+			public const int ic_vol_type_tv_light = 2130837743;
+			
+			// aapt resource value: 0x7f0200f0
+			public const int list = 2130837744;
+			
+			// aapt resource value: 0x7f0200f1
+			public const int mr_button_connected_dark = 2130837745;
+			
+			// aapt resource value: 0x7f0200f2
+			public const int mr_button_connected_light = 2130837746;
+			
+			// aapt resource value: 0x7f0200f3
+			public const int mr_button_connecting_dark = 2130837747;
+			
+			// aapt resource value: 0x7f0200f4
+			public const int mr_button_connecting_light = 2130837748;
+			
+			// aapt resource value: 0x7f0200f5
+			public const int mr_button_dark = 2130837749;
+			
+			// aapt resource value: 0x7f0200f6
+			public const int mr_button_light = 2130837750;
+			
+			// aapt resource value: 0x7f0200f7
+			public const int mr_dialog_close_dark = 2130837751;
+			
+			// aapt resource value: 0x7f0200f8
+			public const int mr_dialog_close_light = 2130837752;
+			
+			// aapt resource value: 0x7f0200f9
+			public const int mr_dialog_material_background_dark = 2130837753;
+			
+			// aapt resource value: 0x7f0200fa
+			public const int mr_dialog_material_background_light = 2130837754;
+			
+			// aapt resource value: 0x7f0200fb
+			public const int mr_group_collapse = 2130837755;
+			
+			// aapt resource value: 0x7f0200fc
+			public const int mr_group_expand = 2130837756;
+			
+			// aapt resource value: 0x7f0200fd
+			public const int mr_media_pause_dark = 2130837757;
+			
+			// aapt resource value: 0x7f0200fe
+			public const int mr_media_pause_light = 2130837758;
+			
+			// aapt resource value: 0x7f0200ff
+			public const int mr_media_play_dark = 2130837759;
+			
+			// aapt resource value: 0x7f020100
+			public const int mr_media_play_light = 2130837760;
+			
+			// aapt resource value: 0x7f020101
+			public const int mr_media_stop_dark = 2130837761;
+			
+			// aapt resource value: 0x7f020102
+			public const int mr_media_stop_light = 2130837762;
+			
+			// aapt resource value: 0x7f020103
+			public const int mr_vol_type_audiotrack_dark = 2130837763;
+			
+			// aapt resource value: 0x7f020104
+			public const int mr_vol_type_audiotrack_light = 2130837764;
+			
+			// aapt resource value: 0x7f020105
+			public const int navigation_empty_icon = 2130837765;
+			
+			// aapt resource value: 0x7f020106
+			public const int notification_action_background = 2130837766;
+			
+			// aapt resource value: 0x7f020107
+			public const int notification_bg = 2130837767;
+			
+			// aapt resource value: 0x7f020108
+			public const int notification_bg_low = 2130837768;
+			
+			// aapt resource value: 0x7f020109
+			public const int notification_bg_low_normal = 2130837769;
+			
+			// aapt resource value: 0x7f02010a
+			public const int notification_bg_low_pressed = 2130837770;
+			
+			// aapt resource value: 0x7f02010b
+			public const int notification_bg_normal = 2130837771;
+			
+			// aapt resource value: 0x7f02010c
+			public const int notification_bg_normal_pressed = 2130837772;
+			
+			// aapt resource value: 0x7f02010d
+			public const int notification_icon_background = 2130837773;
+			
+			// aapt resource value: 0x7f020112
+			public const int notification_template_icon_bg = 2130837778;
+			
+			// aapt resource value: 0x7f020113
+			public const int notification_template_icon_low_bg = 2130837779;
+			
+			// aapt resource value: 0x7f02010e
+			public const int notification_tile_bg = 2130837774;
+			
+			// aapt resource value: 0x7f02010f
+			public const int notify_panel_notification_icon_bg = 2130837775;
+			
+			// aapt resource value: 0x7f020110
+			public const int plus = 2130837776;
+			
+			// aapt resource value: 0x7f020111
+			public const int xml = 2130837777;
 			
 			static Drawable()
 			{
@@ -4087,467 +4970,545 @@ namespace FABSample.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0b008b
-			public const int action0 = 2131427467;
+			// aapt resource value: 0x7f08009c
+			public const int action0 = 2131230876;
 			
-			// aapt resource value: 0x7f0b005a
-			public const int action_bar = 2131427418;
+			// aapt resource value: 0x7f080064
+			public const int action_bar = 2131230820;
 			
-			// aapt resource value: 0x7f0b0001
-			public const int action_bar_activity_content = 2131427329;
+			// aapt resource value: 0x7f080001
+			public const int action_bar_activity_content = 2131230721;
 			
-			// aapt resource value: 0x7f0b0059
-			public const int action_bar_container = 2131427417;
+			// aapt resource value: 0x7f080063
+			public const int action_bar_container = 2131230819;
 			
-			// aapt resource value: 0x7f0b0055
-			public const int action_bar_root = 2131427413;
+			// aapt resource value: 0x7f08005f
+			public const int action_bar_root = 2131230815;
 			
-			// aapt resource value: 0x7f0b0002
-			public const int action_bar_spinner = 2131427330;
+			// aapt resource value: 0x7f080002
+			public const int action_bar_spinner = 2131230722;
 			
-			// aapt resource value: 0x7f0b003b
-			public const int action_bar_subtitle = 2131427387;
+			// aapt resource value: 0x7f080042
+			public const int action_bar_subtitle = 2131230786;
 			
-			// aapt resource value: 0x7f0b003a
-			public const int action_bar_title = 2131427386;
+			// aapt resource value: 0x7f080041
+			public const int action_bar_title = 2131230785;
 			
-			// aapt resource value: 0x7f0b005b
-			public const int action_context_bar = 2131427419;
+			// aapt resource value: 0x7f080099
+			public const int action_container = 2131230873;
 			
-			// aapt resource value: 0x7f0b008f
-			public const int action_divider = 2131427471;
+			// aapt resource value: 0x7f080065
+			public const int action_context_bar = 2131230821;
 			
-			// aapt resource value: 0x7f0b0003
-			public const int action_menu_divider = 2131427331;
+			// aapt resource value: 0x7f0800a0
+			public const int action_divider = 2131230880;
 			
-			// aapt resource value: 0x7f0b0004
-			public const int action_menu_presenter = 2131427332;
+			// aapt resource value: 0x7f08009a
+			public const int action_image = 2131230874;
 			
-			// aapt resource value: 0x7f0b0057
-			public const int action_mode_bar = 2131427415;
+			// aapt resource value: 0x7f080003
+			public const int action_menu_divider = 2131230723;
 			
-			// aapt resource value: 0x7f0b0056
-			public const int action_mode_bar_stub = 2131427414;
+			// aapt resource value: 0x7f080004
+			public const int action_menu_presenter = 2131230724;
 			
-			// aapt resource value: 0x7f0b003c
-			public const int action_mode_close_button = 2131427388;
+			// aapt resource value: 0x7f080061
+			public const int action_mode_bar = 2131230817;
 			
-			// aapt resource value: 0x7f0b003d
-			public const int activity_chooser_view_content = 2131427389;
+			// aapt resource value: 0x7f080060
+			public const int action_mode_bar_stub = 2131230816;
 			
-			// aapt resource value: 0x7f0b0049
-			public const int alertTitle = 2131427401;
+			// aapt resource value: 0x7f080043
+			public const int action_mode_close_button = 2131230787;
 			
-			// aapt resource value: 0x7f0b0035
-			public const int always = 2131427381;
+			// aapt resource value: 0x7f08009b
+			public const int action_text = 2131230875;
 			
-			// aapt resource value: 0x7f0b0033
-			public const int beginning = 2131427379;
+			// aapt resource value: 0x7f0800a9
+			public const int actions = 2131230889;
 			
-			// aapt resource value: 0x7f0b0013
-			public const int bottom = 2131427347;
+			// aapt resource value: 0x7f080044
+			public const int activity_chooser_view_content = 2131230788;
 			
-			// aapt resource value: 0x7f0b0044
-			public const int buttonPanel = 2131427396;
+			// aapt resource value: 0x7f080019
+			public const int add = 2131230745;
 			
-			// aapt resource value: 0x7f0b008c
-			public const int cancel_action = 2131427468;
+			// aapt resource value: 0x7f080058
+			public const int alertTitle = 2131230808;
 			
-			// aapt resource value: 0x7f0b0014
-			public const int center = 2131427348;
+			// aapt resource value: 0x7f08003d
+			public const int all = 2131230781;
 			
-			// aapt resource value: 0x7f0b0015
-			public const int center_horizontal = 2131427349;
+			// aapt resource value: 0x7f080023
+			public const int always = 2131230755;
 			
-			// aapt resource value: 0x7f0b0016
-			public const int center_vertical = 2131427350;
+			// aapt resource value: 0x7f08002f
+			public const int auto = 2131230767;
 			
-			// aapt resource value: 0x7f0b0052
-			public const int checkbox = 2131427410;
+			// aapt resource value: 0x7f080020
+			public const int beginning = 2131230752;
 			
-			// aapt resource value: 0x7f0b0092
-			public const int chronometer = 2131427474;
+			// aapt resource value: 0x7f080028
+			public const int bottom = 2131230760;
 			
-			// aapt resource value: 0x7f0b001d
-			public const int clip_horizontal = 2131427357;
+			// aapt resource value: 0x7f08004b
+			public const int buttonPanel = 2131230795;
 			
-			// aapt resource value: 0x7f0b001e
-			public const int clip_vertical = 2131427358;
+			// aapt resource value: 0x7f08009d
+			public const int cancel_action = 2131230877;
 			
-			// aapt resource value: 0x7f0b0036
-			public const int collapseActionView = 2131427382;
+			// aapt resource value: 0x7f080030
+			public const int center = 2131230768;
 			
-			// aapt resource value: 0x7f0b004a
-			public const int contentPanel = 2131427402;
+			// aapt resource value: 0x7f080031
+			public const int center_horizontal = 2131230769;
 			
-			// aapt resource value: 0x7f0b0050
-			public const int custom = 2131427408;
+			// aapt resource value: 0x7f080032
+			public const int center_vertical = 2131230770;
 			
-			// aapt resource value: 0x7f0b004f
-			public const int customPanel = 2131427407;
+			// aapt resource value: 0x7f08005b
+			public const int checkbox = 2131230811;
 			
-			// aapt resource value: 0x7f0b0058
-			public const int decor_content_parent = 2131427416;
+			// aapt resource value: 0x7f0800a5
+			public const int chronometer = 2131230885;
 			
-			// aapt resource value: 0x7f0b0040
-			public const int default_activity_button = 2131427392;
+			// aapt resource value: 0x7f080039
+			public const int clip_horizontal = 2131230777;
 			
-			// aapt resource value: 0x7f0b006a
-			public const int design_bottom_sheet = 2131427434;
+			// aapt resource value: 0x7f08003a
+			public const int clip_vertical = 2131230778;
 			
-			// aapt resource value: 0x7f0b0071
-			public const int design_menu_item_action_area = 2131427441;
+			// aapt resource value: 0x7f080024
+			public const int collapseActionView = 2131230756;
 			
-			// aapt resource value: 0x7f0b0070
-			public const int design_menu_item_action_area_stub = 2131427440;
+			// aapt resource value: 0x7f08004e
+			public const int contentPanel = 2131230798;
 			
-			// aapt resource value: 0x7f0b006f
-			public const int design_menu_item_text = 2131427439;
+			// aapt resource value: 0x7f080055
+			public const int custom = 2131230805;
 			
-			// aapt resource value: 0x7f0b006e
-			public const int design_navigation_view = 2131427438;
+			// aapt resource value: 0x7f080054
+			public const int customPanel = 2131230804;
 			
-			// aapt resource value: 0x7f0b0027
-			public const int disableHome = 2131427367;
+			// aapt resource value: 0x7f080062
+			public const int decor_content_parent = 2131230818;
 			
-			// aapt resource value: 0x7f0b005c
-			public const int edit_query = 2131427420;
+			// aapt resource value: 0x7f080047
+			public const int default_activity_button = 2131230791;
 			
-			// aapt resource value: 0x7f0b0017
-			public const int end = 2131427351;
+			// aapt resource value: 0x7f080076
+			public const int design_bottom_sheet = 2131230838;
 			
-			// aapt resource value: 0x7f0b0097
-			public const int end_padder = 2131427479;
+			// aapt resource value: 0x7f08007d
+			public const int design_menu_item_action_area = 2131230845;
 			
-			// aapt resource value: 0x7f0b000b
-			public const int enterAlways = 2131427339;
+			// aapt resource value: 0x7f08007c
+			public const int design_menu_item_action_area_stub = 2131230844;
 			
-			// aapt resource value: 0x7f0b000c
-			public const int enterAlwaysCollapsed = 2131427340;
+			// aapt resource value: 0x7f08007b
+			public const int design_menu_item_text = 2131230843;
 			
-			// aapt resource value: 0x7f0b000d
-			public const int exitUntilCollapsed = 2131427341;
+			// aapt resource value: 0x7f08007a
+			public const int design_navigation_view = 2131230842;
 			
-			// aapt resource value: 0x7f0b003e
-			public const int expand_activities_button = 2131427390;
+			// aapt resource value: 0x7f080012
+			public const int disableHome = 2131230738;
 			
-			// aapt resource value: 0x7f0b0051
-			public const int expanded_menu = 2131427409;
+			// aapt resource value: 0x7f080066
+			public const int edit_query = 2131230822;
 			
-			// aapt resource value: 0x7f0b001f
-			public const int fill = 2131427359;
+			// aapt resource value: 0x7f080021
+			public const int end = 2131230753;
 			
-			// aapt resource value: 0x7f0b0020
-			public const int fill_horizontal = 2131427360;
+			// aapt resource value: 0x7f0800af
+			public const int end_padder = 2131230895;
 			
-			// aapt resource value: 0x7f0b0018
-			public const int fill_vertical = 2131427352;
+			// aapt resource value: 0x7f08002a
+			public const int enterAlways = 2131230762;
 			
-			// aapt resource value: 0x7f0b0023
-			public const int @fixed = 2131427363;
+			// aapt resource value: 0x7f08002b
+			public const int enterAlwaysCollapsed = 2131230763;
 			
-			// aapt resource value: 0x7f0b0005
-			public const int home = 2131427333;
+			// aapt resource value: 0x7f08002c
+			public const int exitUntilCollapsed = 2131230764;
 			
-			// aapt resource value: 0x7f0b0028
-			public const int homeAsUp = 2131427368;
+			// aapt resource value: 0x7f080045
+			public const int expand_activities_button = 2131230789;
 			
-			// aapt resource value: 0x7f0b0042
-			public const int icon = 2131427394;
+			// aapt resource value: 0x7f08005a
+			public const int expanded_menu = 2131230810;
 			
-			// aapt resource value: 0x7f0b0037
-			public const int ifRoom = 2131427383;
+			// aapt resource value: 0x7f08003b
+			public const int fill = 2131230779;
 			
-			// aapt resource value: 0x7f0b003f
-			public const int image = 2131427391;
+			// aapt resource value: 0x7f08003c
+			public const int fill_horizontal = 2131230780;
 			
-			// aapt resource value: 0x7f0b0096
-			public const int info = 2131427478;
+			// aapt resource value: 0x7f080033
+			public const int fill_vertical = 2131230771;
 			
-			// aapt resource value: 0x7f0b000a
-			public const int item_touch_helper_previous_elevation = 2131427338;
+			// aapt resource value: 0x7f08003f
+			public const int @fixed = 2131230783;
 			
-			// aapt resource value: 0x7f0b0019
-			public const int left = 2131427353;
+			// aapt resource value: 0x7f080005
+			public const int home = 2131230725;
 			
-			// aapt resource value: 0x7f0b0090
-			public const int line1 = 2131427472;
+			// aapt resource value: 0x7f080013
+			public const int homeAsUp = 2131230739;
 			
-			// aapt resource value: 0x7f0b0094
-			public const int line3 = 2131427476;
+			// aapt resource value: 0x7f080049
+			public const int icon = 2131230793;
 			
-			// aapt resource value: 0x7f0b0025
-			public const int listMode = 2131427365;
+			// aapt resource value: 0x7f0800aa
+			public const int icon_group = 2131230890;
 			
-			// aapt resource value: 0x7f0b0041
-			public const int list_item = 2131427393;
+			// aapt resource value: 0x7f080025
+			public const int ifRoom = 2131230757;
 			
-			// aapt resource value: 0x7f0b008e
-			public const int media_actions = 2131427470;
+			// aapt resource value: 0x7f080046
+			public const int image = 2131230790;
 			
-			// aapt resource value: 0x7f0b0034
-			public const int middle = 2131427380;
+			// aapt resource value: 0x7f0800a6
+			public const int info = 2131230886;
 			
-			// aapt resource value: 0x7f0b0021
-			public const int mini = 2131427361;
+			// aapt resource value: 0x7f080000
+			public const int item_touch_helper_previous_elevation = 2131230720;
 			
-			// aapt resource value: 0x7f0b007d
-			public const int mr_art = 2131427453;
+			// aapt resource value: 0x7f080074
+			public const int largeLabel = 2131230836;
 			
-			// aapt resource value: 0x7f0b0072
-			public const int mr_chooser_list = 2131427442;
+			// aapt resource value: 0x7f080034
+			public const int left = 2131230772;
 			
-			// aapt resource value: 0x7f0b0075
-			public const int mr_chooser_route_desc = 2131427445;
+			// aapt resource value: 0x7f0800ab
+			public const int line1 = 2131230891;
 			
-			// aapt resource value: 0x7f0b0073
-			public const int mr_chooser_route_icon = 2131427443;
+			// aapt resource value: 0x7f0800ad
+			public const int line3 = 2131230893;
 			
-			// aapt resource value: 0x7f0b0074
-			public const int mr_chooser_route_name = 2131427444;
+			// aapt resource value: 0x7f08000f
+			public const int listMode = 2131230735;
 			
-			// aapt resource value: 0x7f0b007a
-			public const int mr_close = 2131427450;
+			// aapt resource value: 0x7f080048
+			public const int list_item = 2131230792;
 			
-			// aapt resource value: 0x7f0b0080
-			public const int mr_control_divider = 2131427456;
+			// aapt resource value: 0x7f0800b3
+			public const int masked = 2131230899;
 			
-			// aapt resource value: 0x7f0b0086
-			public const int mr_control_play_pause = 2131427462;
+			// aapt resource value: 0x7f08009f
+			public const int media_actions = 2131230879;
 			
-			// aapt resource value: 0x7f0b0089
-			public const int mr_control_subtitle = 2131427465;
+			// aapt resource value: 0x7f080022
+			public const int middle = 2131230754;
 			
-			// aapt resource value: 0x7f0b0088
-			public const int mr_control_title = 2131427464;
+			// aapt resource value: 0x7f08003e
+			public const int mini = 2131230782;
 			
-			// aapt resource value: 0x7f0b0087
-			public const int mr_control_title_container = 2131427463;
+			// aapt resource value: 0x7f08008b
+			public const int mr_art = 2131230859;
 			
-			// aapt resource value: 0x7f0b007b
-			public const int mr_custom_control = 2131427451;
+			// aapt resource value: 0x7f080080
+			public const int mr_chooser_list = 2131230848;
 			
-			// aapt resource value: 0x7f0b007c
-			public const int mr_default_control = 2131427452;
+			// aapt resource value: 0x7f080083
+			public const int mr_chooser_route_desc = 2131230851;
 			
-			// aapt resource value: 0x7f0b0077
-			public const int mr_dialog_area = 2131427447;
+			// aapt resource value: 0x7f080081
+			public const int mr_chooser_route_icon = 2131230849;
 			
-			// aapt resource value: 0x7f0b0076
-			public const int mr_expandable_area = 2131427446;
+			// aapt resource value: 0x7f080082
+			public const int mr_chooser_route_name = 2131230850;
 			
-			// aapt resource value: 0x7f0b008a
-			public const int mr_group_expand_collapse = 2131427466;
+			// aapt resource value: 0x7f08007f
+			public const int mr_chooser_title = 2131230847;
 			
-			// aapt resource value: 0x7f0b007e
-			public const int mr_media_main_control = 2131427454;
+			// aapt resource value: 0x7f080088
+			public const int mr_close = 2131230856;
 			
-			// aapt resource value: 0x7f0b0079
-			public const int mr_name = 2131427449;
+			// aapt resource value: 0x7f08008e
+			public const int mr_control_divider = 2131230862;
 			
-			// aapt resource value: 0x7f0b007f
-			public const int mr_playback_control = 2131427455;
+			// aapt resource value: 0x7f080094
+			public const int mr_control_playback_ctrl = 2131230868;
 			
-			// aapt resource value: 0x7f0b0078
-			public const int mr_title_bar = 2131427448;
+			// aapt resource value: 0x7f080097
+			public const int mr_control_subtitle = 2131230871;
 			
-			// aapt resource value: 0x7f0b0081
-			public const int mr_volume_control = 2131427457;
+			// aapt resource value: 0x7f080096
+			public const int mr_control_title = 2131230870;
 			
-			// aapt resource value: 0x7f0b0082
-			public const int mr_volume_group_list = 2131427458;
+			// aapt resource value: 0x7f080095
+			public const int mr_control_title_container = 2131230869;
 			
-			// aapt resource value: 0x7f0b0084
-			public const int mr_volume_item_icon = 2131427460;
+			// aapt resource value: 0x7f080089
+			public const int mr_custom_control = 2131230857;
 			
-			// aapt resource value: 0x7f0b0085
-			public const int mr_volume_slider = 2131427461;
+			// aapt resource value: 0x7f08008a
+			public const int mr_default_control = 2131230858;
 			
-			// aapt resource value: 0x7f0b002e
-			public const int multiply = 2131427374;
+			// aapt resource value: 0x7f080085
+			public const int mr_dialog_area = 2131230853;
 			
-			// aapt resource value: 0x7f0b006d
-			public const int navigation_header_container = 2131427437;
+			// aapt resource value: 0x7f080084
+			public const int mr_expandable_area = 2131230852;
 			
-			// aapt resource value: 0x7f0b0038
-			public const int never = 2131427384;
+			// aapt resource value: 0x7f080098
+			public const int mr_group_expand_collapse = 2131230872;
 			
-			// aapt resource value: 0x7f0b0010
-			public const int none = 2131427344;
+			// aapt resource value: 0x7f08008c
+			public const int mr_media_main_control = 2131230860;
 			
-			// aapt resource value: 0x7f0b0022
-			public const int normal = 2131427362;
+			// aapt resource value: 0x7f080087
+			public const int mr_name = 2131230855;
 			
-			// aapt resource value: 0x7f0b0011
-			public const int parallax = 2131427345;
+			// aapt resource value: 0x7f08008d
+			public const int mr_playback_control = 2131230861;
 			
-			// aapt resource value: 0x7f0b0046
-			public const int parentPanel = 2131427398;
+			// aapt resource value: 0x7f080086
+			public const int mr_title_bar = 2131230854;
 			
-			// aapt resource value: 0x7f0b0012
-			public const int pin = 2131427346;
+			// aapt resource value: 0x7f08008f
+			public const int mr_volume_control = 2131230863;
 			
-			// aapt resource value: 0x7f0b0006
-			public const int progress_circular = 2131427334;
+			// aapt resource value: 0x7f080090
+			public const int mr_volume_group_list = 2131230864;
 			
-			// aapt resource value: 0x7f0b0007
-			public const int progress_horizontal = 2131427335;
+			// aapt resource value: 0x7f080092
+			public const int mr_volume_item_icon = 2131230866;
 			
-			// aapt resource value: 0x7f0b0054
-			public const int radio = 2131427412;
+			// aapt resource value: 0x7f080093
+			public const int mr_volume_slider = 2131230867;
 			
-			// aapt resource value: 0x7f0b001a
-			public const int right = 2131427354;
+			// aapt resource value: 0x7f08001a
+			public const int multiply = 2131230746;
 			
-			// aapt resource value: 0x7f0b002f
-			public const int screen = 2131427375;
+			// aapt resource value: 0x7f080079
+			public const int navigation_header_container = 2131230841;
 			
-			// aapt resource value: 0x7f0b000e
-			public const int scroll = 2131427342;
+			// aapt resource value: 0x7f080026
+			public const int never = 2131230758;
 			
-			// aapt resource value: 0x7f0b004e
-			public const int scrollIndicatorDown = 2131427406;
+			// aapt resource value: 0x7f080014
+			public const int none = 2131230740;
 			
-			// aapt resource value: 0x7f0b004b
-			public const int scrollIndicatorUp = 2131427403;
+			// aapt resource value: 0x7f080010
+			public const int normal = 2131230736;
 			
-			// aapt resource value: 0x7f0b004c
-			public const int scrollView = 2131427404;
+			// aapt resource value: 0x7f0800a8
+			public const int notification_background = 2131230888;
 			
-			// aapt resource value: 0x7f0b0024
-			public const int scrollable = 2131427364;
+			// aapt resource value: 0x7f0800a2
+			public const int notification_main_column = 2131230882;
 			
-			// aapt resource value: 0x7f0b005e
-			public const int search_badge = 2131427422;
+			// aapt resource value: 0x7f0800a1
+			public const int notification_main_column_container = 2131230881;
 			
-			// aapt resource value: 0x7f0b005d
-			public const int search_bar = 2131427421;
+			// aapt resource value: 0x7f080037
+			public const int parallax = 2131230775;
 			
-			// aapt resource value: 0x7f0b005f
-			public const int search_button = 2131427423;
+			// aapt resource value: 0x7f08004d
+			public const int parentPanel = 2131230797;
 			
-			// aapt resource value: 0x7f0b0064
-			public const int search_close_btn = 2131427428;
+			// aapt resource value: 0x7f080038
+			public const int pin = 2131230776;
 			
-			// aapt resource value: 0x7f0b0060
-			public const int search_edit_frame = 2131427424;
+			// aapt resource value: 0x7f080006
+			public const int progress_circular = 2131230726;
 			
-			// aapt resource value: 0x7f0b0066
-			public const int search_go_btn = 2131427430;
+			// aapt resource value: 0x7f080007
+			public const int progress_horizontal = 2131230727;
 			
-			// aapt resource value: 0x7f0b0061
-			public const int search_mag_icon = 2131427425;
+			// aapt resource value: 0x7f08005d
+			public const int radio = 2131230813;
 			
-			// aapt resource value: 0x7f0b0062
-			public const int search_plate = 2131427426;
+			// aapt resource value: 0x7f080035
+			public const int right = 2131230773;
 			
-			// aapt resource value: 0x7f0b0063
-			public const int search_src_text = 2131427427;
+			// aapt resource value: 0x7f0800a7
+			public const int right_icon = 2131230887;
 			
-			// aapt resource value: 0x7f0b0067
-			public const int search_voice_btn = 2131427431;
+			// aapt resource value: 0x7f0800a3
+			public const int right_side = 2131230883;
 			
-			// aapt resource value: 0x7f0b0068
-			public const int select_dialog_listview = 2131427432;
+			// aapt resource value: 0x7f08001b
+			public const int screen = 2131230747;
 			
-			// aapt resource value: 0x7f0b0053
-			public const int shortcut = 2131427411;
+			// aapt resource value: 0x7f08002d
+			public const int scroll = 2131230765;
 			
-			// aapt resource value: 0x7f0b0029
-			public const int showCustom = 2131427369;
+			// aapt resource value: 0x7f080053
+			public const int scrollIndicatorDown = 2131230803;
 			
-			// aapt resource value: 0x7f0b002a
-			public const int showHome = 2131427370;
+			// aapt resource value: 0x7f08004f
+			public const int scrollIndicatorUp = 2131230799;
 			
-			// aapt resource value: 0x7f0b002b
-			public const int showTitle = 2131427371;
+			// aapt resource value: 0x7f080050
+			public const int scrollView = 2131230800;
 			
-			// aapt resource value: 0x7f0b0098
-			public const int sliding_tabs = 2131427480;
+			// aapt resource value: 0x7f080040
+			public const int scrollable = 2131230784;
 			
-			// aapt resource value: 0x7f0b006c
-			public const int snackbar_action = 2131427436;
+			// aapt resource value: 0x7f080068
+			public const int search_badge = 2131230824;
 			
-			// aapt resource value: 0x7f0b006b
-			public const int snackbar_text = 2131427435;
+			// aapt resource value: 0x7f080067
+			public const int search_bar = 2131230823;
 			
-			// aapt resource value: 0x7f0b000f
-			public const int snap = 2131427343;
+			// aapt resource value: 0x7f080069
+			public const int search_button = 2131230825;
 			
-			// aapt resource value: 0x7f0b0045
-			public const int spacer = 2131427397;
+			// aapt resource value: 0x7f08006e
+			public const int search_close_btn = 2131230830;
 			
-			// aapt resource value: 0x7f0b0008
-			public const int split_action_bar = 2131427336;
+			// aapt resource value: 0x7f08006a
+			public const int search_edit_frame = 2131230826;
 			
-			// aapt resource value: 0x7f0b0030
-			public const int src_atop = 2131427376;
+			// aapt resource value: 0x7f080070
+			public const int search_go_btn = 2131230832;
 			
-			// aapt resource value: 0x7f0b0031
-			public const int src_in = 2131427377;
+			// aapt resource value: 0x7f08006b
+			public const int search_mag_icon = 2131230827;
 			
-			// aapt resource value: 0x7f0b0032
-			public const int src_over = 2131427378;
+			// aapt resource value: 0x7f08006c
+			public const int search_plate = 2131230828;
 			
-			// aapt resource value: 0x7f0b001b
-			public const int start = 2131427355;
+			// aapt resource value: 0x7f08006d
+			public const int search_src_text = 2131230829;
 			
-			// aapt resource value: 0x7f0b008d
-			public const int status_bar_latest_event_content = 2131427469;
+			// aapt resource value: 0x7f080071
+			public const int search_voice_btn = 2131230833;
 			
-			// aapt resource value: 0x7f0b0065
-			public const int submit_area = 2131427429;
+			// aapt resource value: 0x7f080072
+			public const int select_dialog_listview = 2131230834;
 			
-			// aapt resource value: 0x7f0b0026
-			public const int tabMode = 2131427366;
+			// aapt resource value: 0x7f08005c
+			public const int shortcut = 2131230812;
 			
-			// aapt resource value: 0x7f0b0095
-			public const int text = 2131427477;
+			// aapt resource value: 0x7f080015
+			public const int showCustom = 2131230741;
 			
-			// aapt resource value: 0x7f0b0093
-			public const int text2 = 2131427475;
+			// aapt resource value: 0x7f080016
+			public const int showHome = 2131230742;
 			
-			// aapt resource value: 0x7f0b004d
-			public const int textSpacerNoButtons = 2131427405;
+			// aapt resource value: 0x7f080017
+			public const int showTitle = 2131230743;
 			
-			// aapt resource value: 0x7f0b0091
-			public const int time = 2131427473;
+			// aapt resource value: 0x7f0800b0
+			public const int sliding_tabs = 2131230896;
 			
-			// aapt resource value: 0x7f0b0043
-			public const int title = 2131427395;
+			// aapt resource value: 0x7f080073
+			public const int smallLabel = 2131230835;
 			
-			// aapt resource value: 0x7f0b0048
-			public const int title_template = 2131427400;
+			// aapt resource value: 0x7f080078
+			public const int snackbar_action = 2131230840;
 			
-			// aapt resource value: 0x7f0b0099
-			public const int toolbar = 2131427481;
+			// aapt resource value: 0x7f080077
+			public const int snackbar_text = 2131230839;
 			
-			// aapt resource value: 0x7f0b001c
-			public const int top = 2131427356;
+			// aapt resource value: 0x7f08002e
+			public const int snap = 2131230766;
 			
-			// aapt resource value: 0x7f0b0047
-			public const int topPanel = 2131427399;
+			// aapt resource value: 0x7f08004c
+			public const int spacer = 2131230796;
 			
-			// aapt resource value: 0x7f0b0069
-			public const int touch_outside = 2131427433;
+			// aapt resource value: 0x7f080008
+			public const int split_action_bar = 2131230728;
 			
-			// aapt resource value: 0x7f0b0009
-			public const int up = 2131427337;
+			// aapt resource value: 0x7f08001c
+			public const int src_atop = 2131230748;
 			
-			// aapt resource value: 0x7f0b002c
-			public const int useLogo = 2131427372;
+			// aapt resource value: 0x7f08001d
+			public const int src_in = 2131230749;
 			
-			// aapt resource value: 0x7f0b0000
-			public const int view_offset_helper = 2131427328;
+			// aapt resource value: 0x7f08001e
+			public const int src_over = 2131230750;
 			
-			// aapt resource value: 0x7f0b0083
-			public const int volume_item_container = 2131427459;
+			// aapt resource value: 0x7f080036
+			public const int start = 2131230774;
 			
-			// aapt resource value: 0x7f0b0039
-			public const int withText = 2131427385;
+			// aapt resource value: 0x7f08009e
+			public const int status_bar_latest_event_content = 2131230878;
 			
-			// aapt resource value: 0x7f0b002d
-			public const int wrap_content = 2131427373;
+			// aapt resource value: 0x7f08005e
+			public const int submenuarrow = 2131230814;
+			
+			// aapt resource value: 0x7f08006f
+			public const int submit_area = 2131230831;
+			
+			// aapt resource value: 0x7f080011
+			public const int tabMode = 2131230737;
+			
+			// aapt resource value: 0x7f0800ae
+			public const int text = 2131230894;
+			
+			// aapt resource value: 0x7f0800ac
+			public const int text2 = 2131230892;
+			
+			// aapt resource value: 0x7f080052
+			public const int textSpacerNoButtons = 2131230802;
+			
+			// aapt resource value: 0x7f080051
+			public const int textSpacerNoTitle = 2131230801;
+			
+			// aapt resource value: 0x7f08007e
+			public const int text_input_password_toggle = 2131230846;
+			
+			// aapt resource value: 0x7f08000c
+			public const int textinput_counter = 2131230732;
+			
+			// aapt resource value: 0x7f08000d
+			public const int textinput_error = 2131230733;
+			
+			// aapt resource value: 0x7f0800a4
+			public const int time = 2131230884;
+			
+			// aapt resource value: 0x7f08004a
+			public const int title = 2131230794;
+			
+			// aapt resource value: 0x7f080059
+			public const int titleDividerNoCustom = 2131230809;
+			
+			// aapt resource value: 0x7f080057
+			public const int title_template = 2131230807;
+			
+			// aapt resource value: 0x7f0800b1
+			public const int toolbar = 2131230897;
+			
+			// aapt resource value: 0x7f080029
+			public const int top = 2131230761;
+			
+			// aapt resource value: 0x7f080056
+			public const int topPanel = 2131230806;
+			
+			// aapt resource value: 0x7f080075
+			public const int touch_outside = 2131230837;
+			
+			// aapt resource value: 0x7f08000a
+			public const int transition_current_scene = 2131230730;
+			
+			// aapt resource value: 0x7f08000b
+			public const int transition_scene_layoutid_cache = 2131230731;
+			
+			// aapt resource value: 0x7f080009
+			public const int up = 2131230729;
+			
+			// aapt resource value: 0x7f080018
+			public const int useLogo = 2131230744;
+			
+			// aapt resource value: 0x7f08000e
+			public const int view_offset_helper = 2131230734;
+			
+			// aapt resource value: 0x7f0800b2
+			public const int visible = 2131230898;
+			
+			// aapt resource value: 0x7f080091
+			public const int volume_item_container = 2131230865;
+			
+			// aapt resource value: 0x7f080027
+			public const int withText = 2131230759;
+			
+			// aapt resource value: 0x7f08001f
+			public const int wrap_content = 2131230751;
 			
 			static Id()
 			{
@@ -4562,35 +5523,41 @@ namespace FABSample.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f080006
-			public const int abc_config_activityDefaultDur = 2131230726;
+			// aapt resource value: 0x7f0a0003
+			public const int abc_config_activityDefaultDur = 2131361795;
 			
-			// aapt resource value: 0x7f080007
-			public const int abc_config_activityShortDur = 2131230727;
+			// aapt resource value: 0x7f0a0004
+			public const int abc_config_activityShortDur = 2131361796;
 			
-			// aapt resource value: 0x7f080005
-			public const int abc_max_action_buttons = 2131230725;
+			// aapt resource value: 0x7f0a0008
+			public const int app_bar_elevation_anim_duration = 2131361800;
 			
-			// aapt resource value: 0x7f080004
-			public const int bottom_sheet_slide_duration = 2131230724;
+			// aapt resource value: 0x7f0a0009
+			public const int bottom_sheet_slide_duration = 2131361801;
 			
-			// aapt resource value: 0x7f080008
-			public const int cancel_button_image_alpha = 2131230728;
+			// aapt resource value: 0x7f0a0005
+			public const int cancel_button_image_alpha = 2131361797;
 			
-			// aapt resource value: 0x7f080003
-			public const int design_snackbar_text_max_lines = 2131230723;
+			// aapt resource value: 0x7f0a0007
+			public const int design_snackbar_text_max_lines = 2131361799;
 			
-			// aapt resource value: 0x7f080000
-			public const int mr_controller_volume_group_list_animation_duration_ms = 2131230720;
+			// aapt resource value: 0x7f0a000a
+			public const int hide_password_duration = 2131361802;
 			
-			// aapt resource value: 0x7f080001
-			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131230721;
+			// aapt resource value: 0x7f0a0000
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131361792;
 			
-			// aapt resource value: 0x7f080002
-			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131230722;
+			// aapt resource value: 0x7f0a0001
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131361793;
 			
-			// aapt resource value: 0x7f080009
-			public const int status_bar_notification_info_maxnum = 2131230729;
+			// aapt resource value: 0x7f0a0002
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131361794;
+			
+			// aapt resource value: 0x7f0a000b
+			public const int show_password_duration = 2131361803;
+			
+			// aapt resource value: 0x7f0a0006
+			public const int status_bar_notification_info_maxnum = 2131361798;
 			
 			static Integer()
 			{
@@ -4605,11 +5572,11 @@ namespace FABSample.Droid
 		public partial class Interpolator
 		{
 			
-			// aapt resource value: 0x7f050000
-			public const int mr_fast_out_slow_in = 2131034112;
+			// aapt resource value: 0x7f060000
+			public const int mr_fast_out_slow_in = 2131099648;
 			
-			// aapt resource value: 0x7f050001
-			public const int mr_linear_out_slow_in = 2131034113;
+			// aapt resource value: 0x7f060001
+			public const int mr_linear_out_slow_in = 2131099649;
 			
 			static Interpolator()
 			{
@@ -4658,148 +5625,181 @@ namespace FABSample.Droid
 			public const int abc_alert_dialog_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public const int abc_dialog_title_material = 2130903051;
+			public const int abc_alert_dialog_title_material = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public const int abc_expanded_menu_layout = 2130903052;
+			public const int abc_dialog_title_material = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public const int abc_list_menu_item_checkbox = 2130903053;
+			public const int abc_expanded_menu_layout = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public const int abc_list_menu_item_icon = 2130903054;
+			public const int abc_list_menu_item_checkbox = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public const int abc_list_menu_item_layout = 2130903055;
+			public const int abc_list_menu_item_icon = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public const int abc_list_menu_item_radio = 2130903056;
+			public const int abc_list_menu_item_layout = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public const int abc_popup_menu_item_layout = 2130903057;
+			public const int abc_list_menu_item_radio = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public const int abc_screen_content_include = 2130903058;
+			public const int abc_popup_menu_header_item_layout = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public const int abc_screen_simple = 2130903059;
+			public const int abc_popup_menu_item_layout = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public const int abc_screen_simple_overlay_action_mode = 2130903060;
+			public const int abc_screen_content_include = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public const int abc_screen_toolbar = 2130903061;
+			public const int abc_screen_simple = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public const int abc_search_dropdown_item_icons_2line = 2130903062;
+			public const int abc_screen_simple_overlay_action_mode = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public const int abc_search_view = 2130903063;
+			public const int abc_screen_toolbar = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public const int abc_select_dialog_material = 2130903064;
+			public const int abc_search_dropdown_item_icons_2line = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public const int design_bottom_sheet_dialog = 2130903065;
+			public const int abc_search_view = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public const int design_layout_snackbar = 2130903066;
+			public const int abc_select_dialog_material = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public const int design_layout_snackbar_include = 2130903067;
+			public const int design_bottom_navigation_item = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public const int design_layout_tab_icon = 2130903068;
+			public const int design_bottom_sheet_dialog = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public const int design_layout_tab_text = 2130903069;
+			public const int design_layout_snackbar = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public const int design_menu_item_action_area = 2130903070;
+			public const int design_layout_snackbar_include = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public const int design_navigation_item = 2130903071;
+			public const int design_layout_tab_icon = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public const int design_navigation_item_header = 2130903072;
+			public const int design_layout_tab_text = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public const int design_navigation_item_separator = 2130903073;
+			public const int design_menu_item_action_area = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public const int design_navigation_item_subheader = 2130903074;
+			public const int design_navigation_item = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public const int design_navigation_menu = 2130903075;
+			public const int design_navigation_item_header = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public const int design_navigation_menu_item = 2130903076;
+			public const int design_navigation_item_separator = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public const int mini_fab = 2130903077;
+			public const int design_navigation_item_subheader = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public const int mr_chooser_dialog = 2130903078;
+			public const int design_navigation_menu = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public const int mr_chooser_list_item = 2130903079;
+			public const int design_navigation_menu_item = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public const int mr_controller_material_dialog_b = 2130903080;
+			public const int design_text_input_password_icon = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public const int mr_controller_volume_item = 2130903081;
+			public const int mini_fab = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public const int mr_playback_control = 2130903082;
+			public const int mr_chooser_dialog = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public const int mr_volume_control = 2130903083;
+			public const int mr_chooser_list_item = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public const int normal_fab = 2130903084;
+			public const int mr_controller_material_dialog_b = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public const int notification_media_action = 2130903085;
+			public const int mr_controller_volume_item = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public const int notification_media_cancel_action = 2130903086;
+			public const int mr_playback_control = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public const int notification_template_big_media = 2130903087;
+			public const int mr_volume_control = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public const int notification_template_big_media_narrow = 2130903088;
+			public const int normal_fab = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public const int notification_template_lines = 2130903089;
+			public const int notification_action = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public const int notification_template_media = 2130903090;
+			public const int notification_action_tombstone = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public const int notification_template_part_chronometer = 2130903091;
+			public const int notification_media_action = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public const int notification_template_part_time = 2130903092;
+			public const int notification_media_cancel_action = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public const int select_dialog_item_material = 2130903093;
+			public const int notification_template_big_media = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public const int select_dialog_multichoice_material = 2130903094;
+			public const int notification_template_big_media_custom = 2130903094;
 			
 			// aapt resource value: 0x7f030037
-			public const int select_dialog_singlechoice_material = 2130903095;
+			public const int notification_template_big_media_narrow = 2130903095;
 			
 			// aapt resource value: 0x7f030038
-			public const int support_simple_spinner_dropdown_item = 2130903096;
+			public const int notification_template_big_media_narrow_custom = 2130903096;
 			
 			// aapt resource value: 0x7f030039
-			public const int tabs = 2130903097;
+			public const int notification_template_custom_big = 2130903097;
 			
 			// aapt resource value: 0x7f03003a
-			public const int toolbar = 2130903098;
+			public const int notification_template_icon_group = 2130903098;
+			
+			// aapt resource value: 0x7f03003b
+			public const int notification_template_lines_media = 2130903099;
+			
+			// aapt resource value: 0x7f03003c
+			public const int notification_template_media = 2130903100;
+			
+			// aapt resource value: 0x7f03003d
+			public const int notification_template_media_custom = 2130903101;
+			
+			// aapt resource value: 0x7f03003e
+			public const int notification_template_part_chronometer = 2130903102;
+			
+			// aapt resource value: 0x7f03003f
+			public const int notification_template_part_time = 2130903103;
+			
+			// aapt resource value: 0x7f030040
+			public const int select_dialog_item_material = 2130903104;
+			
+			// aapt resource value: 0x7f030041
+			public const int select_dialog_multichoice_material = 2130903105;
+			
+			// aapt resource value: 0x7f030042
+			public const int select_dialog_singlechoice_material = 2130903106;
+			
+			// aapt resource value: 0x7f030043
+			public const int support_simple_spinner_dropdown_item = 2130903107;
+			
+			// aapt resource value: 0x7f030044
+			public const int tabs = 2130903108;
+			
+			// aapt resource value: 0x7f030045
+			public const int toolbar = 2130903109;
 			
 			static Layout()
 			{
@@ -4814,155 +5814,227 @@ namespace FABSample.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f060012
-			public const int abc_action_bar_home_description = 2131099666;
+			// aapt resource value: 0x7f090015
+			public const int abc_action_bar_home_description = 2131296277;
 			
-			// aapt resource value: 0x7f060013
-			public const int abc_action_bar_home_description_format = 2131099667;
+			// aapt resource value: 0x7f090016
+			public const int abc_action_bar_home_description_format = 2131296278;
 			
-			// aapt resource value: 0x7f060014
-			public const int abc_action_bar_home_subtitle_description_format = 2131099668;
+			// aapt resource value: 0x7f090017
+			public const int abc_action_bar_home_subtitle_description_format = 2131296279;
 			
-			// aapt resource value: 0x7f060015
-			public const int abc_action_bar_up_description = 2131099669;
+			// aapt resource value: 0x7f090018
+			public const int abc_action_bar_up_description = 2131296280;
 			
-			// aapt resource value: 0x7f060016
-			public const int abc_action_menu_overflow_description = 2131099670;
+			// aapt resource value: 0x7f090019
+			public const int abc_action_menu_overflow_description = 2131296281;
 			
-			// aapt resource value: 0x7f060017
-			public const int abc_action_mode_done = 2131099671;
+			// aapt resource value: 0x7f09001a
+			public const int abc_action_mode_done = 2131296282;
 			
-			// aapt resource value: 0x7f060018
-			public const int abc_activity_chooser_view_see_all = 2131099672;
+			// aapt resource value: 0x7f09001b
+			public const int abc_activity_chooser_view_see_all = 2131296283;
 			
-			// aapt resource value: 0x7f060019
-			public const int abc_activitychooserview_choose_application = 2131099673;
+			// aapt resource value: 0x7f09001c
+			public const int abc_activitychooserview_choose_application = 2131296284;
 			
-			// aapt resource value: 0x7f06001a
-			public const int abc_capital_off = 2131099674;
+			// aapt resource value: 0x7f09001d
+			public const int abc_capital_off = 2131296285;
 			
-			// aapt resource value: 0x7f06001b
-			public const int abc_capital_on = 2131099675;
+			// aapt resource value: 0x7f09001e
+			public const int abc_capital_on = 2131296286;
 			
-			// aapt resource value: 0x7f06001c
-			public const int abc_search_hint = 2131099676;
+			// aapt resource value: 0x7f09002a
+			public const int abc_font_family_body_1_material = 2131296298;
 			
-			// aapt resource value: 0x7f06001d
-			public const int abc_searchview_description_clear = 2131099677;
+			// aapt resource value: 0x7f09002b
+			public const int abc_font_family_body_2_material = 2131296299;
 			
-			// aapt resource value: 0x7f06001e
-			public const int abc_searchview_description_query = 2131099678;
+			// aapt resource value: 0x7f09002c
+			public const int abc_font_family_button_material = 2131296300;
 			
-			// aapt resource value: 0x7f06001f
-			public const int abc_searchview_description_search = 2131099679;
+			// aapt resource value: 0x7f09002d
+			public const int abc_font_family_caption_material = 2131296301;
 			
-			// aapt resource value: 0x7f060020
-			public const int abc_searchview_description_submit = 2131099680;
+			// aapt resource value: 0x7f09002e
+			public const int abc_font_family_display_1_material = 2131296302;
 			
-			// aapt resource value: 0x7f060021
-			public const int abc_searchview_description_voice = 2131099681;
+			// aapt resource value: 0x7f09002f
+			public const int abc_font_family_display_2_material = 2131296303;
 			
-			// aapt resource value: 0x7f060022
-			public const int abc_shareactionprovider_share_with = 2131099682;
+			// aapt resource value: 0x7f090030
+			public const int abc_font_family_display_3_material = 2131296304;
 			
-			// aapt resource value: 0x7f060023
-			public const int abc_shareactionprovider_share_with_application = 2131099683;
+			// aapt resource value: 0x7f090031
+			public const int abc_font_family_display_4_material = 2131296305;
 			
-			// aapt resource value: 0x7f060024
-			public const int abc_toolbar_collapse_description = 2131099684;
+			// aapt resource value: 0x7f090032
+			public const int abc_font_family_headline_material = 2131296306;
 			
-			// aapt resource value: 0x7f060031
-			public const int app_name = 2131099697;
+			// aapt resource value: 0x7f090033
+			public const int abc_font_family_menu_material = 2131296307;
 			
-			// aapt resource value: 0x7f06000f
-			public const int appbar_scrolling_view_behavior = 2131099663;
+			// aapt resource value: 0x7f090034
+			public const int abc_font_family_subhead_material = 2131296308;
 			
-			// aapt resource value: 0x7f060010
-			public const int bottom_sheet_behavior = 2131099664;
+			// aapt resource value: 0x7f090035
+			public const int abc_font_family_title_material = 2131296309;
 			
-			// aapt resource value: 0x7f060011
-			public const int character_counter_pattern = 2131099665;
+			// aapt resource value: 0x7f09001f
+			public const int abc_search_hint = 2131296287;
 			
-			// aapt resource value: 0x7f060026
-			public const int define_FloatingActionButton = 2131099686;
+			// aapt resource value: 0x7f090020
+			public const int abc_searchview_description_clear = 2131296288;
 			
-			// aapt resource value: 0x7f060027
-			public const int library_FloatingActionButton_author = 2131099687;
+			// aapt resource value: 0x7f090021
+			public const int abc_searchview_description_query = 2131296289;
 			
-			// aapt resource value: 0x7f060028
-			public const int library_FloatingActionButton_authorWebsite = 2131099688;
+			// aapt resource value: 0x7f090022
+			public const int abc_searchview_description_search = 2131296290;
 			
-			// aapt resource value: 0x7f06002d
-			public const int library_FloatingActionButton_isOpenSource = 2131099693;
+			// aapt resource value: 0x7f090023
+			public const int abc_searchview_description_submit = 2131296291;
 			
-			// aapt resource value: 0x7f06002a
-			public const int library_FloatingActionButton_libraryDescription = 2131099690;
+			// aapt resource value: 0x7f090024
+			public const int abc_searchview_description_voice = 2131296292;
 			
-			// aapt resource value: 0x7f060029
-			public const int library_FloatingActionButton_libraryName = 2131099689;
+			// aapt resource value: 0x7f090025
+			public const int abc_shareactionprovider_share_with = 2131296293;
 			
-			// aapt resource value: 0x7f06002c
-			public const int library_FloatingActionButton_libraryVersion = 2131099692;
+			// aapt resource value: 0x7f090026
+			public const int abc_shareactionprovider_share_with_application = 2131296294;
 			
-			// aapt resource value: 0x7f06002b
-			public const int library_FloatingActionButton_libraryWebsite = 2131099691;
+			// aapt resource value: 0x7f090027
+			public const int abc_toolbar_collapse_description = 2131296295;
 			
-			// aapt resource value: 0x7f06002f
-			public const int library_FloatingActionButton_licenseId = 2131099695;
+			// aapt resource value: 0x7f090049
+			public const int app_name = 2131296329;
 			
-			// aapt resource value: 0x7f06002e
-			public const int library_FloatingActionButton_repositoryLink = 2131099694;
+			// aapt resource value: 0x7f090036
+			public const int appbar_scrolling_view_behavior = 2131296310;
 			
-			// aapt resource value: 0x7f060030
-			public const int library_name = 2131099696;
+			// aapt resource value: 0x7f090037
+			public const int bottom_sheet_behavior = 2131296311;
 			
-			// aapt resource value: 0x7f060000
-			public const int mr_button_content_description = 2131099648;
+			// aapt resource value: 0x7f090038
+			public const int character_counter_pattern = 2131296312;
 			
-			// aapt resource value: 0x7f060001
-			public const int mr_chooser_searching = 2131099649;
+			// aapt resource value: 0x7f09003e
+			public const int define_FloatingActionButton = 2131296318;
 			
-			// aapt resource value: 0x7f060002
-			public const int mr_chooser_title = 2131099650;
+			// aapt resource value: 0x7f09003f
+			public const int library_FloatingActionButton_author = 2131296319;
 			
-			// aapt resource value: 0x7f060003
-			public const int mr_controller_casting_screen = 2131099651;
+			// aapt resource value: 0x7f090040
+			public const int library_FloatingActionButton_authorWebsite = 2131296320;
 			
-			// aapt resource value: 0x7f060004
-			public const int mr_controller_close_description = 2131099652;
+			// aapt resource value: 0x7f090045
+			public const int library_FloatingActionButton_isOpenSource = 2131296325;
 			
-			// aapt resource value: 0x7f060005
-			public const int mr_controller_collapse_group = 2131099653;
+			// aapt resource value: 0x7f090042
+			public const int library_FloatingActionButton_libraryDescription = 2131296322;
 			
-			// aapt resource value: 0x7f060006
-			public const int mr_controller_disconnect = 2131099654;
+			// aapt resource value: 0x7f090041
+			public const int library_FloatingActionButton_libraryName = 2131296321;
 			
-			// aapt resource value: 0x7f060007
-			public const int mr_controller_expand_group = 2131099655;
+			// aapt resource value: 0x7f090044
+			public const int library_FloatingActionButton_libraryVersion = 2131296324;
 			
-			// aapt resource value: 0x7f060008
-			public const int mr_controller_no_info_available = 2131099656;
+			// aapt resource value: 0x7f090043
+			public const int library_FloatingActionButton_libraryWebsite = 2131296323;
 			
-			// aapt resource value: 0x7f060009
-			public const int mr_controller_no_media_selected = 2131099657;
+			// aapt resource value: 0x7f090047
+			public const int library_FloatingActionButton_licenseId = 2131296327;
 			
-			// aapt resource value: 0x7f06000a
-			public const int mr_controller_pause = 2131099658;
+			// aapt resource value: 0x7f090046
+			public const int library_FloatingActionButton_repositoryLink = 2131296326;
 			
-			// aapt resource value: 0x7f06000b
-			public const int mr_controller_play = 2131099659;
+			// aapt resource value: 0x7f090048
+			public const int library_name = 2131296328;
 			
-			// aapt resource value: 0x7f06000c
-			public const int mr_controller_stop = 2131099660;
+			// aapt resource value: 0x7f090000
+			public const int mr_button_content_description = 2131296256;
 			
-			// aapt resource value: 0x7f06000d
-			public const int mr_system_route_name = 2131099661;
+			// aapt resource value: 0x7f090001
+			public const int mr_cast_button_connected = 2131296257;
 			
-			// aapt resource value: 0x7f06000e
-			public const int mr_user_route_category_name = 2131099662;
+			// aapt resource value: 0x7f090002
+			public const int mr_cast_button_connecting = 2131296258;
 			
-			// aapt resource value: 0x7f060025
-			public const int status_bar_notification_info_overflow = 2131099685;
+			// aapt resource value: 0x7f090003
+			public const int mr_cast_button_disconnected = 2131296259;
+			
+			// aapt resource value: 0x7f090004
+			public const int mr_chooser_searching = 2131296260;
+			
+			// aapt resource value: 0x7f090005
+			public const int mr_chooser_title = 2131296261;
+			
+			// aapt resource value: 0x7f090006
+			public const int mr_controller_album_art = 2131296262;
+			
+			// aapt resource value: 0x7f090007
+			public const int mr_controller_casting_screen = 2131296263;
+			
+			// aapt resource value: 0x7f090008
+			public const int mr_controller_close_description = 2131296264;
+			
+			// aapt resource value: 0x7f090009
+			public const int mr_controller_collapse_group = 2131296265;
+			
+			// aapt resource value: 0x7f09000a
+			public const int mr_controller_disconnect = 2131296266;
+			
+			// aapt resource value: 0x7f09000b
+			public const int mr_controller_expand_group = 2131296267;
+			
+			// aapt resource value: 0x7f09000c
+			public const int mr_controller_no_info_available = 2131296268;
+			
+			// aapt resource value: 0x7f09000d
+			public const int mr_controller_no_media_selected = 2131296269;
+			
+			// aapt resource value: 0x7f09000e
+			public const int mr_controller_pause = 2131296270;
+			
+			// aapt resource value: 0x7f09000f
+			public const int mr_controller_play = 2131296271;
+			
+			// aapt resource value: 0x7f090014
+			public const int mr_controller_stop = 2131296276;
+			
+			// aapt resource value: 0x7f090010
+			public const int mr_controller_stop_casting = 2131296272;
+			
+			// aapt resource value: 0x7f090011
+			public const int mr_controller_volume_slider = 2131296273;
+			
+			// aapt resource value: 0x7f090012
+			public const int mr_system_route_name = 2131296274;
+			
+			// aapt resource value: 0x7f090013
+			public const int mr_user_route_category_name = 2131296275;
+			
+			// aapt resource value: 0x7f090039
+			public const int password_toggle_content_description = 2131296313;
+			
+			// aapt resource value: 0x7f09003a
+			public const int path_password_eye = 2131296314;
+			
+			// aapt resource value: 0x7f09003b
+			public const int path_password_eye_mask_strike_through = 2131296315;
+			
+			// aapt resource value: 0x7f09003c
+			public const int path_password_eye_mask_visible = 2131296316;
+			
+			// aapt resource value: 0x7f09003d
+			public const int path_password_strike_through = 2131296317;
+			
+			// aapt resource value: 0x7f090028
+			public const int search_menu_title = 2131296296;
+			
+			// aapt resource value: 0x7f090029
+			public const int status_bar_notification_info_overflow = 2131296297;
 			
 			static String()
 			{
@@ -4977,1124 +6049,1193 @@ namespace FABSample.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0900b6
-			public const int AlertDialog_AppCompat = 2131296438;
+			// aapt resource value: 0x7f0b00ae
+			public const int AlertDialog_AppCompat = 2131427502;
 			
-			// aapt resource value: 0x7f0900b7
-			public const int AlertDialog_AppCompat_Light = 2131296439;
+			// aapt resource value: 0x7f0b00af
+			public const int AlertDialog_AppCompat_Light = 2131427503;
 			
-			// aapt resource value: 0x7f0900b8
-			public const int Animation_AppCompat_Dialog = 2131296440;
+			// aapt resource value: 0x7f0b00b0
+			public const int Animation_AppCompat_Dialog = 2131427504;
 			
-			// aapt resource value: 0x7f0900b9
-			public const int Animation_AppCompat_DropDownUp = 2131296441;
+			// aapt resource value: 0x7f0b00b1
+			public const int Animation_AppCompat_DropDownUp = 2131427505;
 			
-			// aapt resource value: 0x7f090018
-			public const int Animation_Design_BottomSheetDialog = 2131296280;
+			// aapt resource value: 0x7f0b0170
+			public const int Animation_Design_BottomSheetDialog = 2131427696;
 			
-			// aapt resource value: 0x7f090174
-			public const int AppCompatDialogStyle = 2131296628;
+			// aapt resource value: 0x7f0b018b
+			public const int AppCompatDialogStyle = 2131427723;
 			
-			// aapt resource value: 0x7f0900ba
-			public const int Base_AlertDialog_AppCompat = 2131296442;
+			// aapt resource value: 0x7f0b00b2
+			public const int Base_AlertDialog_AppCompat = 2131427506;
 			
-			// aapt resource value: 0x7f0900bb
-			public const int Base_AlertDialog_AppCompat_Light = 2131296443;
+			// aapt resource value: 0x7f0b00b3
+			public const int Base_AlertDialog_AppCompat_Light = 2131427507;
 			
-			// aapt resource value: 0x7f0900bc
-			public const int Base_Animation_AppCompat_Dialog = 2131296444;
+			// aapt resource value: 0x7f0b00b4
+			public const int Base_Animation_AppCompat_Dialog = 2131427508;
 			
-			// aapt resource value: 0x7f0900bd
-			public const int Base_Animation_AppCompat_DropDownUp = 2131296445;
+			// aapt resource value: 0x7f0b00b5
+			public const int Base_Animation_AppCompat_DropDownUp = 2131427509;
 			
-			// aapt resource value: 0x7f09016f
-			public const int Base_CardView = 2131296623;
+			// aapt resource value: 0x7f0b000c
+			public const int Base_CardView = 2131427340;
 			
-			// aapt resource value: 0x7f0900be
-			public const int Base_DialogWindowTitle_AppCompat = 2131296446;
+			// aapt resource value: 0x7f0b00b6
+			public const int Base_DialogWindowTitle_AppCompat = 2131427510;
 			
-			// aapt resource value: 0x7f0900bf
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131296447;
+			// aapt resource value: 0x7f0b00b7
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131427511;
 			
-			// aapt resource value: 0x7f090066
-			public const int Base_TextAppearance_AppCompat = 2131296358;
+			// aapt resource value: 0x7f0b004e
+			public const int Base_TextAppearance_AppCompat = 2131427406;
 			
-			// aapt resource value: 0x7f090067
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131296359;
+			// aapt resource value: 0x7f0b004f
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131427407;
 			
-			// aapt resource value: 0x7f090068
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131296360;
+			// aapt resource value: 0x7f0b0050
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131427408;
 			
-			// aapt resource value: 0x7f090050
-			public const int Base_TextAppearance_AppCompat_Button = 2131296336;
+			// aapt resource value: 0x7f0b0036
+			public const int Base_TextAppearance_AppCompat_Button = 2131427382;
 			
-			// aapt resource value: 0x7f090069
-			public const int Base_TextAppearance_AppCompat_Caption = 2131296361;
+			// aapt resource value: 0x7f0b0051
+			public const int Base_TextAppearance_AppCompat_Caption = 2131427409;
 			
-			// aapt resource value: 0x7f09006a
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131296362;
+			// aapt resource value: 0x7f0b0052
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131427410;
 			
-			// aapt resource value: 0x7f09006b
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131296363;
+			// aapt resource value: 0x7f0b0053
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131427411;
 			
-			// aapt resource value: 0x7f09006c
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131296364;
+			// aapt resource value: 0x7f0b0054
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131427412;
 			
-			// aapt resource value: 0x7f09006d
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131296365;
+			// aapt resource value: 0x7f0b0055
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131427413;
 			
-			// aapt resource value: 0x7f09006e
-			public const int Base_TextAppearance_AppCompat_Headline = 2131296366;
+			// aapt resource value: 0x7f0b0056
+			public const int Base_TextAppearance_AppCompat_Headline = 2131427414;
 			
-			// aapt resource value: 0x7f09003b
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131296315;
+			// aapt resource value: 0x7f0b001a
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131427354;
 			
-			// aapt resource value: 0x7f09006f
-			public const int Base_TextAppearance_AppCompat_Large = 2131296367;
+			// aapt resource value: 0x7f0b0057
+			public const int Base_TextAppearance_AppCompat_Large = 2131427415;
 			
-			// aapt resource value: 0x7f09003c
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131296316;
+			// aapt resource value: 0x7f0b001b
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131427355;
 			
-			// aapt resource value: 0x7f090070
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296368;
+			// aapt resource value: 0x7f0b0058
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427416;
 			
-			// aapt resource value: 0x7f090071
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296369;
+			// aapt resource value: 0x7f0b0059
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427417;
 			
-			// aapt resource value: 0x7f090072
-			public const int Base_TextAppearance_AppCompat_Medium = 2131296370;
+			// aapt resource value: 0x7f0b005a
+			public const int Base_TextAppearance_AppCompat_Medium = 2131427418;
 			
-			// aapt resource value: 0x7f09003d
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296317;
+			// aapt resource value: 0x7f0b001c
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427356;
 			
-			// aapt resource value: 0x7f090073
-			public const int Base_TextAppearance_AppCompat_Menu = 2131296371;
+			// aapt resource value: 0x7f0b005b
+			public const int Base_TextAppearance_AppCompat_Menu = 2131427419;
 			
-			// aapt resource value: 0x7f0900c0
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131296448;
+			// aapt resource value: 0x7f0b00b8
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131427512;
 			
-			// aapt resource value: 0x7f090074
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296372;
+			// aapt resource value: 0x7f0b005c
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427420;
 			
-			// aapt resource value: 0x7f090075
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296373;
+			// aapt resource value: 0x7f0b005d
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427421;
 			
-			// aapt resource value: 0x7f090076
-			public const int Base_TextAppearance_AppCompat_Small = 2131296374;
+			// aapt resource value: 0x7f0b005e
+			public const int Base_TextAppearance_AppCompat_Small = 2131427422;
 			
-			// aapt resource value: 0x7f09003e
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131296318;
+			// aapt resource value: 0x7f0b001d
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131427357;
 			
-			// aapt resource value: 0x7f090077
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131296375;
+			// aapt resource value: 0x7f0b005f
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131427423;
 			
-			// aapt resource value: 0x7f09003f
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296319;
+			// aapt resource value: 0x7f0b001e
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427358;
 			
-			// aapt resource value: 0x7f090078
-			public const int Base_TextAppearance_AppCompat_Title = 2131296376;
+			// aapt resource value: 0x7f0b0060
+			public const int Base_TextAppearance_AppCompat_Title = 2131427424;
 			
-			// aapt resource value: 0x7f090040
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131296320;
+			// aapt resource value: 0x7f0b001f
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131427359;
 			
-			// aapt resource value: 0x7f0900af
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296431;
+			// aapt resource value: 0x7f0b00a3
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427491;
 			
-			// aapt resource value: 0x7f090079
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296377;
+			// aapt resource value: 0x7f0b0061
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427425;
 			
-			// aapt resource value: 0x7f09007a
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296378;
+			// aapt resource value: 0x7f0b0062
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427426;
 			
-			// aapt resource value: 0x7f09007b
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296379;
+			// aapt resource value: 0x7f0b0063
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427427;
 			
-			// aapt resource value: 0x7f09007c
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296380;
+			// aapt resource value: 0x7f0b0064
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427428;
 			
-			// aapt resource value: 0x7f09007d
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296381;
+			// aapt resource value: 0x7f0b0065
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427429;
 			
-			// aapt resource value: 0x7f09007e
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296382;
+			// aapt resource value: 0x7f0b0066
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427430;
 			
-			// aapt resource value: 0x7f09007f
-			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131296383;
+			// aapt resource value: 0x7f0b0067
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131427431;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131296432;
+			// aapt resource value: 0x7f0b00aa
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427498;
 			
-			// aapt resource value: 0x7f0900c1
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296449;
+			// aapt resource value: 0x7f0b00ab
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131427499;
 			
-			// aapt resource value: 0x7f090080
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296384;
+			// aapt resource value: 0x7f0b00a4
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131427492;
 			
-			// aapt resource value: 0x7f090081
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296385;
+			// aapt resource value: 0x7f0b00b9
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427513;
 			
-			// aapt resource value: 0x7f090082
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131296386;
+			// aapt resource value: 0x7f0b0068
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427432;
 			
-			// aapt resource value: 0x7f090083
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296387;
+			// aapt resource value: 0x7f0b0069
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427433;
 			
-			// aapt resource value: 0x7f0900c2
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296450;
+			// aapt resource value: 0x7f0b006a
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427434;
 			
-			// aapt resource value: 0x7f090084
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296388;
+			// aapt resource value: 0x7f0b006b
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131427435;
 			
-			// aapt resource value: 0x7f090085
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296389;
+			// aapt resource value: 0x7f0b006c
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427436;
 			
-			// aapt resource value: 0x7f090086
-			public const int Base_Theme_AppCompat = 2131296390;
+			// aapt resource value: 0x7f0b00ba
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427514;
 			
-			// aapt resource value: 0x7f0900c3
-			public const int Base_Theme_AppCompat_CompactMenu = 2131296451;
+			// aapt resource value: 0x7f0b006d
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427437;
 			
-			// aapt resource value: 0x7f090041
-			public const int Base_Theme_AppCompat_Dialog = 2131296321;
+			// aapt resource value: 0x7f0b006e
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427438;
 			
-			// aapt resource value: 0x7f0900c4
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131296452;
+			// aapt resource value: 0x7f0b006f
+			public const int Base_Theme_AppCompat = 2131427439;
 			
-			// aapt resource value: 0x7f0900c5
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131296453;
+			// aapt resource value: 0x7f0b00bb
+			public const int Base_Theme_AppCompat_CompactMenu = 2131427515;
 			
-			// aapt resource value: 0x7f0900c6
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131296454;
+			// aapt resource value: 0x7f0b0020
+			public const int Base_Theme_AppCompat_Dialog = 2131427360;
 			
-			// aapt resource value: 0x7f090031
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131296305;
+			// aapt resource value: 0x7f0b0021
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131427361;
 			
-			// aapt resource value: 0x7f090087
-			public const int Base_Theme_AppCompat_Light = 2131296391;
+			// aapt resource value: 0x7f0b00bc
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131427516;
 			
-			// aapt resource value: 0x7f0900c7
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131296455;
+			// aapt resource value: 0x7f0b0022
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131427362;
 			
-			// aapt resource value: 0x7f090042
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131296322;
+			// aapt resource value: 0x7f0b0010
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131427344;
 			
-			// aapt resource value: 0x7f0900c8
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296456;
+			// aapt resource value: 0x7f0b0070
+			public const int Base_Theme_AppCompat_Light = 2131427440;
 			
-			// aapt resource value: 0x7f0900c9
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296457;
+			// aapt resource value: 0x7f0b00bd
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131427517;
 			
-			// aapt resource value: 0x7f0900ca
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296458;
+			// aapt resource value: 0x7f0b0023
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131427363;
 			
-			// aapt resource value: 0x7f090032
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296306;
+			// aapt resource value: 0x7f0b0024
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131427364;
 			
-			// aapt resource value: 0x7f0900cb
-			public const int Base_ThemeOverlay_AppCompat = 2131296459;
+			// aapt resource value: 0x7f0b00be
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427518;
 			
-			// aapt resource value: 0x7f0900cc
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131296460;
+			// aapt resource value: 0x7f0b0025
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131427365;
 			
-			// aapt resource value: 0x7f0900cd
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131296461;
+			// aapt resource value: 0x7f0b0011
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427345;
 			
-			// aapt resource value: 0x7f0900ce
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296462;
+			// aapt resource value: 0x7f0b00bf
+			public const int Base_ThemeOverlay_AppCompat = 2131427519;
 			
-			// aapt resource value: 0x7f0900cf
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131296463;
+			// aapt resource value: 0x7f0b00c0
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131427520;
 			
-			// aapt resource value: 0x7f090043
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131296323;
+			// aapt resource value: 0x7f0b00c1
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131427521;
 			
-			// aapt resource value: 0x7f090044
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131296324;
+			// aapt resource value: 0x7f0b00c2
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427522;
 			
-			// aapt resource value: 0x7f09004c
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296332;
+			// aapt resource value: 0x7f0b0026
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131427366;
 			
-			// aapt resource value: 0x7f09004d
-			public const int Base_V12_Widget_AppCompat_EditText = 2131296333;
+			// aapt resource value: 0x7f0b0027
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131427367;
 			
-			// aapt resource value: 0x7f090088
-			public const int Base_V21_Theme_AppCompat = 2131296392;
+			// aapt resource value: 0x7f0b00c3
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131427523;
 			
-			// aapt resource value: 0x7f090089
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131296393;
+			// aapt resource value: 0x7f0b0028
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131427368;
 			
-			// aapt resource value: 0x7f09008a
-			public const int Base_V21_Theme_AppCompat_Light = 2131296394;
+			// aapt resource value: 0x7f0b0029
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131427369;
 			
-			// aapt resource value: 0x7f09008b
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131296395;
+			// aapt resource value: 0x7f0b002a
+			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131427370;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int Base_V22_Theme_AppCompat = 2131296429;
+			// aapt resource value: 0x7f0b0032
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131427378;
 			
-			// aapt resource value: 0x7f0900ae
-			public const int Base_V22_Theme_AppCompat_Light = 2131296430;
+			// aapt resource value: 0x7f0b0033
+			public const int Base_V12_Widget_AppCompat_EditText = 2131427379;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int Base_V23_Theme_AppCompat = 2131296433;
+			// aapt resource value: 0x7f0b0071
+			public const int Base_V21_Theme_AppCompat = 2131427441;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int Base_V23_Theme_AppCompat_Light = 2131296434;
+			// aapt resource value: 0x7f0b0072
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131427442;
 			
-			// aapt resource value: 0x7f0900d0
-			public const int Base_V7_Theme_AppCompat = 2131296464;
+			// aapt resource value: 0x7f0b0073
+			public const int Base_V21_Theme_AppCompat_Light = 2131427443;
 			
-			// aapt resource value: 0x7f0900d1
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131296465;
+			// aapt resource value: 0x7f0b0074
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131427444;
 			
-			// aapt resource value: 0x7f0900d2
-			public const int Base_V7_Theme_AppCompat_Light = 2131296466;
+			// aapt resource value: 0x7f0b0075
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131427445;
 			
-			// aapt resource value: 0x7f0900d3
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131296467;
+			// aapt resource value: 0x7f0b00a1
+			public const int Base_V22_Theme_AppCompat = 2131427489;
 			
-			// aapt resource value: 0x7f0900d4
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296468;
+			// aapt resource value: 0x7f0b00a2
+			public const int Base_V22_Theme_AppCompat_Light = 2131427490;
 			
-			// aapt resource value: 0x7f0900d5
-			public const int Base_V7_Widget_AppCompat_EditText = 2131296469;
+			// aapt resource value: 0x7f0b00a5
+			public const int Base_V23_Theme_AppCompat = 2131427493;
 			
-			// aapt resource value: 0x7f0900d6
-			public const int Base_Widget_AppCompat_ActionBar = 2131296470;
+			// aapt resource value: 0x7f0b00a6
+			public const int Base_V23_Theme_AppCompat_Light = 2131427494;
 			
-			// aapt resource value: 0x7f0900d7
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131296471;
+			// aapt resource value: 0x7f0b00c4
+			public const int Base_V7_Theme_AppCompat = 2131427524;
 			
-			// aapt resource value: 0x7f0900d8
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131296472;
+			// aapt resource value: 0x7f0b00c5
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131427525;
 			
-			// aapt resource value: 0x7f09008c
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131296396;
+			// aapt resource value: 0x7f0b00c6
+			public const int Base_V7_Theme_AppCompat_Light = 2131427526;
 			
-			// aapt resource value: 0x7f09008d
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131296397;
+			// aapt resource value: 0x7f0b00c7
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131427527;
 			
-			// aapt resource value: 0x7f09008e
-			public const int Base_Widget_AppCompat_ActionButton = 2131296398;
+			// aapt resource value: 0x7f0b00c8
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131427528;
 			
-			// aapt resource value: 0x7f09008f
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296399;
+			// aapt resource value: 0x7f0b00c9
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131427529;
 			
-			// aapt resource value: 0x7f090090
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131296400;
+			// aapt resource value: 0x7f0b00ca
+			public const int Base_V7_Widget_AppCompat_EditText = 2131427530;
 			
-			// aapt resource value: 0x7f0900d9
-			public const int Base_Widget_AppCompat_ActionMode = 2131296473;
+			// aapt resource value: 0x7f0b00cb
+			public const int Base_Widget_AppCompat_ActionBar = 2131427531;
 			
-			// aapt resource value: 0x7f0900da
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131296474;
+			// aapt resource value: 0x7f0b00cc
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131427532;
 			
-			// aapt resource value: 0x7f09004e
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131296334;
+			// aapt resource value: 0x7f0b00cd
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131427533;
 			
-			// aapt resource value: 0x7f090091
-			public const int Base_Widget_AppCompat_Button = 2131296401;
+			// aapt resource value: 0x7f0b0076
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131427446;
 			
-			// aapt resource value: 0x7f090092
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131296402;
+			// aapt resource value: 0x7f0b0077
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131427447;
 			
-			// aapt resource value: 0x7f090093
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296403;
+			// aapt resource value: 0x7f0b0078
+			public const int Base_Widget_AppCompat_ActionButton = 2131427448;
 			
-			// aapt resource value: 0x7f0900db
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296475;
+			// aapt resource value: 0x7f0b0079
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427449;
 			
-			// aapt resource value: 0x7f0900b3
-			public const int Base_Widget_AppCompat_Button_Colored = 2131296435;
+			// aapt resource value: 0x7f0b007a
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131427450;
 			
-			// aapt resource value: 0x7f090094
-			public const int Base_Widget_AppCompat_Button_Small = 2131296404;
+			// aapt resource value: 0x7f0b00ce
+			public const int Base_Widget_AppCompat_ActionMode = 2131427534;
 			
-			// aapt resource value: 0x7f090095
-			public const int Base_Widget_AppCompat_ButtonBar = 2131296405;
+			// aapt resource value: 0x7f0b00cf
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131427535;
 			
-			// aapt resource value: 0x7f0900dc
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296476;
+			// aapt resource value: 0x7f0b0034
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131427380;
 			
-			// aapt resource value: 0x7f090096
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296406;
+			// aapt resource value: 0x7f0b007b
+			public const int Base_Widget_AppCompat_Button = 2131427451;
 			
-			// aapt resource value: 0x7f090097
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296407;
+			// aapt resource value: 0x7f0b007c
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131427452;
 			
-			// aapt resource value: 0x7f0900dd
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131296477;
+			// aapt resource value: 0x7f0b007d
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131427453;
 			
-			// aapt resource value: 0x7f090030
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131296304;
+			// aapt resource value: 0x7f0b00d0
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427536;
 			
-			// aapt resource value: 0x7f0900de
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296478;
+			// aapt resource value: 0x7f0b00a7
+			public const int Base_Widget_AppCompat_Button_Colored = 2131427495;
 			
-			// aapt resource value: 0x7f090098
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296408;
+			// aapt resource value: 0x7f0b007e
+			public const int Base_Widget_AppCompat_Button_Small = 2131427454;
 			
-			// aapt resource value: 0x7f09004f
-			public const int Base_Widget_AppCompat_EditText = 2131296335;
+			// aapt resource value: 0x7f0b007f
+			public const int Base_Widget_AppCompat_ButtonBar = 2131427455;
 			
-			// aapt resource value: 0x7f090099
-			public const int Base_Widget_AppCompat_ImageButton = 2131296409;
+			// aapt resource value: 0x7f0b00d1
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131427537;
 			
-			// aapt resource value: 0x7f0900df
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131296479;
+			// aapt resource value: 0x7f0b0080
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131427456;
 			
-			// aapt resource value: 0x7f0900e0
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296480;
+			// aapt resource value: 0x7f0b0081
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131427457;
 			
-			// aapt resource value: 0x7f0900e1
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296481;
+			// aapt resource value: 0x7f0b00d2
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131427538;
 			
-			// aapt resource value: 0x7f09009a
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296410;
+			// aapt resource value: 0x7f0b000f
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131427343;
 			
-			// aapt resource value: 0x7f09009b
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296411;
+			// aapt resource value: 0x7f0b00d3
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131427539;
 			
-			// aapt resource value: 0x7f09009c
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296412;
+			// aapt resource value: 0x7f0b0082
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427458;
 			
-			// aapt resource value: 0x7f09009d
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131296413;
+			// aapt resource value: 0x7f0b0035
+			public const int Base_Widget_AppCompat_EditText = 2131427381;
 			
-			// aapt resource value: 0x7f09009e
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296414;
+			// aapt resource value: 0x7f0b0083
+			public const int Base_Widget_AppCompat_ImageButton = 2131427459;
 			
-			// aapt resource value: 0x7f09009f
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131296415;
+			// aapt resource value: 0x7f0b00d4
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131427540;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int Base_Widget_AppCompat_ListView = 2131296416;
+			// aapt resource value: 0x7f0b00d5
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427541;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131296417;
+			// aapt resource value: 0x7f0b00d6
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427542;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131296418;
+			// aapt resource value: 0x7f0b0084
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427460;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int Base_Widget_AppCompat_PopupMenu = 2131296419;
+			// aapt resource value: 0x7f0b0085
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427461;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296420;
+			// aapt resource value: 0x7f0b0086
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427462;
 			
-			// aapt resource value: 0x7f0900e2
-			public const int Base_Widget_AppCompat_PopupWindow = 2131296482;
+			// aapt resource value: 0x7f0b0087
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131427463;
 			
-			// aapt resource value: 0x7f090045
-			public const int Base_Widget_AppCompat_ProgressBar = 2131296325;
+			// aapt resource value: 0x7f0b0088
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427464;
 			
-			// aapt resource value: 0x7f090046
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296326;
+			// aapt resource value: 0x7f0b00d7
+			public const int Base_Widget_AppCompat_ListMenuView = 2131427543;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int Base_Widget_AppCompat_RatingBar = 2131296421;
+			// aapt resource value: 0x7f0b0089
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131427465;
 			
-			// aapt resource value: 0x7f0900b4
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131296436;
+			// aapt resource value: 0x7f0b008a
+			public const int Base_Widget_AppCompat_ListView = 2131427466;
 			
-			// aapt resource value: 0x7f0900b5
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131296437;
+			// aapt resource value: 0x7f0b008b
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131427467;
 			
-			// aapt resource value: 0x7f0900e3
-			public const int Base_Widget_AppCompat_SearchView = 2131296483;
+			// aapt resource value: 0x7f0b008c
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131427468;
 			
-			// aapt resource value: 0x7f0900e4
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131296484;
+			// aapt resource value: 0x7f0b008d
+			public const int Base_Widget_AppCompat_PopupMenu = 2131427469;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int Base_Widget_AppCompat_SeekBar = 2131296422;
+			// aapt resource value: 0x7f0b008e
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427470;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int Base_Widget_AppCompat_Spinner = 2131296423;
+			// aapt resource value: 0x7f0b00d8
+			public const int Base_Widget_AppCompat_PopupWindow = 2131427544;
 			
-			// aapt resource value: 0x7f090033
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131296307;
+			// aapt resource value: 0x7f0b002b
+			public const int Base_Widget_AppCompat_ProgressBar = 2131427371;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296424;
+			// aapt resource value: 0x7f0b002c
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427372;
 			
-			// aapt resource value: 0x7f0900e5
-			public const int Base_Widget_AppCompat_Toolbar = 2131296485;
+			// aapt resource value: 0x7f0b008f
+			public const int Base_Widget_AppCompat_RatingBar = 2131427471;
 			
-			// aapt resource value: 0x7f0900a9
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296425;
+			// aapt resource value: 0x7f0b00a8
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131427496;
 			
-			// aapt resource value: 0x7f090019
-			public const int Base_Widget_Design_TabLayout = 2131296281;
+			// aapt resource value: 0x7f0b00a9
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131427497;
 			
-			// aapt resource value: 0x7f09016e
-			public const int CardView = 2131296622;
+			// aapt resource value: 0x7f0b00d9
+			public const int Base_Widget_AppCompat_SearchView = 2131427545;
 			
-			// aapt resource value: 0x7f090170
-			public const int CardView_Dark = 2131296624;
+			// aapt resource value: 0x7f0b00da
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131427546;
 			
-			// aapt resource value: 0x7f090171
-			public const int CardView_Light = 2131296625;
+			// aapt resource value: 0x7f0b0090
+			public const int Base_Widget_AppCompat_SeekBar = 2131427472;
 			
-			// aapt resource value: 0x7f090172
-			public const int MyTheme = 2131296626;
+			// aapt resource value: 0x7f0b00db
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131427547;
 			
-			// aapt resource value: 0x7f090173
-			public const int MyTheme_Base = 2131296627;
+			// aapt resource value: 0x7f0b0091
+			public const int Base_Widget_AppCompat_Spinner = 2131427473;
 			
-			// aapt resource value: 0x7f090047
-			public const int Platform_AppCompat = 2131296327;
+			// aapt resource value: 0x7f0b0012
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131427346;
 			
-			// aapt resource value: 0x7f090048
-			public const int Platform_AppCompat_Light = 2131296328;
+			// aapt resource value: 0x7f0b0092
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131427474;
 			
-			// aapt resource value: 0x7f0900aa
-			public const int Platform_ThemeOverlay_AppCompat = 2131296426;
+			// aapt resource value: 0x7f0b00dc
+			public const int Base_Widget_AppCompat_Toolbar = 2131427548;
 			
-			// aapt resource value: 0x7f0900ab
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131296427;
+			// aapt resource value: 0x7f0b0093
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427475;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131296428;
+			// aapt resource value: 0x7f0b0171
+			public const int Base_Widget_Design_AppBarLayout = 2131427697;
 			
-			// aapt resource value: 0x7f090049
-			public const int Platform_V11_AppCompat = 2131296329;
+			// aapt resource value: 0x7f0b0172
+			public const int Base_Widget_Design_TabLayout = 2131427698;
 			
-			// aapt resource value: 0x7f09004a
-			public const int Platform_V11_AppCompat_Light = 2131296330;
+			// aapt resource value: 0x7f0b000b
+			public const int CardView = 2131427339;
 			
-			// aapt resource value: 0x7f090051
-			public const int Platform_V14_AppCompat = 2131296337;
+			// aapt resource value: 0x7f0b000d
+			public const int CardView_Dark = 2131427341;
 			
-			// aapt resource value: 0x7f090052
-			public const int Platform_V14_AppCompat_Light = 2131296338;
+			// aapt resource value: 0x7f0b000e
+			public const int CardView_Light = 2131427342;
 			
-			// aapt resource value: 0x7f09004b
-			public const int Platform_Widget_AppCompat_Spinner = 2131296331;
+			// aapt resource value: 0x7f0b0189
+			public const int MyTheme = 2131427721;
 			
-			// aapt resource value: 0x7f090058
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131296344;
+			// aapt resource value: 0x7f0b018a
+			public const int MyTheme_Base = 2131427722;
 			
-			// aapt resource value: 0x7f090059
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296345;
+			// aapt resource value: 0x7f0b002d
+			public const int Platform_AppCompat = 2131427373;
 			
-			// aapt resource value: 0x7f09005a
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296346;
+			// aapt resource value: 0x7f0b002e
+			public const int Platform_AppCompat_Light = 2131427374;
 			
-			// aapt resource value: 0x7f09005b
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296347;
+			// aapt resource value: 0x7f0b0094
+			public const int Platform_ThemeOverlay_AppCompat = 2131427476;
 			
-			// aapt resource value: 0x7f09005c
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296348;
+			// aapt resource value: 0x7f0b0095
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131427477;
 			
-			// aapt resource value: 0x7f09005d
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296349;
+			// aapt resource value: 0x7f0b0096
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131427478;
 			
-			// aapt resource value: 0x7f09005e
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296350;
+			// aapt resource value: 0x7f0b002f
+			public const int Platform_V11_AppCompat = 2131427375;
 			
-			// aapt resource value: 0x7f09005f
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296351;
+			// aapt resource value: 0x7f0b0030
+			public const int Platform_V11_AppCompat_Light = 2131427376;
 			
-			// aapt resource value: 0x7f090060
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296352;
+			// aapt resource value: 0x7f0b0037
+			public const int Platform_V14_AppCompat = 2131427383;
 			
-			// aapt resource value: 0x7f090061
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296353;
+			// aapt resource value: 0x7f0b0038
+			public const int Platform_V14_AppCompat_Light = 2131427384;
 			
-			// aapt resource value: 0x7f090062
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296354;
+			// aapt resource value: 0x7f0b0097
+			public const int Platform_V21_AppCompat = 2131427479;
 			
-			// aapt resource value: 0x7f090063
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296355;
+			// aapt resource value: 0x7f0b0098
+			public const int Platform_V21_AppCompat_Light = 2131427480;
 			
-			// aapt resource value: 0x7f090064
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131296356;
+			// aapt resource value: 0x7f0b00ac
+			public const int Platform_V25_AppCompat = 2131427500;
 			
-			// aapt resource value: 0x7f090065
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131296357;
+			// aapt resource value: 0x7f0b00ad
+			public const int Platform_V25_AppCompat_Light = 2131427501;
 			
-			// aapt resource value: 0x7f0900e6
-			public const int TextAppearance_AppCompat = 2131296486;
+			// aapt resource value: 0x7f0b0031
+			public const int Platform_Widget_AppCompat_Spinner = 2131427377;
 			
-			// aapt resource value: 0x7f0900e7
-			public const int TextAppearance_AppCompat_Body1 = 2131296487;
+			// aapt resource value: 0x7f0b0040
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131427392;
 			
-			// aapt resource value: 0x7f0900e8
-			public const int TextAppearance_AppCompat_Body2 = 2131296488;
+			// aapt resource value: 0x7f0b0041
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427393;
 			
-			// aapt resource value: 0x7f0900e9
-			public const int TextAppearance_AppCompat_Button = 2131296489;
+			// aapt resource value: 0x7f0b0042
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131427394;
 			
-			// aapt resource value: 0x7f0900ea
-			public const int TextAppearance_AppCompat_Caption = 2131296490;
+			// aapt resource value: 0x7f0b0043
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427395;
 			
-			// aapt resource value: 0x7f0900eb
-			public const int TextAppearance_AppCompat_Display1 = 2131296491;
+			// aapt resource value: 0x7f0b0044
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427396;
 			
-			// aapt resource value: 0x7f0900ec
-			public const int TextAppearance_AppCompat_Display2 = 2131296492;
+			// aapt resource value: 0x7f0b0045
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427397;
 			
-			// aapt resource value: 0x7f0900ed
-			public const int TextAppearance_AppCompat_Display3 = 2131296493;
+			// aapt resource value: 0x7f0b0046
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427398;
 			
-			// aapt resource value: 0x7f0900ee
-			public const int TextAppearance_AppCompat_Display4 = 2131296494;
+			// aapt resource value: 0x7f0b0047
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427399;
 			
-			// aapt resource value: 0x7f0900ef
-			public const int TextAppearance_AppCompat_Headline = 2131296495;
+			// aapt resource value: 0x7f0b0048
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427400;
 			
-			// aapt resource value: 0x7f0900f0
-			public const int TextAppearance_AppCompat_Inverse = 2131296496;
+			// aapt resource value: 0x7f0b0049
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427401;
 			
-			// aapt resource value: 0x7f0900f1
-			public const int TextAppearance_AppCompat_Large = 2131296497;
+			// aapt resource value: 0x7f0b004a
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427402;
 			
-			// aapt resource value: 0x7f0900f2
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131296498;
+			// aapt resource value: 0x7f0b004b
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427403;
 			
-			// aapt resource value: 0x7f0900f3
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296499;
+			// aapt resource value: 0x7f0b004c
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131427404;
 			
-			// aapt resource value: 0x7f0900f4
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296500;
+			// aapt resource value: 0x7f0b004d
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131427405;
 			
-			// aapt resource value: 0x7f0900f5
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296501;
+			// aapt resource value: 0x7f0b00dd
+			public const int TextAppearance_AppCompat = 2131427549;
 			
-			// aapt resource value: 0x7f0900f6
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296502;
+			// aapt resource value: 0x7f0b00de
+			public const int TextAppearance_AppCompat_Body1 = 2131427550;
 			
-			// aapt resource value: 0x7f0900f7
-			public const int TextAppearance_AppCompat_Medium = 2131296503;
+			// aapt resource value: 0x7f0b00df
+			public const int TextAppearance_AppCompat_Body2 = 2131427551;
 			
-			// aapt resource value: 0x7f0900f8
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131296504;
+			// aapt resource value: 0x7f0b00e0
+			public const int TextAppearance_AppCompat_Button = 2131427552;
 			
-			// aapt resource value: 0x7f0900f9
-			public const int TextAppearance_AppCompat_Menu = 2131296505;
+			// aapt resource value: 0x7f0b00e1
+			public const int TextAppearance_AppCompat_Caption = 2131427553;
 			
-			// aapt resource value: 0x7f0900fa
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296506;
+			// aapt resource value: 0x7f0b00e2
+			public const int TextAppearance_AppCompat_Display1 = 2131427554;
 			
-			// aapt resource value: 0x7f0900fb
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131296507;
+			// aapt resource value: 0x7f0b00e3
+			public const int TextAppearance_AppCompat_Display2 = 2131427555;
 			
-			// aapt resource value: 0x7f0900fc
-			public const int TextAppearance_AppCompat_Small = 2131296508;
+			// aapt resource value: 0x7f0b00e4
+			public const int TextAppearance_AppCompat_Display3 = 2131427556;
 			
-			// aapt resource value: 0x7f0900fd
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131296509;
+			// aapt resource value: 0x7f0b00e5
+			public const int TextAppearance_AppCompat_Display4 = 2131427557;
 			
-			// aapt resource value: 0x7f0900fe
-			public const int TextAppearance_AppCompat_Subhead = 2131296510;
+			// aapt resource value: 0x7f0b00e6
+			public const int TextAppearance_AppCompat_Headline = 2131427558;
 			
-			// aapt resource value: 0x7f0900ff
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131296511;
+			// aapt resource value: 0x7f0b00e7
+			public const int TextAppearance_AppCompat_Inverse = 2131427559;
 			
-			// aapt resource value: 0x7f090100
-			public const int TextAppearance_AppCompat_Title = 2131296512;
+			// aapt resource value: 0x7f0b00e8
+			public const int TextAppearance_AppCompat_Large = 2131427560;
 			
-			// aapt resource value: 0x7f090101
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131296513;
+			// aapt resource value: 0x7f0b00e9
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131427561;
 			
-			// aapt resource value: 0x7f090102
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296514;
+			// aapt resource value: 0x7f0b00ea
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427562;
 			
-			// aapt resource value: 0x7f090103
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296515;
+			// aapt resource value: 0x7f0b00eb
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427563;
 			
-			// aapt resource value: 0x7f090104
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296516;
+			// aapt resource value: 0x7f0b00ec
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427564;
 			
-			// aapt resource value: 0x7f090105
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296517;
+			// aapt resource value: 0x7f0b00ed
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427565;
 			
-			// aapt resource value: 0x7f090106
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296518;
+			// aapt resource value: 0x7f0b00ee
+			public const int TextAppearance_AppCompat_Medium = 2131427566;
 			
-			// aapt resource value: 0x7f090107
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296519;
+			// aapt resource value: 0x7f0b00ef
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131427567;
 			
-			// aapt resource value: 0x7f090108
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296520;
+			// aapt resource value: 0x7f0b00f0
+			public const int TextAppearance_AppCompat_Menu = 2131427568;
 			
-			// aapt resource value: 0x7f090109
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296521;
+			// aapt resource value: 0x7f0b0039
+			public const int TextAppearance_AppCompat_Notification = 2131427385;
 			
-			// aapt resource value: 0x7f09010a
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296522;
+			// aapt resource value: 0x7f0b0099
+			public const int TextAppearance_AppCompat_Notification_Info = 2131427481;
 			
-			// aapt resource value: 0x7f09010b
-			public const int TextAppearance_AppCompat_Widget_Button = 2131296523;
+			// aapt resource value: 0x7f0b009a
+			public const int TextAppearance_AppCompat_Notification_Info_Media = 2131427482;
 			
-			// aapt resource value: 0x7f09010c
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131296524;
+			// aapt resource value: 0x7f0b00f1
+			public const int TextAppearance_AppCompat_Notification_Line2 = 2131427569;
 			
-			// aapt resource value: 0x7f09010d
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131296525;
+			// aapt resource value: 0x7f0b00f2
+			public const int TextAppearance_AppCompat_Notification_Line2_Media = 2131427570;
 			
-			// aapt resource value: 0x7f09010e
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296526;
+			// aapt resource value: 0x7f0b009b
+			public const int TextAppearance_AppCompat_Notification_Media = 2131427483;
 			
-			// aapt resource value: 0x7f09010f
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296527;
+			// aapt resource value: 0x7f0b009c
+			public const int TextAppearance_AppCompat_Notification_Time = 2131427484;
 			
-			// aapt resource value: 0x7f090110
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131296528;
+			// aapt resource value: 0x7f0b009d
+			public const int TextAppearance_AppCompat_Notification_Time_Media = 2131427485;
 			
-			// aapt resource value: 0x7f090111
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296529;
+			// aapt resource value: 0x7f0b003a
+			public const int TextAppearance_AppCompat_Notification_Title = 2131427386;
 			
-			// aapt resource value: 0x7f09001a
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131296282;
+			// aapt resource value: 0x7f0b009e
+			public const int TextAppearance_AppCompat_Notification_Title_Media = 2131427486;
 			
-			// aapt resource value: 0x7f09001b
-			public const int TextAppearance_Design_Counter = 2131296283;
+			// aapt resource value: 0x7f0b00f3
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427571;
 			
-			// aapt resource value: 0x7f09001c
-			public const int TextAppearance_Design_Counter_Overflow = 2131296284;
+			// aapt resource value: 0x7f0b00f4
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131427572;
 			
-			// aapt resource value: 0x7f09001d
-			public const int TextAppearance_Design_Error = 2131296285;
+			// aapt resource value: 0x7f0b00f5
+			public const int TextAppearance_AppCompat_Small = 2131427573;
 			
-			// aapt resource value: 0x7f09001e
-			public const int TextAppearance_Design_Hint = 2131296286;
+			// aapt resource value: 0x7f0b00f6
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131427574;
 			
-			// aapt resource value: 0x7f09001f
-			public const int TextAppearance_Design_Snackbar_Message = 2131296287;
+			// aapt resource value: 0x7f0b00f7
+			public const int TextAppearance_AppCompat_Subhead = 2131427575;
 			
-			// aapt resource value: 0x7f090020
-			public const int TextAppearance_Design_Tab = 2131296288;
+			// aapt resource value: 0x7f0b00f8
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131427576;
 			
-			// aapt resource value: 0x7f090053
-			public const int TextAppearance_StatusBar_EventContent = 2131296339;
+			// aapt resource value: 0x7f0b00f9
+			public const int TextAppearance_AppCompat_Title = 2131427577;
 			
-			// aapt resource value: 0x7f090054
-			public const int TextAppearance_StatusBar_EventContent_Info = 2131296340;
+			// aapt resource value: 0x7f0b00fa
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131427578;
 			
-			// aapt resource value: 0x7f090055
-			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131296341;
+			// aapt resource value: 0x7f0b00fb
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427579;
 			
-			// aapt resource value: 0x7f090056
-			public const int TextAppearance_StatusBar_EventContent_Time = 2131296342;
+			// aapt resource value: 0x7f0b00fc
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427580;
 			
-			// aapt resource value: 0x7f090057
-			public const int TextAppearance_StatusBar_EventContent_Title = 2131296343;
+			// aapt resource value: 0x7f0b00fd
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427581;
 			
-			// aapt resource value: 0x7f090112
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296530;
+			// aapt resource value: 0x7f0b00fe
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427582;
 			
-			// aapt resource value: 0x7f090113
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296531;
+			// aapt resource value: 0x7f0b00ff
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427583;
 			
-			// aapt resource value: 0x7f090114
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296532;
+			// aapt resource value: 0x7f0b0100
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427584;
 			
-			// aapt resource value: 0x7f090115
-			public const int Theme_AppCompat = 2131296533;
+			// aapt resource value: 0x7f0b0101
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427585;
 			
-			// aapt resource value: 0x7f090116
-			public const int Theme_AppCompat_CompactMenu = 2131296534;
+			// aapt resource value: 0x7f0b0102
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427586;
 			
-			// aapt resource value: 0x7f090034
-			public const int Theme_AppCompat_DayNight = 2131296308;
+			// aapt resource value: 0x7f0b0103
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427587;
 			
-			// aapt resource value: 0x7f090035
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131296309;
+			// aapt resource value: 0x7f0b0104
+			public const int TextAppearance_AppCompat_Widget_Button = 2131427588;
 			
-			// aapt resource value: 0x7f090036
-			public const int Theme_AppCompat_DayNight_Dialog = 2131296310;
+			// aapt resource value: 0x7f0b0105
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427589;
 			
-			// aapt resource value: 0x7f090037
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131296311;
+			// aapt resource value: 0x7f0b0106
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131427590;
 			
-			// aapt resource value: 0x7f090038
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131296312;
+			// aapt resource value: 0x7f0b0107
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131427591;
 			
-			// aapt resource value: 0x7f090039
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131296313;
+			// aapt resource value: 0x7f0b0108
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131427592;
 			
-			// aapt resource value: 0x7f09003a
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131296314;
+			// aapt resource value: 0x7f0b0109
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427593;
 			
-			// aapt resource value: 0x7f090117
-			public const int Theme_AppCompat_Dialog = 2131296535;
+			// aapt resource value: 0x7f0b010a
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427594;
 			
-			// aapt resource value: 0x7f090118
-			public const int Theme_AppCompat_Dialog_Alert = 2131296536;
+			// aapt resource value: 0x7f0b010b
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427595;
 			
-			// aapt resource value: 0x7f090119
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131296537;
+			// aapt resource value: 0x7f0b010c
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131427596;
 			
-			// aapt resource value: 0x7f09011a
-			public const int Theme_AppCompat_DialogWhenLarge = 2131296538;
+			// aapt resource value: 0x7f0b010d
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427597;
 			
-			// aapt resource value: 0x7f09011b
-			public const int Theme_AppCompat_Light = 2131296539;
+			// aapt resource value: 0x7f0b0173
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131427699;
 			
-			// aapt resource value: 0x7f09011c
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131296540;
+			// aapt resource value: 0x7f0b0174
+			public const int TextAppearance_Design_Counter = 2131427700;
 			
-			// aapt resource value: 0x7f09011d
-			public const int Theme_AppCompat_Light_Dialog = 2131296541;
+			// aapt resource value: 0x7f0b0175
+			public const int TextAppearance_Design_Counter_Overflow = 2131427701;
 			
-			// aapt resource value: 0x7f09011e
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131296542;
+			// aapt resource value: 0x7f0b0176
+			public const int TextAppearance_Design_Error = 2131427702;
 			
-			// aapt resource value: 0x7f09011f
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131296543;
+			// aapt resource value: 0x7f0b0177
+			public const int TextAppearance_Design_Hint = 2131427703;
 			
-			// aapt resource value: 0x7f090120
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131296544;
+			// aapt resource value: 0x7f0b0178
+			public const int TextAppearance_Design_Snackbar_Message = 2131427704;
 			
-			// aapt resource value: 0x7f090121
-			public const int Theme_AppCompat_Light_NoActionBar = 2131296545;
+			// aapt resource value: 0x7f0b0179
+			public const int TextAppearance_Design_Tab = 2131427705;
 			
-			// aapt resource value: 0x7f090122
-			public const int Theme_AppCompat_NoActionBar = 2131296546;
+			// aapt resource value: 0x7f0b0000
+			public const int TextAppearance_MediaRouter_PrimaryText = 2131427328;
 			
-			// aapt resource value: 0x7f090021
-			public const int Theme_Design = 2131296289;
+			// aapt resource value: 0x7f0b0001
+			public const int TextAppearance_MediaRouter_SecondaryText = 2131427329;
 			
-			// aapt resource value: 0x7f090022
-			public const int Theme_Design_BottomSheetDialog = 2131296290;
+			// aapt resource value: 0x7f0b0002
+			public const int TextAppearance_MediaRouter_Title = 2131427330;
 			
-			// aapt resource value: 0x7f090023
-			public const int Theme_Design_Light = 2131296291;
+			// aapt resource value: 0x7f0b003b
+			public const int TextAppearance_StatusBar_EventContent = 2131427387;
 			
-			// aapt resource value: 0x7f090024
-			public const int Theme_Design_Light_BottomSheetDialog = 2131296292;
+			// aapt resource value: 0x7f0b003c
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131427388;
 			
-			// aapt resource value: 0x7f090025
-			public const int Theme_Design_Light_NoActionBar = 2131296293;
+			// aapt resource value: 0x7f0b003d
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131427389;
 			
-			// aapt resource value: 0x7f090026
-			public const int Theme_Design_NoActionBar = 2131296294;
+			// aapt resource value: 0x7f0b003e
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131427390;
 			
-			// aapt resource value: 0x7f090000
-			public const int Theme_MediaRouter = 2131296256;
+			// aapt resource value: 0x7f0b003f
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131427391;
 			
-			// aapt resource value: 0x7f090001
-			public const int Theme_MediaRouter_Light = 2131296257;
+			// aapt resource value: 0x7f0b010e
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427598;
 			
-			// aapt resource value: 0x7f090002
-			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131296258;
+			// aapt resource value: 0x7f0b010f
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427599;
 			
-			// aapt resource value: 0x7f090003
-			public const int Theme_MediaRouter_LightControlPanel = 2131296259;
+			// aapt resource value: 0x7f0b0110
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427600;
 			
-			// aapt resource value: 0x7f090123
-			public const int ThemeOverlay_AppCompat = 2131296547;
+			// aapt resource value: 0x7f0b0111
+			public const int Theme_AppCompat = 2131427601;
 			
-			// aapt resource value: 0x7f090124
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131296548;
+			// aapt resource value: 0x7f0b0112
+			public const int Theme_AppCompat_CompactMenu = 2131427602;
 			
-			// aapt resource value: 0x7f090125
-			public const int ThemeOverlay_AppCompat_Dark = 2131296549;
+			// aapt resource value: 0x7f0b0013
+			public const int Theme_AppCompat_DayNight = 2131427347;
 			
-			// aapt resource value: 0x7f090126
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296550;
+			// aapt resource value: 0x7f0b0014
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131427348;
 			
-			// aapt resource value: 0x7f090127
-			public const int ThemeOverlay_AppCompat_Light = 2131296551;
+			// aapt resource value: 0x7f0b0015
+			public const int Theme_AppCompat_DayNight_Dialog = 2131427349;
 			
-			// aapt resource value: 0x7f090128
-			public const int Widget_AppCompat_ActionBar = 2131296552;
+			// aapt resource value: 0x7f0b0016
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131427350;
 			
-			// aapt resource value: 0x7f090129
-			public const int Widget_AppCompat_ActionBar_Solid = 2131296553;
+			// aapt resource value: 0x7f0b0017
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131427351;
 			
-			// aapt resource value: 0x7f09012a
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131296554;
+			// aapt resource value: 0x7f0b0018
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131427352;
 			
-			// aapt resource value: 0x7f09012b
-			public const int Widget_AppCompat_ActionBar_TabText = 2131296555;
+			// aapt resource value: 0x7f0b0019
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131427353;
 			
-			// aapt resource value: 0x7f09012c
-			public const int Widget_AppCompat_ActionBar_TabView = 2131296556;
+			// aapt resource value: 0x7f0b0113
+			public const int Theme_AppCompat_Dialog = 2131427603;
 			
-			// aapt resource value: 0x7f09012d
-			public const int Widget_AppCompat_ActionButton = 2131296557;
+			// aapt resource value: 0x7f0b0114
+			public const int Theme_AppCompat_Dialog_Alert = 2131427604;
 			
-			// aapt resource value: 0x7f09012e
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131296558;
+			// aapt resource value: 0x7f0b0115
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131427605;
 			
-			// aapt resource value: 0x7f09012f
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131296559;
+			// aapt resource value: 0x7f0b0116
+			public const int Theme_AppCompat_DialogWhenLarge = 2131427606;
 			
-			// aapt resource value: 0x7f090130
-			public const int Widget_AppCompat_ActionMode = 2131296560;
+			// aapt resource value: 0x7f0b0117
+			public const int Theme_AppCompat_Light = 2131427607;
 			
-			// aapt resource value: 0x7f090131
-			public const int Widget_AppCompat_ActivityChooserView = 2131296561;
+			// aapt resource value: 0x7f0b0118
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131427608;
 			
-			// aapt resource value: 0x7f090132
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131296562;
+			// aapt resource value: 0x7f0b0119
+			public const int Theme_AppCompat_Light_Dialog = 2131427609;
 			
-			// aapt resource value: 0x7f090133
-			public const int Widget_AppCompat_Button = 2131296563;
+			// aapt resource value: 0x7f0b011a
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131427610;
 			
-			// aapt resource value: 0x7f090134
-			public const int Widget_AppCompat_Button_Borderless = 2131296564;
+			// aapt resource value: 0x7f0b011b
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131427611;
 			
-			// aapt resource value: 0x7f090135
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131296565;
+			// aapt resource value: 0x7f0b011c
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131427612;
 			
-			// aapt resource value: 0x7f090136
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296566;
+			// aapt resource value: 0x7f0b011d
+			public const int Theme_AppCompat_Light_NoActionBar = 2131427613;
 			
-			// aapt resource value: 0x7f090137
-			public const int Widget_AppCompat_Button_Colored = 2131296567;
+			// aapt resource value: 0x7f0b011e
+			public const int Theme_AppCompat_NoActionBar = 2131427614;
 			
-			// aapt resource value: 0x7f090138
-			public const int Widget_AppCompat_Button_Small = 2131296568;
+			// aapt resource value: 0x7f0b017a
+			public const int Theme_Design = 2131427706;
 			
-			// aapt resource value: 0x7f090139
-			public const int Widget_AppCompat_ButtonBar = 2131296569;
+			// aapt resource value: 0x7f0b017b
+			public const int Theme_Design_BottomSheetDialog = 2131427707;
 			
-			// aapt resource value: 0x7f09013a
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131296570;
+			// aapt resource value: 0x7f0b017c
+			public const int Theme_Design_Light = 2131427708;
 			
-			// aapt resource value: 0x7f09013b
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131296571;
+			// aapt resource value: 0x7f0b017d
+			public const int Theme_Design_Light_BottomSheetDialog = 2131427709;
 			
-			// aapt resource value: 0x7f09013c
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131296572;
+			// aapt resource value: 0x7f0b017e
+			public const int Theme_Design_Light_NoActionBar = 2131427710;
 			
-			// aapt resource value: 0x7f09013d
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131296573;
+			// aapt resource value: 0x7f0b017f
+			public const int Theme_Design_NoActionBar = 2131427711;
 			
-			// aapt resource value: 0x7f09013e
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131296574;
+			// aapt resource value: 0x7f0b0003
+			public const int Theme_MediaRouter = 2131427331;
 			
-			// aapt resource value: 0x7f09013f
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131296575;
+			// aapt resource value: 0x7f0b0004
+			public const int Theme_MediaRouter_Light = 2131427332;
 			
-			// aapt resource value: 0x7f090140
-			public const int Widget_AppCompat_EditText = 2131296576;
+			// aapt resource value: 0x7f0b0005
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131427333;
 			
-			// aapt resource value: 0x7f090141
-			public const int Widget_AppCompat_ImageButton = 2131296577;
+			// aapt resource value: 0x7f0b0006
+			public const int Theme_MediaRouter_LightControlPanel = 2131427334;
 			
-			// aapt resource value: 0x7f090142
-			public const int Widget_AppCompat_Light_ActionBar = 2131296578;
+			// aapt resource value: 0x7f0b011f
+			public const int ThemeOverlay_AppCompat = 2131427615;
 			
-			// aapt resource value: 0x7f090143
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131296579;
+			// aapt resource value: 0x7f0b0120
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131427616;
 			
-			// aapt resource value: 0x7f090144
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296580;
+			// aapt resource value: 0x7f0b0121
+			public const int ThemeOverlay_AppCompat_Dark = 2131427617;
 			
-			// aapt resource value: 0x7f090145
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131296581;
+			// aapt resource value: 0x7f0b0122
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427618;
 			
-			// aapt resource value: 0x7f090146
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296582;
+			// aapt resource value: 0x7f0b0123
+			public const int ThemeOverlay_AppCompat_Dialog = 2131427619;
 			
-			// aapt resource value: 0x7f090147
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131296583;
+			// aapt resource value: 0x7f0b0124
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131427620;
 			
-			// aapt resource value: 0x7f090148
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296584;
+			// aapt resource value: 0x7f0b0125
+			public const int ThemeOverlay_AppCompat_Light = 2131427621;
 			
-			// aapt resource value: 0x7f090149
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131296585;
+			// aapt resource value: 0x7f0b0007
+			public const int ThemeOverlay_MediaRouter_Dark = 2131427335;
 			
-			// aapt resource value: 0x7f09014a
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296586;
+			// aapt resource value: 0x7f0b0008
+			public const int ThemeOverlay_MediaRouter_Light = 2131427336;
 			
-			// aapt resource value: 0x7f09014b
-			public const int Widget_AppCompat_Light_ActionButton = 2131296587;
+			// aapt resource value: 0x7f0b0126
+			public const int Widget_AppCompat_ActionBar = 2131427622;
 			
-			// aapt resource value: 0x7f09014c
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296588;
+			// aapt resource value: 0x7f0b0127
+			public const int Widget_AppCompat_ActionBar_Solid = 2131427623;
 			
-			// aapt resource value: 0x7f09014d
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131296589;
+			// aapt resource value: 0x7f0b0128
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131427624;
 			
-			// aapt resource value: 0x7f09014e
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131296590;
+			// aapt resource value: 0x7f0b0129
+			public const int Widget_AppCompat_ActionBar_TabText = 2131427625;
 			
-			// aapt resource value: 0x7f09014f
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131296591;
+			// aapt resource value: 0x7f0b012a
+			public const int Widget_AppCompat_ActionBar_TabView = 2131427626;
 			
-			// aapt resource value: 0x7f090150
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131296592;
+			// aapt resource value: 0x7f0b012b
+			public const int Widget_AppCompat_ActionButton = 2131427627;
 			
-			// aapt resource value: 0x7f090151
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296593;
+			// aapt resource value: 0x7f0b012c
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131427628;
 			
-			// aapt resource value: 0x7f090152
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131296594;
+			// aapt resource value: 0x7f0b012d
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131427629;
 			
-			// aapt resource value: 0x7f090153
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131296595;
+			// aapt resource value: 0x7f0b012e
+			public const int Widget_AppCompat_ActionMode = 2131427630;
 			
-			// aapt resource value: 0x7f090154
-			public const int Widget_AppCompat_Light_PopupMenu = 2131296596;
+			// aapt resource value: 0x7f0b012f
+			public const int Widget_AppCompat_ActivityChooserView = 2131427631;
 			
-			// aapt resource value: 0x7f090155
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296597;
+			// aapt resource value: 0x7f0b0130
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131427632;
 			
-			// aapt resource value: 0x7f090156
-			public const int Widget_AppCompat_Light_SearchView = 2131296598;
+			// aapt resource value: 0x7f0b0131
+			public const int Widget_AppCompat_Button = 2131427633;
 			
-			// aapt resource value: 0x7f090157
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296599;
+			// aapt resource value: 0x7f0b0132
+			public const int Widget_AppCompat_Button_Borderless = 2131427634;
 			
-			// aapt resource value: 0x7f090158
-			public const int Widget_AppCompat_ListPopupWindow = 2131296600;
+			// aapt resource value: 0x7f0b0133
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131427635;
 			
-			// aapt resource value: 0x7f090159
-			public const int Widget_AppCompat_ListView = 2131296601;
+			// aapt resource value: 0x7f0b0134
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427636;
 			
-			// aapt resource value: 0x7f09015a
-			public const int Widget_AppCompat_ListView_DropDown = 2131296602;
+			// aapt resource value: 0x7f0b0135
+			public const int Widget_AppCompat_Button_Colored = 2131427637;
 			
-			// aapt resource value: 0x7f09015b
-			public const int Widget_AppCompat_ListView_Menu = 2131296603;
+			// aapt resource value: 0x7f0b0136
+			public const int Widget_AppCompat_Button_Small = 2131427638;
 			
-			// aapt resource value: 0x7f09015c
-			public const int Widget_AppCompat_PopupMenu = 2131296604;
+			// aapt resource value: 0x7f0b0137
+			public const int Widget_AppCompat_ButtonBar = 2131427639;
 			
-			// aapt resource value: 0x7f09015d
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131296605;
+			// aapt resource value: 0x7f0b0138
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131427640;
 			
-			// aapt resource value: 0x7f09015e
-			public const int Widget_AppCompat_PopupWindow = 2131296606;
+			// aapt resource value: 0x7f0b0139
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131427641;
 			
-			// aapt resource value: 0x7f09015f
-			public const int Widget_AppCompat_ProgressBar = 2131296607;
+			// aapt resource value: 0x7f0b013a
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131427642;
 			
-			// aapt resource value: 0x7f090160
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131296608;
+			// aapt resource value: 0x7f0b013b
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131427643;
 			
-			// aapt resource value: 0x7f090161
-			public const int Widget_AppCompat_RatingBar = 2131296609;
+			// aapt resource value: 0x7f0b013c
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131427644;
 			
-			// aapt resource value: 0x7f090162
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131296610;
+			// aapt resource value: 0x7f0b013d
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131427645;
 			
-			// aapt resource value: 0x7f090163
-			public const int Widget_AppCompat_RatingBar_Small = 2131296611;
+			// aapt resource value: 0x7f0b013e
+			public const int Widget_AppCompat_EditText = 2131427646;
 			
-			// aapt resource value: 0x7f090164
-			public const int Widget_AppCompat_SearchView = 2131296612;
+			// aapt resource value: 0x7f0b013f
+			public const int Widget_AppCompat_ImageButton = 2131427647;
 			
-			// aapt resource value: 0x7f090165
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131296613;
+			// aapt resource value: 0x7f0b0140
+			public const int Widget_AppCompat_Light_ActionBar = 2131427648;
 			
-			// aapt resource value: 0x7f090166
-			public const int Widget_AppCompat_SeekBar = 2131296614;
+			// aapt resource value: 0x7f0b0141
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131427649;
 			
-			// aapt resource value: 0x7f090167
-			public const int Widget_AppCompat_Spinner = 2131296615;
+			// aapt resource value: 0x7f0b0142
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427650;
 			
-			// aapt resource value: 0x7f090168
-			public const int Widget_AppCompat_Spinner_DropDown = 2131296616;
+			// aapt resource value: 0x7f0b0143
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131427651;
 			
-			// aapt resource value: 0x7f090169
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296617;
+			// aapt resource value: 0x7f0b0144
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427652;
 			
-			// aapt resource value: 0x7f09016a
-			public const int Widget_AppCompat_Spinner_Underlined = 2131296618;
+			// aapt resource value: 0x7f0b0145
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131427653;
 			
-			// aapt resource value: 0x7f09016b
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131296619;
+			// aapt resource value: 0x7f0b0146
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427654;
 			
-			// aapt resource value: 0x7f09016c
-			public const int Widget_AppCompat_Toolbar = 2131296620;
+			// aapt resource value: 0x7f0b0147
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131427655;
 			
-			// aapt resource value: 0x7f09016d
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131296621;
+			// aapt resource value: 0x7f0b0148
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427656;
 			
-			// aapt resource value: 0x7f090027
-			public const int Widget_Design_AppBarLayout = 2131296295;
+			// aapt resource value: 0x7f0b0149
+			public const int Widget_AppCompat_Light_ActionButton = 2131427657;
 			
-			// aapt resource value: 0x7f090028
-			public const int Widget_Design_BottomSheet_Modal = 2131296296;
+			// aapt resource value: 0x7f0b014a
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427658;
 			
-			// aapt resource value: 0x7f090029
-			public const int Widget_Design_CollapsingToolbar = 2131296297;
+			// aapt resource value: 0x7f0b014b
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131427659;
 			
-			// aapt resource value: 0x7f09002a
-			public const int Widget_Design_CoordinatorLayout = 2131296298;
+			// aapt resource value: 0x7f0b014c
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131427660;
 			
-			// aapt resource value: 0x7f09002b
-			public const int Widget_Design_FloatingActionButton = 2131296299;
+			// aapt resource value: 0x7f0b014d
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131427661;
 			
-			// aapt resource value: 0x7f09002c
-			public const int Widget_Design_NavigationView = 2131296300;
+			// aapt resource value: 0x7f0b014e
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131427662;
 			
-			// aapt resource value: 0x7f09002d
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131296301;
+			// aapt resource value: 0x7f0b014f
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427663;
 			
-			// aapt resource value: 0x7f09002e
-			public const int Widget_Design_Snackbar = 2131296302;
+			// aapt resource value: 0x7f0b0150
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131427664;
 			
-			// aapt resource value: 0x7f090017
-			public const int Widget_Design_TabLayout = 2131296279;
+			// aapt resource value: 0x7f0b0151
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131427665;
 			
-			// aapt resource value: 0x7f09002f
-			public const int Widget_Design_TextInputLayout = 2131296303;
+			// aapt resource value: 0x7f0b0152
+			public const int Widget_AppCompat_Light_PopupMenu = 2131427666;
 			
-			// aapt resource value: 0x7f090004
-			public const int Widget_MediaRouter_ChooserText = 2131296260;
+			// aapt resource value: 0x7f0b0153
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427667;
 			
-			// aapt resource value: 0x7f090005
-			public const int Widget_MediaRouter_ChooserText_Primary = 2131296261;
+			// aapt resource value: 0x7f0b0154
+			public const int Widget_AppCompat_Light_SearchView = 2131427668;
 			
-			// aapt resource value: 0x7f090006
-			public const int Widget_MediaRouter_ChooserText_Primary_Dark = 2131296262;
+			// aapt resource value: 0x7f0b0155
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427669;
 			
-			// aapt resource value: 0x7f090007
-			public const int Widget_MediaRouter_ChooserText_Primary_Light = 2131296263;
+			// aapt resource value: 0x7f0b0156
+			public const int Widget_AppCompat_ListMenuView = 2131427670;
 			
-			// aapt resource value: 0x7f090008
-			public const int Widget_MediaRouter_ChooserText_Secondary = 2131296264;
+			// aapt resource value: 0x7f0b0157
+			public const int Widget_AppCompat_ListPopupWindow = 2131427671;
 			
-			// aapt resource value: 0x7f090009
-			public const int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131296265;
+			// aapt resource value: 0x7f0b0158
+			public const int Widget_AppCompat_ListView = 2131427672;
 			
-			// aapt resource value: 0x7f09000a
-			public const int Widget_MediaRouter_ChooserText_Secondary_Light = 2131296266;
+			// aapt resource value: 0x7f0b0159
+			public const int Widget_AppCompat_ListView_DropDown = 2131427673;
 			
-			// aapt resource value: 0x7f09000b
-			public const int Widget_MediaRouter_ControllerText = 2131296267;
+			// aapt resource value: 0x7f0b015a
+			public const int Widget_AppCompat_ListView_Menu = 2131427674;
 			
-			// aapt resource value: 0x7f09000c
-			public const int Widget_MediaRouter_ControllerText_Primary = 2131296268;
+			// aapt resource value: 0x7f0b009f
+			public const int Widget_AppCompat_NotificationActionContainer = 2131427487;
 			
-			// aapt resource value: 0x7f09000d
-			public const int Widget_MediaRouter_ControllerText_Primary_Dark = 2131296269;
+			// aapt resource value: 0x7f0b00a0
+			public const int Widget_AppCompat_NotificationActionText = 2131427488;
 			
-			// aapt resource value: 0x7f09000e
-			public const int Widget_MediaRouter_ControllerText_Primary_Light = 2131296270;
+			// aapt resource value: 0x7f0b015b
+			public const int Widget_AppCompat_PopupMenu = 2131427675;
 			
-			// aapt resource value: 0x7f09000f
-			public const int Widget_MediaRouter_ControllerText_Secondary = 2131296271;
+			// aapt resource value: 0x7f0b015c
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131427676;
 			
-			// aapt resource value: 0x7f090010
-			public const int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131296272;
+			// aapt resource value: 0x7f0b015d
+			public const int Widget_AppCompat_PopupWindow = 2131427677;
 			
-			// aapt resource value: 0x7f090011
-			public const int Widget_MediaRouter_ControllerText_Secondary_Light = 2131296273;
+			// aapt resource value: 0x7f0b015e
+			public const int Widget_AppCompat_ProgressBar = 2131427678;
 			
-			// aapt resource value: 0x7f090012
-			public const int Widget_MediaRouter_ControllerText_Title = 2131296274;
+			// aapt resource value: 0x7f0b015f
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131427679;
 			
-			// aapt resource value: 0x7f090013
-			public const int Widget_MediaRouter_ControllerText_Title_Dark = 2131296275;
+			// aapt resource value: 0x7f0b0160
+			public const int Widget_AppCompat_RatingBar = 2131427680;
 			
-			// aapt resource value: 0x7f090014
-			public const int Widget_MediaRouter_ControllerText_Title_Light = 2131296276;
+			// aapt resource value: 0x7f0b0161
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131427681;
 			
-			// aapt resource value: 0x7f090015
-			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131296277;
+			// aapt resource value: 0x7f0b0162
+			public const int Widget_AppCompat_RatingBar_Small = 2131427682;
 			
-			// aapt resource value: 0x7f090016
-			public const int Widget_MediaRouter_MediaRouteButton = 2131296278;
+			// aapt resource value: 0x7f0b0163
+			public const int Widget_AppCompat_SearchView = 2131427683;
+			
+			// aapt resource value: 0x7f0b0164
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131427684;
+			
+			// aapt resource value: 0x7f0b0165
+			public const int Widget_AppCompat_SeekBar = 2131427685;
+			
+			// aapt resource value: 0x7f0b0166
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131427686;
+			
+			// aapt resource value: 0x7f0b0167
+			public const int Widget_AppCompat_Spinner = 2131427687;
+			
+			// aapt resource value: 0x7f0b0168
+			public const int Widget_AppCompat_Spinner_DropDown = 2131427688;
+			
+			// aapt resource value: 0x7f0b0169
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427689;
+			
+			// aapt resource value: 0x7f0b016a
+			public const int Widget_AppCompat_Spinner_Underlined = 2131427690;
+			
+			// aapt resource value: 0x7f0b016b
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131427691;
+			
+			// aapt resource value: 0x7f0b016c
+			public const int Widget_AppCompat_Toolbar = 2131427692;
+			
+			// aapt resource value: 0x7f0b016d
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131427693;
+			
+			// aapt resource value: 0x7f0b016f
+			public const int Widget_Design_AppBarLayout = 2131427695;
+			
+			// aapt resource value: 0x7f0b0180
+			public const int Widget_Design_BottomNavigationView = 2131427712;
+			
+			// aapt resource value: 0x7f0b0181
+			public const int Widget_Design_BottomSheet_Modal = 2131427713;
+			
+			// aapt resource value: 0x7f0b0182
+			public const int Widget_Design_CollapsingToolbar = 2131427714;
+			
+			// aapt resource value: 0x7f0b0183
+			public const int Widget_Design_CoordinatorLayout = 2131427715;
+			
+			// aapt resource value: 0x7f0b0184
+			public const int Widget_Design_FloatingActionButton = 2131427716;
+			
+			// aapt resource value: 0x7f0b0185
+			public const int Widget_Design_NavigationView = 2131427717;
+			
+			// aapt resource value: 0x7f0b0186
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131427718;
+			
+			// aapt resource value: 0x7f0b0187
+			public const int Widget_Design_Snackbar = 2131427719;
+			
+			// aapt resource value: 0x7f0b016e
+			public const int Widget_Design_TabLayout = 2131427694;
+			
+			// aapt resource value: 0x7f0b0188
+			public const int Widget_Design_TextInputLayout = 2131427720;
+			
+			// aapt resource value: 0x7f0b0009
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131427337;
+			
+			// aapt resource value: 0x7f0b000a
+			public const int Widget_MediaRouter_MediaRouteButton = 2131427338;
 			
 			static Style()
 			{
@@ -6111,33 +7252,35 @@ namespace FABSample.Droid
 			
 			public static int[] ActionBar = new int[]
 			{
-					2130772061,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074,
-					2130772075,
-					2130772076,
-					2130772077,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772144};
+					2130771997,
+					2130771999,
+					2130772000,
+					2130772001,
+					2130772002,
+					2130772003,
+					2130772004,
+					2130772005,
+					2130772006,
+					2130772007,
+					2130772008,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012,
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772087};
 			
 			// aapt resource value: 10
 			public const int ActionBar_background = 10;
@@ -6151,6 +7294,9 @@ namespace FABSample.Droid
 			// aapt resource value: 21
 			public const int ActionBar_contentInsetEnd = 21;
 			
+			// aapt resource value: 25
+			public const int ActionBar_contentInsetEndWithActions = 25;
+			
 			// aapt resource value: 22
 			public const int ActionBar_contentInsetLeft = 22;
 			
@@ -6159,6 +7305,9 @@ namespace FABSample.Droid
 			
 			// aapt resource value: 20
 			public const int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public const int ActionBar_contentInsetStartWithNavigation = 24;
 			
 			// aapt resource value: 13
 			public const int ActionBar_customNavigationLayout = 13;
@@ -6169,8 +7318,8 @@ namespace FABSample.Droid
 			// aapt resource value: 9
 			public const int ActionBar_divider = 9;
 			
-			// aapt resource value: 24
-			public const int ActionBar_elevation = 24;
+			// aapt resource value: 26
+			public const int ActionBar_elevation = 26;
 			
 			// aapt resource value: 0
 			public const int ActionBar_height = 0;
@@ -6178,8 +7327,8 @@ namespace FABSample.Droid
 			// aapt resource value: 19
 			public const int ActionBar_hideOnContentScroll = 19;
 			
-			// aapt resource value: 26
-			public const int ActionBar_homeAsUpIndicator = 26;
+			// aapt resource value: 28
+			public const int ActionBar_homeAsUpIndicator = 28;
 			
 			// aapt resource value: 14
 			public const int ActionBar_homeLayout = 14;
@@ -6199,8 +7348,8 @@ namespace FABSample.Droid
 			// aapt resource value: 2
 			public const int ActionBar_navigationMode = 2;
 			
-			// aapt resource value: 25
-			public const int ActionBar_popupTheme = 25;
+			// aapt resource value: 27
+			public const int ActionBar_popupTheme = 27;
 			
 			// aapt resource value: 17
 			public const int ActionBar_progressBarPadding = 17;
@@ -6238,12 +7387,12 @@ namespace FABSample.Droid
 			
 			public static int[] ActionMode = new int[]
 			{
-					2130772061,
-					2130772067,
-					2130772068,
-					2130772072,
-					2130772074,
-					2130772088};
+					2130771997,
+					2130772003,
+					2130772004,
+					2130772008,
+					2130772010,
+					2130772026};
 			
 			// aapt resource value: 3
 			public const int ActionMode_background = 3;
@@ -6265,8 +7414,8 @@ namespace FABSample.Droid
 			
 			public static int[] ActivityChooserView = new int[]
 			{
-					2130772089,
-					2130772090};
+					2130772027,
+					2130772028};
 			
 			// aapt resource value: 1
 			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -6277,11 +7426,12 @@ namespace FABSample.Droid
 			public static int[] AlertDialog = new int[]
 			{
 					16842994,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095};
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
@@ -6298,39 +7448,53 @@ namespace FABSample.Droid
 			// aapt resource value: 3
 			public const int AlertDialog_multiChoiceItemLayout = 3;
 			
+			// aapt resource value: 6
+			public const int AlertDialog_showTitle = 6;
+			
 			// aapt resource value: 4
 			public const int AlertDialog_singleChoiceItemLayout = 4;
 			
 			public static int[] AppBarLayout = new int[]
 			{
 					16842964,
-					2130771991,
-					2130772086};
+					2130772024,
+					2130772224};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 2
-			public const int AppBarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public const int AppBarLayout_expanded = 1;
+			public const int AppBarLayout_elevation = 1;
 			
-			public static int[] AppBarLayout_LayoutParams = new int[]
+			// aapt resource value: 2
+			public const int AppBarLayout_expanded = 2;
+			
+			public static int[] AppBarLayoutStates = new int[]
 			{
-					2130771992,
-					2130771993};
+					2130772225,
+					2130772226};
 			
 			// aapt resource value: 0
-			public const int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
+			public const int AppBarLayoutStates_state_collapsed = 0;
 			
 			// aapt resource value: 1
-			public const int AppBarLayout_LayoutParams_layout_scrollInterpolator = 1;
+			public const int AppBarLayoutStates_state_collapsible = 1;
+			
+			public static int[] AppBarLayout_Layout = new int[]
+			{
+					2130772227,
+					2130772228};
+			
+			// aapt resource value: 0
+			public const int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public const int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
 			public static int[] AppCompatImageView = new int[]
 			{
 					16843033,
-					2130772096};
+					2130772035};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -6338,10 +7502,60 @@ namespace FABSample.Droid
 			// aapt resource value: 1
 			public const int AppCompatImageView_srcCompat = 1;
 			
+			public static int[] AppCompatSeekBar = new int[]
+			{
+					16843074,
+					2130772036,
+					2130772037,
+					2130772038};
+			
+			// aapt resource value: 0
+			public const int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public const int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[]
+			{
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public const int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public const int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public const int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTextHelper_android_textAppearance = 0;
+			
 			public static int[] AppCompatTextView = new int[]
 			{
 					16842804,
-					2130772097};
+					2130772039};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
@@ -6353,6 +7567,64 @@ namespace FABSample.Droid
 			{
 					16842839,
 					16842926,
+					2130772040,
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065,
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074,
+					2130772075,
+					2130772076,
+					2130772077,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
 					2130772098,
 					2130772099,
 					2130772100,
@@ -6407,62 +7679,7 @@ namespace FABSample.Droid
 					2130772149,
 					2130772150,
 					2130772151,
-					2130772152,
-					2130772153,
-					2130772154,
-					2130772155,
-					2130772156,
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164,
-					2130772165,
-					2130772166,
-					2130772167,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171,
-					2130772172,
-					2130772173,
-					2130772174,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207};
+					2130772152};
 			
 			// aapt resource value: 23
 			public const int AppCompatTheme_actionBarDivider = 23;
@@ -6497,11 +7714,11 @@ namespace FABSample.Droid
 			// aapt resource value: 21
 			public const int AppCompatTheme_actionBarWidgetTheme = 21;
 			
-			// aapt resource value: 49
-			public const int AppCompatTheme_actionButtonStyle = 49;
+			// aapt resource value: 50
+			public const int AppCompatTheme_actionButtonStyle = 50;
 			
-			// aapt resource value: 45
-			public const int AppCompatTheme_actionDropDownStyle = 45;
+			// aapt resource value: 46
+			public const int AppCompatTheme_actionDropDownStyle = 46;
 			
 			// aapt resource value: 25
 			public const int AppCompatTheme_actionMenuTextAppearance = 25;
@@ -6554,20 +7771,20 @@ namespace FABSample.Droid
 			// aapt resource value: 16
 			public const int AppCompatTheme_actionOverflowMenuStyle = 16;
 			
-			// aapt resource value: 57
-			public const int AppCompatTheme_activityChooserViewStyle = 57;
-			
-			// aapt resource value: 92
-			public const int AppCompatTheme_alertDialogButtonGroupStyle = 92;
-			
-			// aapt resource value: 93
-			public const int AppCompatTheme_alertDialogCenterButtons = 93;
-			
-			// aapt resource value: 91
-			public const int AppCompatTheme_alertDialogStyle = 91;
+			// aapt resource value: 58
+			public const int AppCompatTheme_activityChooserViewStyle = 58;
 			
 			// aapt resource value: 94
-			public const int AppCompatTheme_alertDialogTheme = 94;
+			public const int AppCompatTheme_alertDialogButtonGroupStyle = 94;
+			
+			// aapt resource value: 95
+			public const int AppCompatTheme_alertDialogCenterButtons = 95;
+			
+			// aapt resource value: 93
+			public const int AppCompatTheme_alertDialogStyle = 93;
+			
+			// aapt resource value: 96
+			public const int AppCompatTheme_alertDialogTheme = 96;
 			
 			// aapt resource value: 1
 			public const int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -6575,200 +7792,209 @@ namespace FABSample.Droid
 			// aapt resource value: 0
 			public const int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 99
-			public const int AppCompatTheme_autoCompleteTextViewStyle = 99;
-			
-			// aapt resource value: 54
-			public const int AppCompatTheme_borderlessButtonStyle = 54;
-			
-			// aapt resource value: 51
-			public const int AppCompatTheme_buttonBarButtonStyle = 51;
-			
-			// aapt resource value: 97
-			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 97;
-			
-			// aapt resource value: 98
-			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 98;
-			
-			// aapt resource value: 96
-			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 96;
-			
-			// aapt resource value: 50
-			public const int AppCompatTheme_buttonBarStyle = 50;
-			
-			// aapt resource value: 100
-			public const int AppCompatTheme_buttonStyle = 100;
-			
 			// aapt resource value: 101
-			public const int AppCompatTheme_buttonStyleSmall = 101;
-			
-			// aapt resource value: 102
-			public const int AppCompatTheme_checkboxStyle = 102;
-			
-			// aapt resource value: 103
-			public const int AppCompatTheme_checkedTextViewStyle = 103;
-			
-			// aapt resource value: 84
-			public const int AppCompatTheme_colorAccent = 84;
-			
-			// aapt resource value: 88
-			public const int AppCompatTheme_colorButtonNormal = 88;
-			
-			// aapt resource value: 86
-			public const int AppCompatTheme_colorControlActivated = 86;
-			
-			// aapt resource value: 87
-			public const int AppCompatTheme_colorControlHighlight = 87;
-			
-			// aapt resource value: 85
-			public const int AppCompatTheme_colorControlNormal = 85;
-			
-			// aapt resource value: 82
-			public const int AppCompatTheme_colorPrimary = 82;
-			
-			// aapt resource value: 83
-			public const int AppCompatTheme_colorPrimaryDark = 83;
-			
-			// aapt resource value: 89
-			public const int AppCompatTheme_colorSwitchThumbNormal = 89;
-			
-			// aapt resource value: 90
-			public const int AppCompatTheme_controlBackground = 90;
-			
-			// aapt resource value: 43
-			public const int AppCompatTheme_dialogPreferredPadding = 43;
-			
-			// aapt resource value: 42
-			public const int AppCompatTheme_dialogTheme = 42;
-			
-			// aapt resource value: 56
-			public const int AppCompatTheme_dividerHorizontal = 56;
+			public const int AppCompatTheme_autoCompleteTextViewStyle = 101;
 			
 			// aapt resource value: 55
-			public const int AppCompatTheme_dividerVertical = 55;
-			
-			// aapt resource value: 74
-			public const int AppCompatTheme_dropDownListViewStyle = 74;
-			
-			// aapt resource value: 46
-			public const int AppCompatTheme_dropdownListPreferredItemHeight = 46;
-			
-			// aapt resource value: 63
-			public const int AppCompatTheme_editTextBackground = 63;
-			
-			// aapt resource value: 62
-			public const int AppCompatTheme_editTextColor = 62;
-			
-			// aapt resource value: 104
-			public const int AppCompatTheme_editTextStyle = 104;
-			
-			// aapt resource value: 48
-			public const int AppCompatTheme_homeAsUpIndicator = 48;
-			
-			// aapt resource value: 64
-			public const int AppCompatTheme_imageButtonStyle = 64;
-			
-			// aapt resource value: 81
-			public const int AppCompatTheme_listChoiceBackgroundIndicator = 81;
-			
-			// aapt resource value: 44
-			public const int AppCompatTheme_listDividerAlertDialog = 44;
-			
-			// aapt resource value: 75
-			public const int AppCompatTheme_listPopupWindowStyle = 75;
-			
-			// aapt resource value: 69
-			public const int AppCompatTheme_listPreferredItemHeight = 69;
-			
-			// aapt resource value: 71
-			public const int AppCompatTheme_listPreferredItemHeightLarge = 71;
-			
-			// aapt resource value: 70
-			public const int AppCompatTheme_listPreferredItemHeightSmall = 70;
-			
-			// aapt resource value: 72
-			public const int AppCompatTheme_listPreferredItemPaddingLeft = 72;
-			
-			// aapt resource value: 73
-			public const int AppCompatTheme_listPreferredItemPaddingRight = 73;
-			
-			// aapt resource value: 78
-			public const int AppCompatTheme_panelBackground = 78;
-			
-			// aapt resource value: 80
-			public const int AppCompatTheme_panelMenuListTheme = 80;
-			
-			// aapt resource value: 79
-			public const int AppCompatTheme_panelMenuListWidth = 79;
-			
-			// aapt resource value: 60
-			public const int AppCompatTheme_popupMenuStyle = 60;
-			
-			// aapt resource value: 61
-			public const int AppCompatTheme_popupWindowStyle = 61;
-			
-			// aapt resource value: 105
-			public const int AppCompatTheme_radioButtonStyle = 105;
-			
-			// aapt resource value: 106
-			public const int AppCompatTheme_ratingBarStyle = 106;
-			
-			// aapt resource value: 107
-			public const int AppCompatTheme_ratingBarStyleIndicator = 107;
-			
-			// aapt resource value: 108
-			public const int AppCompatTheme_ratingBarStyleSmall = 108;
-			
-			// aapt resource value: 68
-			public const int AppCompatTheme_searchViewStyle = 68;
-			
-			// aapt resource value: 109
-			public const int AppCompatTheme_seekBarStyle = 109;
+			public const int AppCompatTheme_borderlessButtonStyle = 55;
 			
 			// aapt resource value: 52
-			public const int AppCompatTheme_selectableItemBackground = 52;
+			public const int AppCompatTheme_buttonBarButtonStyle = 52;
 			
-			// aapt resource value: 53
-			public const int AppCompatTheme_selectableItemBackgroundBorderless = 53;
+			// aapt resource value: 99
+			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 99;
+			
+			// aapt resource value: 100
+			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 100;
+			
+			// aapt resource value: 98
+			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 98;
+			
+			// aapt resource value: 51
+			public const int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 102
+			public const int AppCompatTheme_buttonStyle = 102;
+			
+			// aapt resource value: 103
+			public const int AppCompatTheme_buttonStyleSmall = 103;
+			
+			// aapt resource value: 104
+			public const int AppCompatTheme_checkboxStyle = 104;
+			
+			// aapt resource value: 105
+			public const int AppCompatTheme_checkedTextViewStyle = 105;
+			
+			// aapt resource value: 85
+			public const int AppCompatTheme_colorAccent = 85;
+			
+			// aapt resource value: 92
+			public const int AppCompatTheme_colorBackgroundFloating = 92;
+			
+			// aapt resource value: 89
+			public const int AppCompatTheme_colorButtonNormal = 89;
+			
+			// aapt resource value: 87
+			public const int AppCompatTheme_colorControlActivated = 87;
+			
+			// aapt resource value: 88
+			public const int AppCompatTheme_colorControlHighlight = 88;
+			
+			// aapt resource value: 86
+			public const int AppCompatTheme_colorControlNormal = 86;
+			
+			// aapt resource value: 83
+			public const int AppCompatTheme_colorPrimary = 83;
+			
+			// aapt resource value: 84
+			public const int AppCompatTheme_colorPrimaryDark = 84;
+			
+			// aapt resource value: 90
+			public const int AppCompatTheme_colorSwitchThumbNormal = 90;
+			
+			// aapt resource value: 91
+			public const int AppCompatTheme_controlBackground = 91;
+			
+			// aapt resource value: 44
+			public const int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public const int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public const int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public const int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public const int AppCompatTheme_dropDownListViewStyle = 75;
 			
 			// aapt resource value: 47
-			public const int AppCompatTheme_spinnerDropDownItemStyle = 47;
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public const int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 106
+			public const int AppCompatTheme_editTextStyle = 106;
+			
+			// aapt resource value: 49
+			public const int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public const int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 82
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 82;
+			
+			// aapt resource value: 45
+			public const int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 114
+			public const int AppCompatTheme_listMenuViewStyle = 114;
+			
+			// aapt resource value: 76
+			public const int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public const int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 79
+			public const int AppCompatTheme_panelBackground = 79;
+			
+			// aapt resource value: 81
+			public const int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 80
+			public const int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 61
+			public const int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public const int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 107
+			public const int AppCompatTheme_radioButtonStyle = 107;
+			
+			// aapt resource value: 108
+			public const int AppCompatTheme_ratingBarStyle = 108;
+			
+			// aapt resource value: 109
+			public const int AppCompatTheme_ratingBarStyleIndicator = 109;
 			
 			// aapt resource value: 110
-			public const int AppCompatTheme_spinnerStyle = 110;
+			public const int AppCompatTheme_ratingBarStyleSmall = 110;
+			
+			// aapt resource value: 69
+			public const int AppCompatTheme_searchViewStyle = 69;
 			
 			// aapt resource value: 111
-			public const int AppCompatTheme_switchStyle = 111;
+			public const int AppCompatTheme_seekBarStyle = 111;
+			
+			// aapt resource value: 53
+			public const int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 112
+			public const int AppCompatTheme_spinnerStyle = 112;
+			
+			// aapt resource value: 113
+			public const int AppCompatTheme_switchStyle = 113;
 			
 			// aapt resource value: 40
 			public const int AppCompatTheme_textAppearanceLargePopupMenu = 40;
 			
-			// aapt resource value: 76
-			public const int AppCompatTheme_textAppearanceListItem = 76;
-			
 			// aapt resource value: 77
-			public const int AppCompatTheme_textAppearanceListItemSmall = 77;
+			public const int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public const int AppCompatTheme_textAppearanceListItemSmall = 78;
+			
+			// aapt resource value: 42
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
 			
 			// aapt resource value: 66
-			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 66;
-			
-			// aapt resource value: 65
-			public const int AppCompatTheme_textAppearanceSearchResultTitle = 65;
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 66;
 			
 			// aapt resource value: 41
 			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
 			
-			// aapt resource value: 95
-			public const int AppCompatTheme_textColorAlertDialogListItem = 95;
+			// aapt resource value: 97
+			public const int AppCompatTheme_textColorAlertDialogListItem = 97;
 			
-			// aapt resource value: 67
-			public const int AppCompatTheme_textColorSearchUrl = 67;
+			// aapt resource value: 68
+			public const int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 60;
 			
 			// aapt resource value: 59
-			public const int AppCompatTheme_toolbarNavigationButtonStyle = 59;
-			
-			// aapt resource value: 58
-			public const int AppCompatTheme_toolbarStyle = 58;
+			public const int AppCompatTheme_toolbarStyle = 59;
 			
 			// aapt resource value: 2
 			public const int AppCompatTheme_windowActionBar = 2;
@@ -6800,20 +8026,47 @@ namespace FABSample.Droid
 			// aapt resource value: 3
 			public const int AppCompatTheme_windowNoTitle = 3;
 			
-			public static int[] BottomSheetBehavior_Params = new int[]
+			public static int[] BottomNavigationView = new int[]
 			{
-					2130771994,
-					2130771995};
-			
-			// aapt resource value: 1
-			public const int BottomSheetBehavior_Params_behavior_hideable = 1;
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270};
 			
 			// aapt resource value: 0
-			public const int BottomSheetBehavior_Params_behavior_peekHeight = 0;
+			public const int BottomNavigationView_elevation = 0;
+			
+			// aapt resource value: 4
+			public const int BottomNavigationView_itemBackground = 4;
+			
+			// aapt resource value: 2
+			public const int BottomNavigationView_itemIconTint = 2;
+			
+			// aapt resource value: 3
+			public const int BottomNavigationView_itemTextColor = 3;
+			
+			// aapt resource value: 1
+			public const int BottomNavigationView_menu = 1;
+			
+			public static int[] BottomSheetBehavior_Layout = new int[]
+			{
+					2130772229,
+					2130772230,
+					2130772231};
+			
+			// aapt resource value: 1
+			public const int BottomSheetBehavior_Layout_behavior_hideable = 1;
+			
+			// aapt resource value: 0
+			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 0;
+			
+			// aapt resource value: 2
+			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
 			
 			public static int[] ButtonBarLayout = new int[]
 			{
-					2130772208};
+					2130772153};
 			
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
@@ -6822,17 +8075,17 @@ namespace FABSample.Droid
 			{
 					16843071,
 					16843072,
-					2130772273,
-					2130772274,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278,
-					2130772279,
-					2130772280,
-					2130772281,
-					2130772282,
-					2130772283};
+					2130771985,
+					2130771986,
+					2130771987,
+					2130771988,
+					2130771989,
+					2130771990,
+					2130771991,
+					2130771992,
+					2130771993,
+					2130771994,
+					2130771995};
 			
 			// aapt resource value: 1
 			public const int CardView_android_minHeight = 1;
@@ -6873,81 +8126,104 @@ namespace FABSample.Droid
 			// aapt resource value: 11
 			public const int CardView_contentPaddingTop = 11;
 			
-			public static int[] CollapsingAppBarLayout_LayoutParams = new int[]
-			{
-					2130771996,
-					2130771997};
-			
-			// aapt resource value: 0
-			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
-			
-			// aapt resource value: 1
-			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = 1;
-			
 			public static int[] CollapsingToolbarLayout = new int[]
 			{
-					2130771998,
 					2130771999,
-					2130772000,
-					2130772001,
-					2130772002,
-					2130772003,
-					2130772004,
-					2130772005,
-					2130772006,
-					2130772007,
-					2130772008,
-					2130772009,
-					2130772010,
-					2130772063};
-			
-			// aapt resource value: 10
-			public const int CollapsingToolbarLayout_collapsedTitleGravity = 10;
-			
-			// aapt resource value: 6
-			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 6;
-			
-			// aapt resource value: 7
-			public const int CollapsingToolbarLayout_contentScrim = 7;
-			
-			// aapt resource value: 11
-			public const int CollapsingToolbarLayout_expandedTitleGravity = 11;
-			
-			// aapt resource value: 0
-			public const int CollapsingToolbarLayout_expandedTitleMargin = 0;
-			
-			// aapt resource value: 4
-			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 4;
-			
-			// aapt resource value: 3
-			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 3;
-			
-			// aapt resource value: 1
-			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 1;
-			
-			// aapt resource value: 2
-			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 2;
-			
-			// aapt resource value: 5
-			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 5;
-			
-			// aapt resource value: 8
-			public const int CollapsingToolbarLayout_statusBarScrim = 8;
+					2130772232,
+					2130772233,
+					2130772234,
+					2130772235,
+					2130772236,
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240,
+					2130772241,
+					2130772242,
+					2130772243,
+					2130772244,
+					2130772245,
+					2130772246};
 			
 			// aapt resource value: 13
-			public const int CollapsingToolbarLayout_title = 13;
+			public const int CollapsingToolbarLayout_collapsedTitleGravity = 13;
+			
+			// aapt resource value: 7
+			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public const int CollapsingToolbarLayout_contentScrim = 8;
+			
+			// aapt resource value: 14
+			public const int CollapsingToolbarLayout_expandedTitleGravity = 14;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_expandedTitleMargin = 1;
+			
+			// aapt resource value: 5
+			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 4
+			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
+			
+			// aapt resource value: 2
+			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
+			
+			// aapt resource value: 3
+			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
+			
+			// aapt resource value: 6
+			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
 			
 			// aapt resource value: 12
-			public const int CollapsingToolbarLayout_titleEnabled = 12;
+			public const int CollapsingToolbarLayout_scrimAnimationDuration = 12;
+			
+			// aapt resource value: 11
+			public const int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
 			
 			// aapt resource value: 9
-			public const int CollapsingToolbarLayout_toolbarId = 9;
+			public const int CollapsingToolbarLayout_statusBarScrim = 9;
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_title = 0;
+			
+			// aapt resource value: 15
+			public const int CollapsingToolbarLayout_titleEnabled = 15;
+			
+			// aapt resource value: 10
+			public const int CollapsingToolbarLayout_toolbarId = 10;
+			
+			public static int[] CollapsingToolbarLayout_Layout = new int[]
+			{
+					2130772247,
+					2130772248};
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			public static int[] ColorStateListItem = new int[]
+			{
+					16843173,
+					16843551,
+					2130772154};
+			
+			// aapt resource value: 2
+			public const int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public const int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public const int ColorStateListItem_android_color = 0;
 			
 			public static int[] CompoundButton = new int[]
 			{
 					16843015,
-					2130772209,
-					2130772210};
+					2130772155,
+					2130772156};
 			
 			// aapt resource value: 0
 			public const int CompoundButton_android_button = 0;
@@ -6960,8 +8236,8 @@ namespace FABSample.Droid
 			
 			public static int[] CoordinatorLayout = new int[]
 			{
-					2130772011,
-					2130772012};
+					2130772249,
+					2130772250};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
@@ -6969,34 +8245,42 @@ namespace FABSample.Droid
 			// aapt resource value: 1
 			public const int CoordinatorLayout_statusBarBackground = 1;
 			
-			public static int[] CoordinatorLayout_LayoutParams = new int[]
+			public static int[] CoordinatorLayout_Layout = new int[]
 			{
 					16842931,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016};
+					2130772251,
+					2130772252,
+					2130772253,
+					2130772254,
+					2130772255,
+					2130772256};
 			
 			// aapt resource value: 0
-			public const int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
+			public const int CoordinatorLayout_Layout_android_layout_gravity = 0;
 			
 			// aapt resource value: 2
-			public const int CoordinatorLayout_LayoutParams_layout_anchor = 2;
+			public const int CoordinatorLayout_Layout_layout_anchor = 2;
 			
 			// aapt resource value: 4
-			public const int CoordinatorLayout_LayoutParams_layout_anchorGravity = 4;
+			public const int CoordinatorLayout_Layout_layout_anchorGravity = 4;
 			
 			// aapt resource value: 1
-			public const int CoordinatorLayout_LayoutParams_layout_behavior = 1;
+			public const int CoordinatorLayout_Layout_layout_behavior = 1;
+			
+			// aapt resource value: 6
+			public const int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 6;
+			
+			// aapt resource value: 5
+			public const int CoordinatorLayout_Layout_layout_insetEdge = 5;
 			
 			// aapt resource value: 3
-			public const int CoordinatorLayout_LayoutParams_layout_keyline = 3;
+			public const int CoordinatorLayout_Layout_layout_keyline = 3;
 			
 			public static int[] DesignTheme = new int[]
 			{
-					2130772017,
-					2130772018,
-					2130772019};
+					2130772257,
+					2130772258,
+					2130772259};
 			
 			// aapt resource value: 0
 			public const int DesignTheme_bottomSheetDialogTheme = 0;
@@ -7009,14 +8293,14 @@ namespace FABSample.Droid
 			
 			public static int[] DrawerArrowToggle = new int[]
 			{
-					2130772211,
-					2130772212,
-					2130772213,
-					2130772214,
-					2130772215,
-					2130772216,
-					2130772217,
-					2130772218};
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164};
 			
 			// aapt resource value: 4
 			public const int DrawerArrowToggle_arrowHeadLength = 4;
@@ -7044,35 +8328,35 @@ namespace FABSample.Droid
 			
 			public static int[] FloatingActionButton = new int[]
 			{
-					2130772020,
-					2130772021,
-					2130772022,
-					2130772023,
 					2130772024,
-					2130772086,
-					2130772267,
-					2130772268,
-					2130772284,
-					2130772285,
-					2130772286,
-					2130772287,
-					2130772288,
-					2130772289};
-			
-			// aapt resource value: 6
-			public const int FloatingActionButton_backgroundTint = 6;
-			
-			// aapt resource value: 7
-			public const int FloatingActionButton_backgroundTintMode = 7;
-			
-			// aapt resource value: 3
-			public const int FloatingActionButton_borderWidth = 3;
-			
-			// aapt resource value: 5
-			public const int FloatingActionButton_elevation = 5;
+					2130772222,
+					2130772223,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264,
+					2130772306,
+					2130772307,
+					2130772308,
+					2130772309,
+					2130772310,
+					2130772311};
 			
 			// aapt resource value: 1
-			public const int FloatingActionButton_fabSize = 1;
+			public const int FloatingActionButton_backgroundTint = 1;
+			
+			// aapt resource value: 2
+			public const int FloatingActionButton_backgroundTintMode = 2;
+			
+			// aapt resource value: 6
+			public const int FloatingActionButton_borderWidth = 6;
+			
+			// aapt resource value: 0
+			public const int FloatingActionButton_elevation = 0;
+			
+			// aapt resource value: 4
+			public const int FloatingActionButton_fabSize = 4;
 			
 			// aapt resource value: 10
 			public const int FloatingActionButton_fab_colorDisabled = 10;
@@ -7092,20 +8376,27 @@ namespace FABSample.Droid
 			// aapt resource value: 13
 			public const int FloatingActionButton_fab_size = 13;
 			
-			// aapt resource value: 2
-			public const int FloatingActionButton_pressedTranslationZ = 2;
+			// aapt resource value: 5
+			public const int FloatingActionButton_pressedTranslationZ = 5;
+			
+			// aapt resource value: 3
+			public const int FloatingActionButton_rippleColor = 3;
+			
+			// aapt resource value: 7
+			public const int FloatingActionButton_useCompatPadding = 7;
+			
+			public static int[] FloatingActionButton_Behavior_Layout = new int[]
+			{
+					2130772265};
 			
 			// aapt resource value: 0
-			public const int FloatingActionButton_rippleColor = 0;
-			
-			// aapt resource value: 4
-			public const int FloatingActionButton_useCompatPadding = 4;
+			public const int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
 			
 			public static int[] ForegroundLinearLayout = new int[]
 			{
 					16843017,
 					16843264,
-					2130772025};
+					2130772266};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -7123,10 +8414,10 @@ namespace FABSample.Droid
 					16843046,
 					16843047,
 					16843048,
-					2130772071,
-					2130772219,
-					2130772220,
-					2130772221};
+					2130772007,
+					2130772165,
+					2130772166,
+					2130772167};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -7189,13 +8480,17 @@ namespace FABSample.Droid
 			{
 					16843071,
 					16843072,
-					2130771990};
+					2130771984,
+					2130772155};
 			
 			// aapt resource value: 1
 			public const int MediaRouteButton_android_minHeight = 1;
 			
 			// aapt resource value: 0
 			public const int MediaRouteButton_android_minWidth = 0;
+			
+			// aapt resource value: 3
+			public const int MediaRouteButton_buttonTint = 3;
 			
 			// aapt resource value: 2
 			public const int MediaRouteButton_externalRouteEnabledDrawable = 2;
@@ -7242,10 +8537,10 @@ namespace FABSample.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772222,
-					2130772223,
-					2130772224,
-					2130772225};
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171};
 			
 			// aapt resource value: 14
 			public const int MenuItem_actionLayout = 14;
@@ -7307,7 +8602,8 @@ namespace FABSample.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772226};
+					2130772172,
+					2130772173};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -7333,18 +8629,21 @@ namespace FABSample.Droid
 			// aapt resource value: 7
 			public const int MenuView_preserveIconSpacing = 7;
 			
+			// aapt resource value: 8
+			public const int MenuView_subMenuArrow = 8;
+			
 			public static int[] NavigationView = new int[]
 			{
 					16842964,
 					16842973,
 					16843039,
-					2130772026,
-					2130772027,
-					2130772028,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772086};
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270,
+					2130772271,
+					2130772272};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -7355,81 +8654,100 @@ namespace FABSample.Droid
 			// aapt resource value: 2
 			public const int NavigationView_android_maxWidth = 2;
 			
+			// aapt resource value: 3
+			public const int NavigationView_elevation = 3;
+			
 			// aapt resource value: 9
-			public const int NavigationView_elevation = 9;
-			
-			// aapt resource value: 8
-			public const int NavigationView_headerLayout = 8;
-			
-			// aapt resource value: 6
-			public const int NavigationView_itemBackground = 6;
-			
-			// aapt resource value: 4
-			public const int NavigationView_itemIconTint = 4;
+			public const int NavigationView_headerLayout = 9;
 			
 			// aapt resource value: 7
-			public const int NavigationView_itemTextAppearance = 7;
+			public const int NavigationView_itemBackground = 7;
 			
 			// aapt resource value: 5
-			public const int NavigationView_itemTextColor = 5;
+			public const int NavigationView_itemIconTint = 5;
 			
-			// aapt resource value: 3
-			public const int NavigationView_menu = 3;
+			// aapt resource value: 8
+			public const int NavigationView_itemTextAppearance = 8;
+			
+			// aapt resource value: 6
+			public const int NavigationView_itemTextColor = 6;
+			
+			// aapt resource value: 4
+			public const int NavigationView_menu = 4;
 			
 			public static int[] PopupWindow = new int[]
 			{
 					16843126,
-					2130772227};
+					16843465,
+					2130772174};
+			
+			// aapt resource value: 1
+			public const int PopupWindow_android_popupAnimationStyle = 1;
 			
 			// aapt resource value: 0
 			public const int PopupWindow_android_popupBackground = 0;
 			
-			// aapt resource value: 1
-			public const int PopupWindow_overlapAnchor = 1;
+			// aapt resource value: 2
+			public const int PopupWindow_overlapAnchor = 2;
 			
 			public static int[] PopupWindowBackgroundState = new int[]
 			{
-					2130772228};
+					2130772175};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
 			
+			public static int[] RecycleListView = new int[]
+			{
+					2130772176,
+					2130772177};
+			
+			// aapt resource value: 0
+			public const int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public const int RecycleListView_paddingTopNoTitle = 1;
+			
 			public static int[] RecyclerView = new int[]
 			{
 					16842948,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272};
+					16842993,
+					2130771968,
+					2130771969,
+					2130771970,
+					2130771971};
+			
+			// aapt resource value: 1
+			public const int RecyclerView_android_descendantFocusability = 1;
 			
 			// aapt resource value: 0
 			public const int RecyclerView_android_orientation = 0;
 			
-			// aapt resource value: 1
-			public const int RecyclerView_layoutManager = 1;
-			
-			// aapt resource value: 3
-			public const int RecyclerView_reverseLayout = 3;
-			
 			// aapt resource value: 2
-			public const int RecyclerView_spanCount = 2;
+			public const int RecyclerView_layoutManager = 2;
 			
 			// aapt resource value: 4
-			public const int RecyclerView_stackFromEnd = 4;
+			public const int RecyclerView_reverseLayout = 4;
+			
+			// aapt resource value: 3
+			public const int RecyclerView_spanCount = 3;
+			
+			// aapt resource value: 5
+			public const int RecyclerView_stackFromEnd = 5;
 			
 			public static int[] ScrimInsetsFrameLayout = new int[]
 			{
-					2130772032};
+					2130772273};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
 			
-			public static int[] ScrollingViewBehavior_Params = new int[]
+			public static int[] ScrollingViewBehavior_Layout = new int[]
 			{
-					2130772033};
+					2130772274};
 			
 			// aapt resource value: 0
-			public const int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
+			public const int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
 			public static int[] SearchView = new int[]
 			{
@@ -7437,19 +8755,19 @@ namespace FABSample.Droid
 					16843039,
 					16843296,
 					16843364,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233,
-					2130772234,
-					2130772235,
-					2130772236,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240,
-					2130772241};
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187,
+					2130772188,
+					2130772189,
+					2130772190};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -7505,17 +8823,17 @@ namespace FABSample.Droid
 			public static int[] SnackbarLayout = new int[]
 			{
 					16843039,
-					2130772034,
-					2130772086};
+					2130772024,
+					2130772275};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
 			
-			// aapt resource value: 2
-			public const int SnackbarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public const int SnackbarLayout_maxActionInlineWidth = 1;
+			public const int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public const int SnackbarLayout_maxActionInlineWidth = 2;
 			
 			public static int[] Spinner = new int[]
 			{
@@ -7523,7 +8841,7 @@ namespace FABSample.Droid
 					16843126,
 					16843131,
 					16843362,
-					2130772087};
+					2130772025};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -7545,13 +8863,17 @@ namespace FABSample.Droid
 					16843044,
 					16843045,
 					16843074,
-					2130772242,
-					2130772243,
-					2130772244,
-					2130772245,
-					2130772246,
-					2130772247,
-					2130772248};
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199,
+					2130772200,
+					2130772201};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -7562,26 +8884,38 @@ namespace FABSample.Droid
 			// aapt resource value: 2
 			public const int SwitchCompat_android_thumb = 2;
 			
+			// aapt resource value: 13
+			public const int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public const int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public const int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public const int SwitchCompat_switchPadding = 11;
+			
 			// aapt resource value: 9
-			public const int SwitchCompat_showText = 9;
+			public const int SwitchCompat_switchTextAppearance = 9;
 			
 			// aapt resource value: 8
-			public const int SwitchCompat_splitTrack = 8;
-			
-			// aapt resource value: 6
-			public const int SwitchCompat_switchMinWidth = 6;
-			
-			// aapt resource value: 7
-			public const int SwitchCompat_switchPadding = 7;
-			
-			// aapt resource value: 5
-			public const int SwitchCompat_switchTextAppearance = 5;
-			
-			// aapt resource value: 4
-			public const int SwitchCompat_thumbTextPadding = 4;
+			public const int SwitchCompat_thumbTextPadding = 8;
 			
 			// aapt resource value: 3
-			public const int SwitchCompat_track = 3;
+			public const int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public const int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public const int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public const int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public const int SwitchCompat_trackTintMode = 7;
 			
 			public static int[] TabItem = new int[]
 			{
@@ -7600,22 +8934,22 @@ namespace FABSample.Droid
 			
 			public static int[] TabLayout = new int[]
 			{
-					2130772035,
-					2130772036,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040,
-					2130772041,
-					2130772042,
-					2130772043,
-					2130772044,
-					2130772045,
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050};
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280,
+					2130772281,
+					2130772282,
+					2130772283,
+					2130772284,
+					2130772285,
+					2130772286,
+					2130772287,
+					2130772288,
+					2130772289,
+					2130772290,
+					2130772291};
 			
 			// aapt resource value: 3
 			public const int TabLayout_tabBackground = 3;
@@ -7671,26 +9005,30 @@ namespace FABSample.Droid
 					16842902,
 					16842903,
 					16842904,
+					16842906,
 					16843105,
 					16843106,
 					16843107,
 					16843108,
-					2130772097};
-			
-			// aapt resource value: 4
-			public const int TextAppearance_android_shadowColor = 4;
+					2130772039};
 			
 			// aapt resource value: 5
-			public const int TextAppearance_android_shadowDx = 5;
+			public const int TextAppearance_android_shadowColor = 5;
 			
 			// aapt resource value: 6
-			public const int TextAppearance_android_shadowDy = 6;
+			public const int TextAppearance_android_shadowDx = 6;
 			
 			// aapt resource value: 7
-			public const int TextAppearance_android_shadowRadius = 7;
+			public const int TextAppearance_android_shadowDy = 7;
+			
+			// aapt resource value: 8
+			public const int TextAppearance_android_shadowRadius = 8;
 			
 			// aapt resource value: 3
 			public const int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public const int TextAppearance_android_textColorHint = 4;
 			
 			// aapt resource value: 0
 			public const int TextAppearance_android_textSize = 0;
@@ -7701,22 +9039,27 @@ namespace FABSample.Droid
 			// aapt resource value: 1
 			public const int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 8
-			public const int TextAppearance_textAllCaps = 8;
+			// aapt resource value: 9
+			public const int TextAppearance_textAllCaps = 9;
 			
 			public static int[] TextInputLayout = new int[]
 			{
 					16842906,
 					16843088,
-					2130772051,
-					2130772052,
-					2130772053,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059};
+					2130772292,
+					2130772293,
+					2130772294,
+					2130772295,
+					2130772296,
+					2130772297,
+					2130772298,
+					2130772299,
+					2130772300,
+					2130772301,
+					2130772302,
+					2130772303,
+					2130772304,
+					2130772305};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -7751,33 +9094,52 @@ namespace FABSample.Droid
 			// aapt resource value: 2
 			public const int TextInputLayout_hintTextAppearance = 2;
 			
+			// aapt resource value: 13
+			public const int TextInputLayout_passwordToggleContentDescription = 13;
+			
+			// aapt resource value: 12
+			public const int TextInputLayout_passwordToggleDrawable = 12;
+			
+			// aapt resource value: 11
+			public const int TextInputLayout_passwordToggleEnabled = 11;
+			
+			// aapt resource value: 14
+			public const int TextInputLayout_passwordToggleTint = 14;
+			
+			// aapt resource value: 15
+			public const int TextInputLayout_passwordToggleTintMode = 15;
+			
 			public static int[] Toolbar = new int[]
 			{
 					16842927,
 					16843072,
-					2130772063,
-					2130772066,
-					2130772070,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772087,
-					2130772249,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255,
-					2130772256,
-					2130772257,
-					2130772258,
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263};
+					2130771999,
+					2130772002,
+					2130772006,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772025,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214,
+					2130772215,
+					2130772216,
+					2130772217,
+					2130772218};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -7785,14 +9147,20 @@ namespace FABSample.Droid
 			// aapt resource value: 1
 			public const int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public const int Toolbar_collapseContentDescription = 19;
+			// aapt resource value: 21
+			public const int Toolbar_buttonGravity = 21;
 			
-			// aapt resource value: 18
-			public const int Toolbar_collapseIcon = 18;
+			// aapt resource value: 23
+			public const int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public const int Toolbar_collapseIcon = 22;
 			
 			// aapt resource value: 6
 			public const int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public const int Toolbar_contentInsetEndWithActions = 10;
 			
 			// aapt resource value: 7
 			public const int Toolbar_contentInsetLeft = 7;
@@ -7803,64 +9171,70 @@ namespace FABSample.Droid
 			// aapt resource value: 5
 			public const int Toolbar_contentInsetStart = 5;
 			
+			// aapt resource value: 9
+			public const int Toolbar_contentInsetStartWithNavigation = 9;
+			
 			// aapt resource value: 4
 			public const int Toolbar_logo = 4;
 			
-			// aapt resource value: 22
-			public const int Toolbar_logoDescription = 22;
-			
-			// aapt resource value: 17
-			public const int Toolbar_maxButtonHeight = 17;
-			
-			// aapt resource value: 21
-			public const int Toolbar_navigationContentDescription = 21;
+			// aapt resource value: 26
+			public const int Toolbar_logoDescription = 26;
 			
 			// aapt resource value: 20
-			public const int Toolbar_navigationIcon = 20;
+			public const int Toolbar_maxButtonHeight = 20;
 			
-			// aapt resource value: 9
-			public const int Toolbar_popupTheme = 9;
+			// aapt resource value: 25
+			public const int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public const int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public const int Toolbar_popupTheme = 11;
 			
 			// aapt resource value: 3
 			public const int Toolbar_subtitle = 3;
 			
-			// aapt resource value: 11
-			public const int Toolbar_subtitleTextAppearance = 11;
+			// aapt resource value: 13
+			public const int Toolbar_subtitleTextAppearance = 13;
 			
-			// aapt resource value: 24
-			public const int Toolbar_subtitleTextColor = 24;
+			// aapt resource value: 28
+			public const int Toolbar_subtitleTextColor = 28;
 			
 			// aapt resource value: 2
 			public const int Toolbar_title = 2;
 			
-			// aapt resource value: 16
-			public const int Toolbar_titleMarginBottom = 16;
-			
 			// aapt resource value: 14
-			public const int Toolbar_titleMarginEnd = 14;
+			public const int Toolbar_titleMargin = 14;
 			
-			// aapt resource value: 13
-			public const int Toolbar_titleMarginStart = 13;
+			// aapt resource value: 18
+			public const int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public const int Toolbar_titleMarginEnd = 16;
 			
 			// aapt resource value: 15
-			public const int Toolbar_titleMarginTop = 15;
+			public const int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public const int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public const int Toolbar_titleMargins = 19;
 			
 			// aapt resource value: 12
-			public const int Toolbar_titleMargins = 12;
+			public const int Toolbar_titleTextAppearance = 12;
 			
-			// aapt resource value: 10
-			public const int Toolbar_titleTextAppearance = 10;
-			
-			// aapt resource value: 23
-			public const int Toolbar_titleTextColor = 23;
+			// aapt resource value: 27
+			public const int Toolbar_titleTextColor = 27;
 			
 			public static int[] View = new int[]
 			{
 					16842752,
 					16842970,
-					2130772264,
-					2130772265,
-					2130772266};
+					2130772219,
+					2130772220,
+					2130772221};
 			
 			// aapt resource value: 1
 			public const int View_android_focusable = 1;
@@ -7880,8 +9254,8 @@ namespace FABSample.Droid
 			public static int[] ViewBackgroundHelper = new int[]
 			{
 					16842964,
-					2130772267,
-					2130772268};
+					2130772222,
+					2130772223};
 			
 			// aapt resource value: 0
 			public const int ViewBackgroundHelper_android_background = 0;

--- a/Sample/Droid/packages.config
+++ b/Sample/Droid/packages.config
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Annotations" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.UI" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Design" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Fragment" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Transition" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v4" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.Palette" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid71" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="monoandroid71" />
 </packages>

--- a/Sample/FABSample/FABSample.csproj
+++ b/Sample/FABSample/FABSample.csproj
@@ -58,18 +58,18 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Sample/FABSample/packages.config
+++ b/Sample/FABSample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/Sample/iOS/FABSample.iOS.csproj
+++ b/Sample/iOS/FABSample.iOS.csproj
@@ -76,16 +76,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -132,5 +132,5 @@
     <BundleResource Include="Resources\list.png" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/Sample/iOS/packages.config
+++ b/Sample/iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
This pull request updates the nuget packages for Xamarin.forms and the Support Libraries in Android. It also uses the RippleColor property instead of SetRippleColor method to fix #24.